### PR TITLE
feat(ci): add deploy-pdf-processor-dev workflow

### DIFF
--- a/.github/workflows/deploy-pdf-processor-dev.yml
+++ b/.github/workflows/deploy-pdf-processor-dev.yml
@@ -1,0 +1,86 @@
+name: Deploy PDF-Processor Dev
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - apps/pdf-processor/**
+  workflow_dispatch: {}
+
+jobs:
+  deploy:
+    name: Deploy to Cloud Run — dev
+    runs-on: ubuntu-latest
+    environment: dev
+    permissions:
+      contents: read
+      id-token: write  # required for OIDC token exchange with GCP
+    env:
+      PROJECT_ID: pdf-craft-dev
+      REGION: us-central1
+      IMAGE: us-central1-docker.pkg.dev/pdf-craft-dev/cloud-run-source-deploy/pdf-processor
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - uses: google-github-actions/auth@c200f3691d83b41bf9bbd8638997a462592937ed # v2
+        with:
+          workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+          service_account: ${{ secrets.GCP_SERVICE_ACCOUNT }}
+
+      - uses: google-github-actions/setup-gcloud@e427ad8a34f8676edf47cf7d7925499adf3eb74f # v2
+
+      - name: Authenticate Docker with Artifact Registry
+        run: gcloud auth configure-docker us-central1-docker.pkg.dev --quiet
+
+      - name: Build image
+        run: |
+          docker build \
+            -f apps/pdf-processor/Dockerfile \
+            -t ${{ env.IMAGE }}:${{ github.sha }} \
+            -t ${{ env.IMAGE }}:latest \
+            .
+
+      - name: Push image
+        run: |
+          docker push ${{ env.IMAGE }}:${{ github.sha }}
+          docker push ${{ env.IMAGE }}:latest
+
+      - name: Deploy to Cloud Run
+        run: |
+          gcloud run deploy pdf-processor \
+            --image=${{ env.IMAGE }}:${{ github.sha }} \
+            --project=${{ env.PROJECT_ID }} \
+            --region=${{ env.REGION }} \
+            --allow-unauthenticated \
+            --min-instances=0 \
+            --max-instances=5 \
+            --memory=512Mi \
+            --cpu=1 \
+            --port=8080 \
+            --quiet
+
+      - name: Get service URL
+        id: service
+        run: |
+          URL=$(gcloud run services describe pdf-processor \
+            --project=${{ env.PROJECT_ID }} \
+            --region=${{ env.REGION }} \
+            --format='value(status.url)')
+          echo "url=$URL" >> "$GITHUB_OUTPUT"
+
+      - name: Verify health endpoint
+        run: |
+          URL="${{ steps.service.outputs.url }}/health"
+          echo "Checking $URL ..."
+          for i in 1 2 3 4 5; do
+            STATUS=$(curl -sf -o /dev/null -w "%{http_code}" "$URL" 2>/dev/null || echo "000")
+            if [ "$STATUS" = "200" ]; then
+              echo "Health check passed (HTTP 200)."
+              exit 0
+            fi
+            echo "Attempt $i/5: HTTP $STATUS — waiting 15s for cold start..."
+            sleep 15
+          done
+          echo "::error::pdf-processor health check failed after 5 attempts. Check Cloud Run logs in pdf-craft-dev."
+          exit 1


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/deploy-pdf-processor-dev.yml` — `pdf-processor` previously had no automated dev deployment at all (`cloudbuild.yaml` exists but nothing ever triggered it).
- Mirrors `deploy-dev.yml`'s continuous-deploy style for pdf-craft: push to `main`, path-filtered to `apps/pdf-processor/**`, no tag/guard needed.
- Authenticates via the `dev` GitHub Environment's WIF identity (#161) rather than a stored key.
- Includes `workflow_dispatch` for manual validation without needing a real code change.
- Build → push → deploy → health-check, same pattern already proven out for staging.

## Test plan
- [ ] Post-merge: trigger via `workflow_dispatch`, confirm image builds, pushes, deploys, and the health check passes

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>

Part of #144