### PR TITLE
fix(terraform): grant github-deploy SA admin over its own service account IAM

### DIFF
--- a/terraform/modules/firebase-env/main.tf
+++ b/terraform/modules/firebase-env/main.tf
@@ -175,6 +175,7 @@ locals {
     "roles/pubsub.admin",               # topics/subscriptions for onMessagePublished
     "roles/cloudscheduler.admin",       # onSchedule jobs
     "roles/iam.workloadIdentityPoolAdmin", # manage the WIF pool/provider this SA authenticates through
+    "roles/iam.serviceAccountAdmin",       # manage IAM policy on its own service account (WIF binding)
   ])
 }
 


### PR DESCRIPTION
## Summary
- Second self-referential IAM gap found while validating `provision-staging.yml` in CI (first one fixed in #158).
- `terraform apply` failed on `iam.serviceAccounts.getIamPolicy` while managing `google_service_account_iam_member.github_oidc` — the binding that lets GitHub Actions impersonate `github-deploy` via WIF.
- `roles/iam.serviceAccountUser` (already granted) only allows *acting as* other SAs, not reading/writing IAM policy *on* a service account. Adds `roles/iam.serviceAccountAdmin`.
- Already applied locally and verified.

## Test plan
- [x] `terraform apply` locally — 1 resource added, 0 errors
- [ ] Post-merge: re-run `provision-staging.yml`, confirm it succeeds end-to-end

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>

Part of #144