### PR TITLE
feat(terraform): provision pdf-craft-prd infra via the firebase-env module

### DIFF
--- a/terraform/environments/prod/.terraform.lock.hcl
+++ b/terraform/environments/prod/.terraform.lock.hcl
@@ -1,0 +1,42 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/google" {
+  version     = "6.50.0"
+  constraints = "~> 6.0"
+  hashes = [
+    "h1:79CwMTsp3Ud1nOl5hFS5mxQHyT0fGVye7pqpU0PPlHI=",
+    "zh:1f3513fcfcbf7ca53d667a168c5067a4dd91a4d4cccd19743e248ff31065503c",
+    "zh:3da7db8fc2c51a77dd958ea8baaa05c29cd7f829bd8941c26e2ea9cb3aadc1e5",
+    "zh:3e09ac3f6ca8111cbb659d38c251771829f4347ab159a12db195e211c76068bb",
+    "zh:7bb9e41c568df15ccf1a8946037355eefb4dfb4e35e3b190808bb7c4abae547d",
+    "zh:81e5d78bdec7778e6d67b5c3544777505db40a826b6eb5abe9b86d4ba396866b",
+    "zh:8d309d020fb321525883f5c4ea864df3d5942b6087f6656d6d8b3a1377f340fc",
+    "zh:93e112559655ab95a523193158f4a4ac0f2bfed7eeaa712010b85ebb551d5071",
+    "zh:d3efe589ffd625b300cef5917c4629513f77e3a7b111c9df65075f76a46a63c7",
+    "zh:d4a4d672bbef756a870d8f32b35925f8ce2ef4f6bbd5b71a3cb764f1b6c85421",
+    "zh:e13a86bca299ba8a118e80d5f84fbdd708fe600ecdceea1a13d4919c068379fe",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+    "zh:fec30c095647b583a246c39d557704947195a1b7d41f81e369ba377d997faef6",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/google-beta" {
+  version     = "6.50.0"
+  constraints = "~> 6.0"
+  hashes = [
+    "h1:P2GiUJM1frlPtBViwKn1A9V2dVBdGuWcX80w9TdH8ZE=",
+    "zh:18b442bd0a05321d39dda1e9e3f1bdede4e61bc2ac62cc7a67037a3864f75101",
+    "zh:2e387c51455862828bec923a3ec81abf63a4d998da470cf00e09003bda53d668",
+    "zh:3942e708fa84ebe54996086f4b1398cb747fe19cbcd0be07ace528291fb35dee",
+    "zh:496287dd48b34ae6197cb1f887abeafd07c33f389dbe431bb01e24846754cfdd",
+    "zh:6eca885419969ce5c2a706f34dce1f10bde9774757675f2d8a92d12e5a1be390",
+    "zh:710dbef826c3fe7f76f844dae47937e8e4c1279dd9205ec4610be04cf3327244",
+    "zh:777ebf44b24bfc7bdbf770dc089f1a72f143b4718fdedb8c6bd75983115a1ec2",
+    "zh:9c8703bba37b8c7ad857efc3513392c5a096c519397c1cb822d7612f38e4262f",
+    "zh:c4f1d3a73de2702277c99d5348ad6d374705bcfdd367ad964ff4cfd2cf06c281",
+    "zh:eca8df11af3f5a948492d5b8b5d01b4ec705aad10bc30ec1524205508ae28393",
+    "zh:f41e7fd5f2628e8fd6b8ea136366923858f54428d1729898925469b862c275c2",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+  ]
+}

--- a/terraform/environments/prod/backend.tf
+++ b/terraform/environments/prod/backend.tf
@@ -1,0 +1,9 @@
+terraform {
+  backend "gcs" {
+    # This bucket must be created manually before first `terraform init`:
+    #   gcloud storage buckets create gs://pdf-craft-prd-tfstate \
+    #     --project=pdf-craft-prd --location=US --uniform-bucket-level-access
+    bucket = "pdf-craft-prd-tfstate"
+    prefix = "terraform/prod"
+  }
+}

--- a/terraform/environments/prod/main.tf
+++ b/terraform/environments/prod/main.tf
@@ -1,0 +1,32 @@
+terraform {
+  required_version = ">= 1.9"
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = "~> 6.0"
+    }
+    google-beta = {
+      source  = "hashicorp/google-beta"
+      version = "~> 6.0"
+    }
+  }
+}
+
+provider "google" {
+  project = var.project_id
+  region  = var.region
+}
+
+provider "google-beta" {
+  project = var.project_id
+  region  = var.region
+}
+
+module "firebase_env" {
+  source = "../../modules/firebase-env"
+
+  project_id        = var.project_id
+  region            = var.region
+  github_repo       = var.github_repo
+  environment_label = "prod"
+}

--- a/terraform/environments/prod/outputs.tf
+++ b/terraform/environments/prod/outputs.tf
@@ -1,0 +1,15 @@
+output "workload_identity_provider" {
+  value = module.firebase_env.workload_identity_provider
+}
+
+output "service_account_email" {
+  value = module.firebase_env.service_account_email
+}
+
+output "firestore_database" {
+  value = module.firebase_env.firestore_database
+}
+
+output "storage_bucket" {
+  value = module.firebase_env.storage_bucket
+}

--- a/terraform/environments/prod/variables.tf
+++ b/terraform/environments/prod/variables.tf
@@ -1,0 +1,15 @@
+variable "project_id" {
+  type    = string
+  default = "pdf-craft-prd"
+}
+
+variable "region" {
+  type    = string
+  default = "us-central1"
+}
+
+variable "github_repo" {
+  type        = string
+  description = "GitHub repository in 'owner/repo' format"
+  default     = "fahadahmed/fhdamd-org"
+}


### PR DESCRIPTION
## Summary
- Adds \`terraform/environments/prod\`, reusing the same module as dev (#161) and staging (#156). \`pdf-craft-prd\` was a genuinely clean project — Firestore, Secret Manager, and Artifact Registry APIs weren't even enabled yet.
- Applied cleanly: 71 of 72 resources created. The last one (\`pubsub_token_creator\`) is pending intentionally — see below.

## Two first-time-apply quirks (neither dev nor staging hit these, since both already had prior activity)
1. Firebase Storage needed one-time Console activation before \`google_firebase_storage_bucket\` could succeed — same step as dev/staging.
2. Enabling \`pubsub.googleapis.com\` / \`firebaseapphosting.googleapis.com\` doesn't *synchronously* create their service agents — those are lazily provisioned on first real product usage (an App Hosting backend existing, a Pub/Sub topic existing). Created the App Hosting backend explicitly between apply attempts to unblock its compute SA's IAM bindings. The Pub/Sub service agent binding will apply cleanly once the first Cloud Functions deploy creates the \`app-event\` topic — tracked as a follow-up, not blocking this PR.

## Process improvement from a staging lesson
Created the App Hosting backend's web app explicitly up front (rather than letting \`--app\` auto-create one), avoiding the confusing duplicate-app situation we hit during staging setup. Confirmed only one web app exists and the backend's internal \`appId\` matches it exactly.

## Test plan
- [x] \`terraform apply\` — 71/72 resources created, 0 destroyed
- [x] App Hosting backend created, confirmed single clean web app (no duplicates)
- [ ] Follow-up after first Cloud Functions deploy: re-run \`terraform apply\` to pick up the last pending resource

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>

Part of #176