### PR TITLE
fix(ci): remove explicit pnpm version from deploy-staging.yml

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -46,8 +46,6 @@ jobs:
           service_account: ${{ secrets.GCP_SERVICE_ACCOUNT }}
 
       - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
-        with:
-          version: 10
 
       - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:


### PR DESCRIPTION
## Summary
- First real RC-tag run of `deploy-staging.yml` failed: `pnpm/action-setup` errors with "Multiple versions of pnpm specified" because the root `package.json` now has `packageManager: pnpm@10.27.0` (Corepack) and the workflow also explicitly set `version: 10`.
- Removes the explicit `version: 10` input, matching `test-pdf-craft.yml`'s existing pattern of letting the action read the version from `packageManager`.

## Test plan
- [ ] Post-merge: delete and re-push `pdf-craft-v1.0.0-rc.1`, confirm `deploy-staging.yml` runs clean end to end

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>

Part of #144