### PR TITLE
fix(terraform): grant github-deploy SA permission to manage its own WIF pool

### DIFF
--- a/terraform/modules/firebase-env/main.tf
+++ b/terraform/modules/firebase-env/main.tf
@@ -174,6 +174,7 @@ locals {
     "roles/eventarc.admin",             # onMessagePublished / onSchedule triggers
     "roles/pubsub.admin",               # topics/subscriptions for onMessagePublished
     "roles/cloudscheduler.admin",       # onSchedule jobs
+    "roles/iam.workloadIdentityPoolAdmin", # manage the WIF pool/provider this SA authenticates through
   ])
 }
 


### PR DESCRIPTION
## Summary
- The first real CI run of `provision-staging.yml` (#157) failed: `terraform apply` got a 403 on `iam.workloadIdentityPools.get` because the `github-deploy` SA was never granted permission to manage the Workload Identity Pool/provider it itself authenticates through.
- This was invisible during local testing since local runs used a personal account with broader project-level access.
- Adds `roles/iam.workloadIdentityPoolAdmin` to the SA's role list in the shared module.
- Already applied locally and verified — `pdf-craft-stg`'s `github-deploy` SA now has the role.

## Test plan
- [x] `terraform apply` locally — 1 resource added, 0 errors
- [ ] Post-merge: re-run `provision-staging.yml` via `workflow_dispatch` on main, confirm it now succeeds end-to-end

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>

Part of #144