### PR TITLE
fix(terraform): add secretmanager.viewer to App Hosting compute SA

### DIFF
--- a/terraform/modules/firebase-env/main.tf
+++ b/terraform/modules/firebase-env/main.tf
@@ -217,7 +217,8 @@ locals {
   apphosting_compute_roles = toset([
     "roles/logging.logWriter",             # write build/runtime logs
     "roles/firebaseapphosting.computeRunner",
-    "roles/secretmanager.secretAccessor",  # read apphosting.yaml secrets
+    "roles/secretmanager.secretAccessor",  # read apphosting.yaml secret payloads
+    "roles/secretmanager.viewer",          # read secret version metadata (build-time resolution)
   ])
 }
 


### PR DESCRIPTION
## Summary
- App Hosting's Cloud Build "preparer" step failed: \"Misconfigured Secret ... Permission 'secretmanager.versions.get' denied\" on \`firebaseApiKey\`, despite the compute SA already having \`roles/secretmanager.secretAccessor\`.
- Root cause: \`secretAccessor\` only grants \`secretmanager.versions.access\` (payload read) — it does **not** include \`secretmanager.versions.get\` (version metadata), which the buildpack's secret-resolution step calls separately.
- Confirmed via \`gcloud iam roles describe roles/secretmanager.secretAccessor\` vs \`roles/secretmanager.viewer\` — the latter includes \`versions.get\`.
- Adds \`roles/secretmanager.viewer\` alongside the existing \`secretAccessor\`. Applied to both dev and staging (1 added each, 0 destroyed).

## Test plan
- [x] Applied locally to both environments, zero drift after
- [ ] Post-merge: re-tag and confirm the App Hosting build step succeeds

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>

Part of #144