### PR TITLE
feat(terraform): provision pdf-craft-dev infra via the firebase-env module

### DIFF
--- a/terraform/environments/dev/.terraform.lock.hcl
+++ b/terraform/environments/dev/.terraform.lock.hcl
@@ -1,0 +1,42 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/google" {
+  version     = "6.50.0"
+  constraints = "~> 6.0"
+  hashes = [
+    "h1:79CwMTsp3Ud1nOl5hFS5mxQHyT0fGVye7pqpU0PPlHI=",
+    "zh:1f3513fcfcbf7ca53d667a168c5067a4dd91a4d4cccd19743e248ff31065503c",
+    "zh:3da7db8fc2c51a77dd958ea8baaa05c29cd7f829bd8941c26e2ea9cb3aadc1e5",
+    "zh:3e09ac3f6ca8111cbb659d38c251771829f4347ab159a12db195e211c76068bb",
+    "zh:7bb9e41c568df15ccf1a8946037355eefb4dfb4e35e3b190808bb7c4abae547d",
+    "zh:81e5d78bdec7778e6d67b5c3544777505db40a826b6eb5abe9b86d4ba396866b",
+    "zh:8d309d020fb321525883f5c4ea864df3d5942b6087f6656d6d8b3a1377f340fc",
+    "zh:93e112559655ab95a523193158f4a4ac0f2bfed7eeaa712010b85ebb551d5071",
+    "zh:d3efe589ffd625b300cef5917c4629513f77e3a7b111c9df65075f76a46a63c7",
+    "zh:d4a4d672bbef756a870d8f32b35925f8ce2ef4f6bbd5b71a3cb764f1b6c85421",
+    "zh:e13a86bca299ba8a118e80d5f84fbdd708fe600ecdceea1a13d4919c068379fe",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+    "zh:fec30c095647b583a246c39d557704947195a1b7d41f81e369ba377d997faef6",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/google-beta" {
+  version     = "6.50.0"
+  constraints = "~> 6.0"
+  hashes = [
+    "h1:P2GiUJM1frlPtBViwKn1A9V2dVBdGuWcX80w9TdH8ZE=",
+    "zh:18b442bd0a05321d39dda1e9e3f1bdede4e61bc2ac62cc7a67037a3864f75101",
+    "zh:2e387c51455862828bec923a3ec81abf63a4d998da470cf00e09003bda53d668",
+    "zh:3942e708fa84ebe54996086f4b1398cb747fe19cbcd0be07ace528291fb35dee",
+    "zh:496287dd48b34ae6197cb1f887abeafd07c33f389dbe431bb01e24846754cfdd",
+    "zh:6eca885419969ce5c2a706f34dce1f10bde9774757675f2d8a92d12e5a1be390",
+    "zh:710dbef826c3fe7f76f844dae47937e8e4c1279dd9205ec4610be04cf3327244",
+    "zh:777ebf44b24bfc7bdbf770dc089f1a72f143b4718fdedb8c6bd75983115a1ec2",
+    "zh:9c8703bba37b8c7ad857efc3513392c5a096c519397c1cb822d7612f38e4262f",
+    "zh:c4f1d3a73de2702277c99d5348ad6d374705bcfdd367ad964ff4cfd2cf06c281",
+    "zh:eca8df11af3f5a948492d5b8b5d01b4ec705aad10bc30ec1524205508ae28393",
+    "zh:f41e7fd5f2628e8fd6b8ea136366923858f54428d1729898925469b862c275c2",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+  ]
+}

--- a/terraform/environments/dev/backend.tf
+++ b/terraform/environments/dev/backend.tf
@@ -1,0 +1,9 @@
+terraform {
+  backend "gcs" {
+    # This bucket must be created manually before first `terraform init`:
+    #   gcloud storage buckets create gs://pdf-craft-dev-tfstate \
+    #     --project=pdf-craft-dev --location=US --uniform-bucket-level-access
+    bucket = "pdf-craft-dev-tfstate"
+    prefix = "terraform/dev"
+  }
+}

--- a/terraform/environments/dev/main.tf
+++ b/terraform/environments/dev/main.tf
@@ -1,0 +1,32 @@
+terraform {
+  required_version = ">= 1.9"
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = "~> 6.0"
+    }
+    google-beta = {
+      source  = "hashicorp/google-beta"
+      version = "~> 6.0"
+    }
+  }
+}
+
+provider "google" {
+  project = var.project_id
+  region  = var.region
+}
+
+provider "google-beta" {
+  project = var.project_id
+  region  = var.region
+}
+
+module "firebase_env" {
+  source = "../../modules/firebase-env"
+
+  project_id        = var.project_id
+  region            = var.region
+  github_repo       = var.github_repo
+  environment_label = "dev"
+}

--- a/terraform/environments/dev/outputs.tf
+++ b/terraform/environments/dev/outputs.tf
@@ -1,0 +1,15 @@
+output "workload_identity_provider" {
+  value = module.firebase_env.workload_identity_provider
+}
+
+output "service_account_email" {
+  value = module.firebase_env.service_account_email
+}
+
+output "firestore_database" {
+  value = module.firebase_env.firestore_database
+}
+
+output "storage_bucket" {
+  value = module.firebase_env.storage_bucket
+}

--- a/terraform/environments/dev/variables.tf
+++ b/terraform/environments/dev/variables.tf
@@ -1,0 +1,15 @@
+variable "project_id" {
+  type    = string
+  default = "pdf-craft-dev"
+}
+
+variable "region" {
+  type    = string
+  default = "us-central1"
+}
+
+variable "github_repo" {
+  type        = string
+  description = "GitHub repository in 'owner/repo' format"
+  default     = "fahadahmed/fhdamd-org"
+}

--- a/terraform/modules/firebase-env/main.tf
+++ b/terraform/modules/firebase-env/main.tf
@@ -47,6 +47,10 @@ resource "google_firestore_database" "default" {
   location_id = "nam5"
   type        = "FIRESTORE_NATIVE"
 
+  lifecycle {
+    prevent_destroy = true
+  }
+
   depends_on = [google_project_service.apis]
 }
 
@@ -59,6 +63,10 @@ resource "google_firebase_storage_bucket" "default" {
   provider  = google-beta
   project   = var.project_id
   bucket_id = "${var.project_id}.firebasestorage.app"
+
+  lifecycle {
+    prevent_destroy = true
+  }
 
   depends_on = [google_project_service.apis]
 }


### PR DESCRIPTION
## Summary
- Adds `terraform/environments/dev`, giving `pdf-craft-dev` the same WIF-based GitHub Actions identity as staging (`github-deploy` SA, no stored keys). Needed because the legacy `FIREBASE_TOKEN` dev currently uses only grants Firebase CLI access, not the GCP IAM/Cloud Run permissions required to deploy `pdf-processor`.
- `pdf-craft-dev` is a **live environment** — Firestore (since 2025-03-28), Storage, 16 matching secrets, and a 65MB+ Artifact Registry repo all pre-existed. All were imported into Terraform state rather than recreated; verified zero data loss (Firestore `createTime` unchanged, secret versions intact, AR repo size unaffected) before and after apply.
- Adds `lifecycle { prevent_destroy = true }` to the Firestore and Storage resources in the shared module — both dev and staging now hold real data, and this prevents a stray `terraform destroy` from ever wiping either.

## Test plan
- [x] Plan reviewed line-by-line before apply: 38 to add, 1 to change (AR repo description only), **0 to destroy**
- [x] Apply succeeded exactly as planned
- [x] Post-apply verification: Firestore `createTime` unchanged, secret version counts unchanged, AR repo content unaffected
- [x] `terraform plan` shows zero drift after apply
- [x] Staging module still plans with zero drift after the `prevent_destroy` addition (shared module change)

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>

Part of #144