### PR TITLE
feat(terraform): add reusable Firebase environment module for staging infra

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,18 @@ firebase-debug.log
 pubsub-debug.log
 
 serviceAccountKey.json
+
+# Terraform
+**/.terraform/
+*.tfstate
+*.tfstate.*
+crash.log
+crash.*.log
+*.tfvars
+*.tfvars.json
+override.tf
+override.tf.json
+*_override.tf
+*_override.tf.json
+.terraformrc
+terraform.rc

--- a/terraform/environments/staging/.terraform.lock.hcl
+++ b/terraform/environments/staging/.terraform.lock.hcl
@@ -1,0 +1,42 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/google" {
+  version     = "6.50.0"
+  constraints = "~> 6.0"
+  hashes = [
+    "h1:79CwMTsp3Ud1nOl5hFS5mxQHyT0fGVye7pqpU0PPlHI=",
+    "zh:1f3513fcfcbf7ca53d667a168c5067a4dd91a4d4cccd19743e248ff31065503c",
+    "zh:3da7db8fc2c51a77dd958ea8baaa05c29cd7f829bd8941c26e2ea9cb3aadc1e5",
+    "zh:3e09ac3f6ca8111cbb659d38c251771829f4347ab159a12db195e211c76068bb",
+    "zh:7bb9e41c568df15ccf1a8946037355eefb4dfb4e35e3b190808bb7c4abae547d",
+    "zh:81e5d78bdec7778e6d67b5c3544777505db40a826b6eb5abe9b86d4ba396866b",
+    "zh:8d309d020fb321525883f5c4ea864df3d5942b6087f6656d6d8b3a1377f340fc",
+    "zh:93e112559655ab95a523193158f4a4ac0f2bfed7eeaa712010b85ebb551d5071",
+    "zh:d3efe589ffd625b300cef5917c4629513f77e3a7b111c9df65075f76a46a63c7",
+    "zh:d4a4d672bbef756a870d8f32b35925f8ce2ef4f6bbd5b71a3cb764f1b6c85421",
+    "zh:e13a86bca299ba8a118e80d5f84fbdd708fe600ecdceea1a13d4919c068379fe",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+    "zh:fec30c095647b583a246c39d557704947195a1b7d41f81e369ba377d997faef6",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/google-beta" {
+  version     = "6.50.0"
+  constraints = "~> 6.0"
+  hashes = [
+    "h1:P2GiUJM1frlPtBViwKn1A9V2dVBdGuWcX80w9TdH8ZE=",
+    "zh:18b442bd0a05321d39dda1e9e3f1bdede4e61bc2ac62cc7a67037a3864f75101",
+    "zh:2e387c51455862828bec923a3ec81abf63a4d998da470cf00e09003bda53d668",
+    "zh:3942e708fa84ebe54996086f4b1398cb747fe19cbcd0be07ace528291fb35dee",
+    "zh:496287dd48b34ae6197cb1f887abeafd07c33f389dbe431bb01e24846754cfdd",
+    "zh:6eca885419969ce5c2a706f34dce1f10bde9774757675f2d8a92d12e5a1be390",
+    "zh:710dbef826c3fe7f76f844dae47937e8e4c1279dd9205ec4610be04cf3327244",
+    "zh:777ebf44b24bfc7bdbf770dc089f1a72f143b4718fdedb8c6bd75983115a1ec2",
+    "zh:9c8703bba37b8c7ad857efc3513392c5a096c519397c1cb822d7612f38e4262f",
+    "zh:c4f1d3a73de2702277c99d5348ad6d374705bcfdd367ad964ff4cfd2cf06c281",
+    "zh:eca8df11af3f5a948492d5b8b5d01b4ec705aad10bc30ec1524205508ae28393",
+    "zh:f41e7fd5f2628e8fd6b8ea136366923858f54428d1729898925469b862c275c2",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+  ]
+}

--- a/terraform/environments/staging/backend.tf
+++ b/terraform/environments/staging/backend.tf
@@ -1,0 +1,9 @@
+terraform {
+  backend "gcs" {
+    # This bucket must be created manually before first `terraform init`:
+    #   gcloud storage buckets create gs://pdf-craft-stg-tfstate \
+    #     --project=pdf-craft-stg --location=US --uniform-bucket-level-access
+    bucket = "pdf-craft-stg-tfstate"
+    prefix = "terraform/staging"
+  }
+}

--- a/terraform/environments/staging/main.tf
+++ b/terraform/environments/staging/main.tf
@@ -1,0 +1,32 @@
+terraform {
+  required_version = ">= 1.9"
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = "~> 6.0"
+    }
+    google-beta = {
+      source  = "hashicorp/google-beta"
+      version = "~> 6.0"
+    }
+  }
+}
+
+provider "google" {
+  project = var.project_id
+  region  = var.region
+}
+
+provider "google-beta" {
+  project = var.project_id
+  region  = var.region
+}
+
+module "firebase_env" {
+  source = "../../modules/firebase-env"
+
+  project_id        = var.project_id
+  region             = var.region
+  github_repo        = var.github_repo
+  environment_label  = "staging"
+}

--- a/terraform/environments/staging/outputs.tf
+++ b/terraform/environments/staging/outputs.tf
@@ -1,0 +1,15 @@
+output "workload_identity_provider" {
+  value = module.firebase_env.workload_identity_provider
+}
+
+output "service_account_email" {
+  value = module.firebase_env.service_account_email
+}
+
+output "firestore_database" {
+  value = module.firebase_env.firestore_database
+}
+
+output "storage_bucket" {
+  value = module.firebase_env.storage_bucket
+}

--- a/terraform/environments/staging/variables.tf
+++ b/terraform/environments/staging/variables.tf
@@ -1,0 +1,15 @@
+variable "project_id" {
+  type    = string
+  default = "pdf-craft-stg"
+}
+
+variable "region" {
+  type    = string
+  default = "us-central1"
+}
+
+variable "github_repo" {
+  type        = string
+  description = "GitHub repository in 'owner/repo' format"
+  default     = "fahadahmed/fhdamd-org"
+}

--- a/terraform/modules/firebase-env/main.tf
+++ b/terraform/modules/firebase-env/main.tf
@@ -1,0 +1,205 @@
+terraform {
+  required_version = ">= 1.9"
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = "~> 6.0"
+    }
+    google-beta = {
+      source  = "hashicorp/google-beta"
+      version = "~> 6.0"
+    }
+  }
+}
+
+# ─── APIs ────────────────────────────────────────────────────────────────────
+
+resource "google_project_service" "apis" {
+  for_each = toset([
+    "cloudresourcemanager.googleapis.com",
+    "iam.googleapis.com",
+    "iamcredentials.googleapis.com",
+    "sts.googleapis.com",
+    "firebase.googleapis.com",
+    "firestore.googleapis.com",
+    "storage.googleapis.com",
+    "secretmanager.googleapis.com",
+    "cloudbuild.googleapis.com",
+    "run.googleapis.com",
+    "firebaseapphosting.googleapis.com",
+    "identitytoolkit.googleapis.com",
+    "artifactregistry.googleapis.com",
+    "cloudfunctions.googleapis.com",
+    "eventarc.googleapis.com",
+    "pubsub.googleapis.com",
+    "cloudscheduler.googleapis.com",
+  ])
+  project            = var.project_id
+  service            = each.key
+  disable_on_destroy = false
+}
+
+# ─── Firestore ───────────────────────────────────────────────────────────────
+
+resource "google_firestore_database" "default" {
+  project     = var.project_id
+  name        = "(default)"
+  location_id = "nam5"
+  type        = "FIRESTORE_NATIVE"
+
+  depends_on = [google_project_service.apis]
+}
+
+# ─── Storage ─────────────────────────────────────────────────────────────────
+# Note: Firebase's default Storage bucket must be provisioned once via
+# `firebase init storage --project <project_id>` before this resource can be
+# created — the Storage product itself isn't bootstrapped by this API call.
+
+resource "google_firebase_storage_bucket" "default" {
+  provider  = google-beta
+  project   = var.project_id
+  bucket_id = "${var.project_id}.firebasestorage.app"
+
+  depends_on = [google_project_service.apis]
+}
+
+# ─── Secret Manager ──────────────────────────────────────────────────────────
+# Secrets are created empty; values must be populated before first deploy.
+# Run: gcloud secrets versions add <name> --data-file=- --project=<project_id>
+
+locals {
+  secret_names = toset([
+    "firebaseApiKey",
+    "firebaseAuthDomain",
+    "firebaseProjectId",
+    "firebaseStorageBucket",
+    "firebaseMessengerId",
+    "firebaseAppId",
+    "firebaseMeasurementId",
+    "firebaseServiceAccountKey",
+    "recaptchaSiteKey",
+    "recaptchaSecretKey",
+    "baseAppUrl",
+    "baseFunctionsUrl",
+    "viteProjectId",
+    "pdfProcessorUrl",
+    "appEnv",
+    "resendApiKey",
+  ])
+}
+
+resource "google_secret_manager_secret" "app_secrets" {
+  for_each  = local.secret_names
+  project   = var.project_id
+  secret_id = each.key
+
+  replication {
+    auto {}
+  }
+
+  depends_on = [google_project_service.apis]
+}
+
+# ─── Artifact Registry ───────────────────────────────────────────────────────
+
+resource "google_artifact_registry_repository" "cloud_run" {
+  project       = var.project_id
+  repository_id = "cloud-run-source-deploy"
+  format        = "DOCKER"
+  location      = var.region
+  description   = "Docker images for Cloud Run services"
+
+  depends_on = [google_project_service.apis]
+}
+
+# ─── Workload Identity Federation ────────────────────────────────────────────
+
+resource "google_iam_workload_identity_pool" "github" {
+  project                    = var.project_id
+  workload_identity_pool_id  = "github-actions"
+  display_name               = "GitHub Actions"
+  description                = "OIDC identity pool for GitHub Actions"
+
+  depends_on = [google_project_service.apis]
+}
+
+resource "google_iam_workload_identity_pool_provider" "github" {
+  project                             = var.project_id
+  workload_identity_pool_id           = google_iam_workload_identity_pool.github.workload_identity_pool_id
+  workload_identity_pool_provider_id  = "github-actions"
+  display_name                        = "GitHub Actions OIDC"
+
+  oidc {
+    issuer_uri = "https://token.actions.githubusercontent.com"
+  }
+
+  attribute_mapping = {
+    "google.subject"       = "assertion.sub"
+    "attribute.actor"      = "assertion.actor"
+    "attribute.repository" = "assertion.repository"
+    "attribute.ref"        = "assertion.ref"
+  }
+
+  # Only tokens from this repository can use the pool
+  attribute_condition = "assertion.repository == '${var.github_repo}'"
+}
+
+# ─── Service Account ─────────────────────────────────────────────────────────
+
+resource "google_service_account" "github_deploy" {
+  project      = var.project_id
+  account_id   = "github-deploy"
+  display_name = "GitHub Actions Deploy (${var.environment_label})"
+  description  = "Impersonated by GitHub Actions via WIF to deploy pdf-craft ${var.environment_label}"
+}
+
+# Allow GitHub Actions OIDC tokens from this repo to impersonate the SA
+resource "google_service_account_iam_member" "github_oidc" {
+  service_account_id = google_service_account.github_deploy.name
+  role                = "roles/iam.workloadIdentityUser"
+  member              = "principalSet://iam.googleapis.com/${google_iam_workload_identity_pool.github.name}/attribute.repository/${var.github_repo}"
+}
+
+locals {
+  deploy_roles = toset([
+    "roles/firebase.developAdmin",      # firebase deploy (rules, functions, apphosting)
+    "roles/secretmanager.admin",        # create/update secrets
+    "roles/storage.admin",              # storage rules + bucket management
+    "roles/datastore.owner",            # firestore rules
+    "roles/run.admin",                  # cloud run (app hosting + gen2 functions)
+    "roles/cloudbuild.builds.editor",   # trigger cloud builds
+    "roles/artifactregistry.admin",     # push container images
+    "roles/iam.serviceAccountUser",     # act as other SAs (cloud build etc.)
+    "roles/cloudfunctions.developer",   # deploy gen2 functions
+    "roles/eventarc.admin",             # onMessagePublished / onSchedule triggers
+    "roles/pubsub.admin",               # topics/subscriptions for onMessagePublished
+    "roles/cloudscheduler.admin",       # onSchedule jobs
+  ])
+}
+
+resource "google_project_iam_member" "github_deploy" {
+  for_each = local.deploy_roles
+  project  = var.project_id
+  role     = each.value
+  member   = "serviceAccount:${google_service_account.github_deploy.email}"
+}
+
+# ─── App Hosting compute service account ─────────────────────────────────────
+# Created automatically by Firebase on first backend creation, but ships with
+# no IAM bindings — without these, builds fail with no logs and secrets are
+# inaccessible to the running app.
+
+locals {
+  apphosting_compute_roles = toset([
+    "roles/logging.logWriter",             # write build/runtime logs
+    "roles/firebaseapphosting.computeRunner",
+    "roles/secretmanager.secretAccessor",  # read apphosting.yaml secrets
+  ])
+}
+
+resource "google_project_iam_member" "apphosting_compute" {
+  for_each = local.apphosting_compute_roles
+  project  = var.project_id
+  role     = each.value
+  member   = "serviceAccount:firebase-app-hosting-compute@${var.project_id}.iam.gserviceaccount.com"
+}

--- a/terraform/modules/firebase-env/outputs.tf
+++ b/terraform/modules/firebase-env/outputs.tf
@@ -1,0 +1,17 @@
+output "workload_identity_provider" {
+  description = "Full WIF provider resource name — set as GCP_WORKLOAD_IDENTITY_PROVIDER in GitHub secrets"
+  value       = google_iam_workload_identity_pool_provider.github.name
+}
+
+output "service_account_email" {
+  description = "Deployment service account email — set as GCP_SERVICE_ACCOUNT in GitHub secrets"
+  value       = google_service_account.github_deploy.email
+}
+
+output "firestore_database" {
+  value = google_firestore_database.default.name
+}
+
+output "storage_bucket" {
+  value = google_firebase_storage_bucket.default.bucket_id
+}

--- a/terraform/modules/firebase-env/variables.tf
+++ b/terraform/modules/firebase-env/variables.tf
@@ -1,0 +1,20 @@
+variable "project_id" {
+  type        = string
+  description = "GCP/Firebase project ID for this environment"
+}
+
+variable "region" {
+  type    = string
+  default = "us-central1"
+}
+
+variable "github_repo" {
+  type        = string
+  description = "GitHub repository in 'owner/repo' format"
+  default     = "fahadahmed/fhdamd-org"
+}
+
+variable "environment_label" {
+  type        = string
+  description = "Human-readable environment name, e.g. 'staging' or 'production'"
+}


### PR DESCRIPTION
## Summary
- Adds `terraform/modules/firebase-env`, a reusable module that provisions the GCP/Firebase resources a `pdf-craft` environment needs: required APIs, Firestore, the default Storage bucket, Secret Manager secret shells (16, values populated out-of-band), an Artifact Registry repo for Cloud Run images, and a GitHub Actions deploy identity via Workload Identity Federation (no service account keys).
- Adds `terraform/environments/staging`, the first caller of the module, targeting `pdf-craft-stg`.
- Module is parameterized by `project_id`/`environment_label` so prod will reuse it with a new `terraform/environments/prod` directory once staging is validated.

## One-time manual steps (not managed by Terraform)
These are Firebase product-activation steps that aren't exposed via the Terraform provider and must be done once per environment before/after apply:
- `gcloud storage buckets create gs://pdf-craft-stg-tfstate ...` (state bucket, prerequisite)
- Firebase Storage must be activated via Console (Build → Storage → Get Started) before the `google_firebase_storage_bucket` resource can succeed
- Firebase App Hosting backend creation (`firebase apphosting:backends:create`) and secret access grants (`firebase apphosting:secrets:grantaccess`) — covered in a later PR alongside the deploy workflow

## Test plan
- [x] `terraform validate` passes
- [x] `terraform plan`/`apply` against `pdf-craft-stg` from a clean project — 55 resources created, 0 errors after resolving two soft-delete edge cases (WIF pool/provider needed `undelete` + `import` since this project had been torn down and rebuilt during testing)
- [x] Re-running `terraform apply` is a no-op ("No changes, infrastructure matches the configuration")
- [ ] Reviewer: confirm IAM role list on `github-deploy` SA matches what's actually needed once the deploy workflow PR lands

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>

Part of #144