### PR TITLE
feat(ci): publish GitHub Releases for staging RC tag deploys

### DIFF
--- a/.github/workflows/deploy-pdf-processor-staging.yml
+++ b/.github/workflows/deploy-pdf-processor-staging.yml
@@ -5,13 +5,12 @@ on:
     tags:
       - 'pdf-processor-v[0-9]+.[0-9]+.[0-9]+-rc.[0-9]+'
 
-permissions:
-  contents: read
-
 jobs:
   guard:
     name: Verify tag is on main
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
@@ -34,6 +33,8 @@ jobs:
     permissions:
       contents: read
       id-token: write  # required for OIDC token exchange with GCP
+    outputs:
+      service-url: ${{ steps.service.outputs.url }}
     env:
       PROJECT_ID: pdf-craft-stg
       REGION: us-central1
@@ -102,3 +103,23 @@ jobs:
           done
           echo "::error::pdf-processor health check failed after 5 attempts. Check Cloud Run logs in pdf-craft-stg."
           exit 1
+
+  release:
+    name: Publish GitHub Release
+    needs: deploy
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Create release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release create "${{ github.ref_name }}" \
+            --repo "${{ github.repository }}" \
+            --title "${{ github.ref_name }} — staging" \
+            --prerelease \
+            --notes "Deployed to staging: ${{ needs.deploy.outputs.service-url }}
+
+          Commit: ${{ github.sha }}
+          Workflow run: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -5,9 +5,6 @@ on:
     tags:
       - 'pdf-craft-v[0-9]+.[0-9]+.[0-9]+-rc.[0-9]+'
 
-permissions:
-  contents: read
-
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
@@ -15,6 +12,8 @@ jobs:
   guard:
     name: Verify tag is on main
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
@@ -77,3 +76,23 @@ jobs:
       - name: Deploy App Hosting
         working-directory: apps/pdf-craft
         run: firebase deploy --only apphosting --project pdf-craft-stg --force
+
+  release:
+    name: Publish GitHub Release
+    needs: deploy
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Create release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release create "${{ github.ref_name }}" \
+            --repo "${{ github.repository }}" \
+            --title "${{ github.ref_name }} — staging" \
+            --prerelease \
+            --notes "Deployed to staging: https://stg.pdf-craft.app
+
+          Commit: ${{ github.sha }}
+          Workflow run: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"


### PR DESCRIPTION
## Summary
- Adds a `release` job to `deploy-staging.yml` and `deploy-pdf-processor-staging.yml`, running after a successful deploy.
- Publishes a **prerelease** GitHub Release for the RC tag, with the deployed URL, commit SHA, and a link to the workflow run.
- pdf-processor's release uses the dynamic Cloud Run URL (passed via job `outputs`); pdf-craft's uses the fixed `stg.pdf-craft.app` domain.

## Scope decisions (from earlier discussion)
- **Dev**: no Release entries — stays continuous/untagged, visibility comes from the Environment deployment activity log instead.
- **Staging (this PR)**: prerelease Release per RC tag.
- **Prod** (future): same pattern, marked as a non-prerelease, once the prod workflow exists.

## Also fixes
- IDE linter caught `S8264` before push — workflow-level `permissions: contents: read` moved to each job individually, same pattern as the `id-token` fix in #163.

## Test plan
- [ ] Post-merge: re-tag `pdf-craft-v1.0.0-rc.1` and `pdf-processor-v1.0.0-rc.1`, confirm both produce a Release entry with correct content

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>

Part of #144