### PR TITLE
fix(terraform): enable Cloud Billing API for Cloud Functions deploys

### DIFF
--- a/terraform/modules/firebase-env/main.tf
+++ b/terraform/modules/firebase-env/main.tf
@@ -37,6 +37,7 @@ resource "google_project_service" "apis" {
     "eventarc.googleapis.com",
     "pubsub.googleapis.com",
     "cloudscheduler.googleapis.com",
+    "cloudbilling.googleapis.com",
   ])
   project            = var.project_id
   service            = each.key


### PR DESCRIPTION
## Summary
- `deploy-staging.yml`'s Cloud Functions step failed with a 403: `Cloud Billing API has not been used in project ... or it is disabled.`
- `firebase deploy --only functions` checks billing status as part of its deploy flow; `cloudbilling.googleapis.com` was never in the module's enabled-APIs list.
- Applied to both dev and staging (1 added each, 0 destroyed).

## Test plan
- [x] Applied locally to both environments, zero drift after
- [ ] Post-merge: re-tag and confirm `deploy-staging.yml` succeeds end to end

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>

Part of #144