### PR TITLE
fix(terraform): grant App Hosting compute SA pubsub.publisher

### DIFF
--- a/terraform/modules/firebase-env/main.tf
+++ b/terraform/modules/firebase-env/main.tf
@@ -219,6 +219,7 @@ locals {
     "roles/firebaseapphosting.computeRunner",
     "roles/secretmanager.secretAccessor",  # read apphosting.yaml secret payloads
     "roles/secretmanager.viewer",          # read secret version metadata (build-time resolution)
+    "roles/pubsub.publisher",              # server actions publish directly to the app-event topic
   ])
 }
 


### PR DESCRIPTION
## Summary
- A Cloud Logging error surfaced from the live staging site: \`7 PERMISSION_DENIED: User not authorized to perform this action\` when running a \`merge\` operation, traced to a Pub/Sub publish call from \`pdf-craft-web\` (the Astro App Hosting service itself, not Cloud Functions).
- \`apps/pdf-craft/src/actions/operations.ts\` publishes directly to the \`app-event\` topic for merge/encrypt/decrypt/imagetopdf operations — the App Hosting compute SA never had \`roles/pubsub.publisher\`.
- Applied to both dev and staging (1 added each, 0 destroyed).

## Test plan
- [x] Applied locally to both environments, zero drift after
- [ ] Post-merge: trigger an apphosting rollout, retest a PDF operation on stg.pdf-craft.app, confirm no more PERMISSION_DENIED in Cloud Logging

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>

Part of #144