### PR TITLE
fix(terraform): add Cloud Functions secrets missing from the module

### DIFF
--- a/terraform/modules/firebase-env/main.tf
+++ b/terraform/modules/firebase-env/main.tf
@@ -93,6 +93,14 @@ locals {
     "pdfProcessorUrl",
     "appEnv",
     "resendApiKey",
+    # Bound directly by Cloud Functions via defineSecret(), not apphosting.yaml
+    "STRIPE_SECRET_KEY",
+    "STRIPE_WEBHOOK_SECRET",
+    "APP_BASE_URL",
+    "RESEND_API_KEY",
+    "RESEND_AUDIENCE_ID",
+    "DATOCMS_API_TOKEN",
+    "DATOCMS_ENV",
   ])
 }
 


### PR DESCRIPTION
## Summary
- First real RC-tag deploy to staging (#163/#164) failed on the Cloud Functions step: `DATOCMS_API_TOKEN` had no value since Terraform's module only tracked the 16 secrets used by `apphosting.yaml`.
- Cloud Functions code binds 7 additional secrets directly via `defineSecret()` that were never accounted for: `STRIPE_SECRET_KEY`, `STRIPE_WEBHOOK_SECRET`, `APP_BASE_URL`, `RESEND_API_KEY`, `RESEND_AUDIENCE_ID`, `DATOCMS_API_TOKEN`, `DATOCMS_ENV`.
- `SENTRY_DSN` is intentionally not added — it's read via `process.env`/`import.meta.env`, not `defineSecret`, so a missing value just disables Sentry rather than blocking deploy.

## Values
- `APP_BASE_URL` / `RESEND_API_KEY`: populated, reusing existing known values (same as `baseAppUrl`/`resendApiKey`).
- `DATOCMS_ENV`: set to `stg`, a new dedicated DatoCMS sandbox environment created for staging.
- `STRIPE_SECRET_KEY` / `STRIPE_WEBHOOK_SECRET`: from a new dedicated Stripe Sandbox + webhook endpoint created for staging (not reusing dev's) — populated directly via `gcloud` by repo owner, never pasted in chat.
- `DATOCMS_API_TOKEN` / `RESEND_AUDIENCE_ID`: same, populated directly via `gcloud`.

## Test plan
- [x] `terraform apply` locally — 7 added, 0 changed, 0 destroyed
- [ ] Post-merge: re-tag and confirm `deploy-staging.yml` succeeds end to end

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>

Part of #144