### PR TITLE
fix(pdf-craft): send contact form submissions to support email

### DIFF
--- a/apps/pdf-craft/src/actions/contact.ts
+++ b/apps/pdf-craft/src/actions/contact.ts
@@ -52,7 +52,7 @@ async function sendViaResend(payload: {
     },
     body: JSON.stringify({
       from: "PDF Craft <no-reply@pdf-craft.app>",
-      to: ["fahad.ahmed@me.com"],
+      to: ["support@pdf-craft.app"],
       reply_to: fromEmail,
       subject: `[Contact] ${subject} — from ${fromName}`,
       text: `From: ${fromName} <${fromEmail}>\nSubject: ${subject}\n\n${message}`,


### PR DESCRIPTION
## Summary
- Contact form submissions were being delivered to a personal inbox (`fahad.ahmed@me.com`) instead of `support@pdf-craft.app`, which is the address shown on the contact page.

Closes #182

## Test plan
- [ ] Submit the contact form on staging/prod and confirm the email arrives at support@pdf-craft.app