### PR TITLE
fix(ci): pin GitHub Actions in provision-staging.yml to commit SHAs

### DIFF
--- a/.github/workflows/provision-staging.yml
+++ b/.github/workflows/provision-staging.yml
@@ -21,14 +21,14 @@ jobs:
       run:
         working-directory: terraform/environments/staging
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
-      - uses: google-github-actions/auth@v2
+      - uses: google-github-actions/auth@c200f3691d83b41bf9bbd8638997a462592937ed # v2
         with:
           workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
           service_account: ${{ secrets.GCP_SERVICE_ACCOUNT }}
 
-      - uses: hashicorp/setup-terraform@v3
+      - uses: hashicorp/setup-terraform@b9cd54a3c349d3f38e8881555d616ced269862dd # v3
         with:
           terraform_version: "~1.9"
 


### PR DESCRIPTION
## Summary
- Fixes the 2 new SonarCloud security hotspots (rule `githubactions:S7637`) introduced by `provision-staging.yml` in #157 — using mutable version tags (`@v4`, `@v2`, `@v3`) for third-party actions instead of pinned commit SHAs.
- Pinning to a full commit SHA prevents a retagged/compromised upstream action from silently changing what runs in CI.
- Matches the convention already used in `test-pdf-craft.yml` (`pnpm/action-setup@<sha> # v4`).

## Note
There are 8 other pre-existing hotspots of the same rule in other workflows (`deploy-dev.yml`, `deploy-storybook.yml`, `preview-storybook.yml`, `release.yml`) plus one Docker root-user hotspot in `pdf-processor/Dockerfile`. Those predate this work and are out of scope here — flagging in case you want a follow-up pass.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>

Part of #144