### PR TITLE
feat(ci): add provision-staging workflow to run terraform for staging infra

### DIFF
--- a/.github/workflows/provision-staging.yml
+++ b/.github/workflows/provision-staging.yml
@@ -1,0 +1,42 @@
+name: Provision PDF-Craft Staging Infra
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'terraform/environments/staging/**'
+      - 'terraform/modules/firebase-env/**'
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+  id-token: write  # required for OIDC token exchange with GCP
+
+jobs:
+  provision:
+    name: Terraform — provision staging infra
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: terraform/environments/staging
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: google-github-actions/auth@v2
+        with:
+          workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+          service_account: ${{ secrets.GCP_SERVICE_ACCOUNT }}
+
+      - uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: "~1.9"
+
+      - name: Terraform init
+        run: terraform init
+
+      - name: Terraform validate
+        run: terraform validate
+
+      - name: Terraform apply
+        run: terraform apply -auto-approve -input=false


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/provision-staging.yml`, which runs `terraform apply` against `terraform/environments/staging` via GitHub Actions OIDC (no stored service account keys).
- Triggers automatically when the module or staging environment Terraform changes on `main`, plus `workflow_dispatch` for manual re-runs.
- Builds on #156 (merged) — this is Phase 2 of the staging rollout: validate Terraform runs cleanly in CI before building the full deploy workflow on top of it.

## Note on validation
GitHub's `workflow_dispatch` only recognizes workflow files that exist on the default branch, so this can't be live-tested from the PR branch itself. Plan is to merge, then trigger `workflow_dispatch` from `main` immediately to confirm `terraform apply` succeeds in CI (already verified to converge with zero drift locally).

## Test plan
- [x] YAML validated, job structure mirrors the working local terraform commands
- [ ] Post-merge: `gh workflow run provision-staging.yml --ref main` succeeds

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>

Part of #144