### PR TITLE
fix(terraform): grant github-deploy projectIamAdmin for App Hosting deploys

### DIFF
--- a/terraform/modules/firebase-env/main.tf
+++ b/terraform/modules/firebase-env/main.tf
@@ -197,6 +197,7 @@ locals {
     "roles/cloudscheduler.admin",       # onSchedule jobs
     "roles/iam.workloadIdentityPoolAdmin", # manage the WIF pool/provider this SA authenticates through
     "roles/iam.serviceAccountAdmin",       # manage IAM policy on its own service account (WIF binding)
+    "roles/resourcemanager.projectIamAdmin", # firebase deploy --only apphosting sets project IAM policy directly
   ])
 }
 


### PR DESCRIPTION
## Summary
- `deploy-staging.yml`'s App Hosting step failed with a 403 on `setIamPolicy` at the project level.
- `firebase deploy --only apphosting` apparently grants IAM bindings directly as part of its rollout (likely to the App Hosting compute SA), which `github-deploy` had no permission to do.
- Adds `roles/resourcemanager.projectIamAdmin`.
- Applied to both dev and staging (1 added each, 0 destroyed).

This is the 4th IAM gap found while validating the real RC-tag deploy end to end (#158, #159, #166 were the others) — each one only surfaced because we're testing with the actual scoped deploy SA rather than a personal account with broad project access.

## Test plan
- [x] Applied locally to both environments, zero drift after
- [ ] Post-merge: re-tag and confirm `deploy-staging.yml` succeeds fully end to end

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>

Part of #144