### PR TITLE
fix(terraform): grant Gen2 Cloud Functions service agents required roles

### DIFF
--- a/terraform/modules/firebase-env/main.tf
+++ b/terraform/modules/firebase-env/main.tf
@@ -12,6 +12,10 @@ terraform {
   }
 }
 
+data "google_project" "current" {
+  project_id = var.project_id
+}
+
 # ─── APIs ────────────────────────────────────────────────────────────────────
 
 resource "google_project_service" "apis" {
@@ -220,4 +224,35 @@ resource "google_project_iam_member" "apphosting_compute" {
   project  = var.project_id
   role     = each.value
   member   = "serviceAccount:firebase-app-hosting-compute@${var.project_id}.iam.gserviceaccount.com"
+}
+
+# ─── Gen2 Cloud Functions service agents ─────────────────────────────────────
+# Required for onMessagePublished/onSchedule triggers (Pub/Sub -> Eventarc ->
+# Cloud Run). `firebase deploy --only functions` checks for these on every
+# deploy and fails outright if the deploying principal can't grant them
+# itself — granting them once via Terraform avoids needing to give
+# github-deploy broad project IAM-admin rights just for this.
+
+resource "google_project_iam_member" "pubsub_token_creator" {
+  project = var.project_id
+  role    = "roles/iam.serviceAccountTokenCreator"
+  member  = "serviceAccount:service-${data.google_project.current.number}@gcp-sa-pubsub.iam.gserviceaccount.com"
+
+  depends_on = [google_project_service.apis]
+}
+
+locals {
+  default_compute_sa_roles = toset([
+    "roles/run.invoker",
+    "roles/eventarc.eventReceiver",
+  ])
+}
+
+resource "google_project_iam_member" "default_compute_sa" {
+  for_each = local.default_compute_sa_roles
+  project  = var.project_id
+  role     = each.value
+  member   = "serviceAccount:${data.google_project.current.number}-compute@developer.gserviceaccount.com"
+
+  depends_on = [google_project_service.apis]
 }


### PR DESCRIPTION
## Summary
- The RC-tag deploy to staging failed at Cloud Functions with: "Failed to verify the project has the correct IAM bindings for a successful deployment."
- Gen2 functions with `onMessagePublished`/`onSchedule` triggers route through Pub/Sub -> Eventarc -> Cloud Run, which requires:
  - Pub/Sub's service agent: `roles/iam.serviceAccountTokenCreator`
  - the default Compute SA: `roles/run.invoker`, `roles/eventarc.eventReceiver`
- Rather than giving `github-deploy` broad project IAM-admin rights so it can self-grant these at deploy time, they're granted once via Terraform — same pattern as the App Hosting compute SA bindings.
- Added a `data "google_project"` lookup to resolve the project number (these service agent emails are number-based, not project-id-based).

## Applied to both environments
- **staging**: 3 added, 0 changed, 0 destroyed
- **dev**: already had these service agents (from earlier successful deploys via the old FIREBASE_TOKEN mechanism), but the bindings weren't Terraform-managed. Verified clean import (0 destroy) before apply, then 3 added.

## Test plan
- [x] Applied locally to both dev and staging, zero drift after
- [ ] Post-merge: re-tag and confirm `deploy-staging.yml`'s Cloud Functions step succeeds

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>

Part of #144