### PR TITLE
fix(pdf-craft): make PaymentCancel icon read as status, not a button

### DIFF
--- a/apps/pdf-craft/src/components/views/PaymentCancel/PaymentCancel.tsx
+++ b/apps/pdf-craft/src/components/views/PaymentCancel/PaymentCancel.tsx
@@ -3,9 +3,9 @@ import { Container, Stack, Text, Button, Callout } from '@fhdamd/threads'
 const iconStyle: React.CSSProperties = {
   width: 64,
   height: 64,
-  borderRadius: '50%',
-  background: 'var(--th-color-surface-3)',
-  color: 'var(--th-color-text-2)',
+  borderRadius: 'var(--th-radius-lg)',
+  background: 'var(--th-color-error-subtle)',
+  color: 'var(--th-color-error-text)',
   display: 'flex',
   alignItems: 'center',
   justifyContent: 'center',


### PR DESCRIPTION
## Summary
- The cancellation icon used a 64px filled circle, the pill shape this design system reserves for buttons/badges — making a purely decorative, `aria-hidden` status icon look like a clickable close/dismiss button.
- Swapped to a card-radius square in error tones (mirroring the success page's status-badge pattern) so it reads as a status indicator instead of a button.

Closes #183

## Test plan
- [x] Existing PaymentCancel tests pass
- [ ] Visually check `/payment/cancel` (or equivalent route) to confirm it no longer looks tappable