### PR TITLE
refactor(ci): scope provision-staging.yml to the staging GitHub Environment

### DIFF
--- a/.github/workflows/provision-staging.yml
+++ b/.github/workflows/provision-staging.yml
@@ -17,6 +17,7 @@ jobs:
   provision:
     name: Terraform — provision staging infra
     runs-on: ubuntu-latest
+    environment: staging
     defaults:
       run:
         working-directory: terraform/environments/staging


### PR DESCRIPTION
## Summary
- Adds `environment: staging` to the `provision` job so it pulls `GCP_WORKLOAD_IDENTITY_PROVIDER`/`GCP_SERVICE_ACCOUNT` from the staging GitHub Environment instead of repo-level secrets.
- Needed now that dev (#161) has its own distinct values under the same secret names — repo-level secrets can't hold two different values for the same name.

## Test plan
- [ ] Post-merge: re-run `provision-staging.yml` via `workflow_dispatch`, confirm it still succeeds pulling from the Environment

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>

Part of #144