### PR TITLE
fix(pdf-craft): add buy-credits link to insufficient-credits errors

### DIFF
--- a/apps/pdf-craft/src/components/shared.tsx
+++ b/apps/pdf-craft/src/components/shared.tsx
@@ -2,7 +2,25 @@ import { useState } from 'react'
 import { DndContext, closestCenter, useSensors, useSensor, PointerSensor, type DragEndEvent } from '@dnd-kit/core'
 import { SortableContext, useSortable, arrayMove } from '@dnd-kit/sortable'
 import { CSS } from '@dnd-kit/utilities'
-import { Stack, Text, Button } from '@fhdamd/threads'
+import { Stack, Text, Button, Callout } from '@fhdamd/threads'
+
+export const INSUFFICIENT_CREDITS_ERROR = 'Insufficient credits for this operation. Please buy more credits.'
+
+export function ErrorCallout({ message }: { readonly message: string }) {
+  return (
+    <Callout variant="error">
+      {message}
+      {message === INSUFFICIENT_CREDITS_ERROR && (
+        <>
+          {' '}
+          <a href="/buy-credits" style={{ color: 'inherit', textDecoration: 'underline', fontWeight: 600 }}>
+            Buy more credits
+          </a>
+        </>
+      )}
+    </Callout>
+  )
+}
 
 export const XIcon = () => (
   <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">

--- a/apps/pdf-craft/src/components/slices/MultiPdfUploader/MultiPdfUploader.tsx
+++ b/apps/pdf-craft/src/components/slices/MultiPdfUploader/MultiPdfUploader.tsx
@@ -6,7 +6,7 @@ import {
 } from '@fhdamd/threads'
 import * as Sentry from '@sentry/astro'
 import { logEvent } from '../../../utils/lib/analytics'
-import { DownloadIcon, DraggableFileList, useDraggableFiles } from '../../shared'
+import { DownloadIcon, DraggableFileList, ErrorCallout, INSUFFICIENT_CREDITS_ERROR, useDraggableFiles } from '../../shared'
 
 const MAX_FILES = 5
 
@@ -26,7 +26,7 @@ export default function MultiPdfUploader({ creditCost }: { creditCost: number })
 
     const response = await actions.credits.checkCredits({ task, requestId, creditCost })
     if (!response.data?.success) {
-      setError('Insufficient credits for this operation. Please buy more credits.')
+      setError(INSUFFICIENT_CREDITS_ERROR)
       setButtonLabel('Merge PDFs')
       setIsMerging(false)
       return
@@ -122,7 +122,7 @@ export default function MultiPdfUploader({ creditCost }: { creditCost: number })
                       <DraggableFileList files={uploadedFiles} sensors={sensors} onDragEnd={handleDragEnd} onDelete={handleDelete} />
                     </Stack>
 
-                    {error && <Callout variant="error">{error}</Callout>}
+                    {error && <ErrorCallout message={error} />}
 
                     <form onSubmit={handleSubmit}>
                       <Button
@@ -136,7 +136,7 @@ export default function MultiPdfUploader({ creditCost }: { creditCost: number })
                   </>
                 )}
 
-                {error && uploadedFiles.length === 0 && <Callout variant="error">{error}</Callout>}
+                {error && uploadedFiles.length === 0 && <ErrorCallout message={error} />}
               </>
             )}
 

--- a/apps/pdf-craft/src/components/views/DecryptPdf/DecryptPdf.tsx
+++ b/apps/pdf-craft/src/components/views/DecryptPdf/DecryptPdf.tsx
@@ -6,7 +6,7 @@ import {
 } from '@fhdamd/threads'
 import * as Sentry from '@sentry/astro'
 import { logEvent } from '../../../utils/lib/analytics'
-import { XIcon, DownloadIcon } from '../../shared'
+import { XIcon, DownloadIcon, ErrorCallout, INSUFFICIENT_CREDITS_ERROR } from '../../shared'
 
 export default function DecryptPdf({ creditCost }: { creditCost: number }) {
   const [file, setFile]                 = useState<File | null>(null)
@@ -36,7 +36,7 @@ export default function DecryptPdf({ creditCost }: { creditCost: number }) {
 
     const creditsResponse = await actions.credits.checkCredits({ task, requestId, creditCost })
     if (!creditsResponse.data?.success) {
-      setError('Insufficient credits for this operation. Please buy more credits.')
+      setError(INSUFFICIENT_CREDITS_ERROR)
       setButtonLabel('Unlock PDF')
       setIsProcessing(false)
       return
@@ -142,7 +142,7 @@ export default function DecryptPdf({ creditCost }: { creditCost: number }) {
                           autoComplete="current-password"
                           required
                         />
-                        {error && <Callout variant="error">{error}</Callout>}
+                        {error && <ErrorCallout message={error} />}
                         <Button
                           type="submit"
                           variant="solid-terra"

--- a/apps/pdf-craft/src/components/views/EncryptPdf/EncryptPdf.tsx
+++ b/apps/pdf-craft/src/components/views/EncryptPdf/EncryptPdf.tsx
@@ -6,7 +6,7 @@ import {
 } from '@fhdamd/threads'
 import * as Sentry from '@sentry/astro'
 import { logEvent } from '../../../utils/lib/analytics'
-import { XIcon, DownloadIcon } from '../../shared'
+import { XIcon, DownloadIcon, ErrorCallout, INSUFFICIENT_CREDITS_ERROR } from '../../shared'
 
 type PermissionPreset = 'full-access' | 'view-and-print' | 'read-only'
 
@@ -46,7 +46,7 @@ export default function EncryptPdf({ creditCost }: { creditCost: number }) {
 
     const creditsResponse = await actions.credits.checkCredits({ task, requestId, creditCost })
     if (!creditsResponse.data?.success) {
-      setError('Insufficient credits for this operation. Please buy more credits.')
+      setError(INSUFFICIENT_CREDITS_ERROR)
       setButtonLabel('Protect PDF')
       setIsProcessing(false)
       return
@@ -205,7 +205,7 @@ export default function EncryptPdf({ creditCost }: { creditCost: number }) {
                           </Stack>
                         </Stack>
 
-                        {error && <Callout variant="error">{error}</Callout>}
+                        {error && <ErrorCallout message={error} />}
                         <Button
                           type="submit"
                           variant="solid-terra"

--- a/apps/pdf-craft/src/components/views/ImageToPdf/ImageToPdf.tsx
+++ b/apps/pdf-craft/src/components/views/ImageToPdf/ImageToPdf.tsx
@@ -6,7 +6,7 @@ import {
 } from '@fhdamd/threads'
 import * as Sentry from '@sentry/astro'
 import { logEvent } from '../../../utils/lib/analytics'
-import { DownloadIcon, DraggableFileList, useDraggableFiles } from '../../shared'
+import { DownloadIcon, DraggableFileList, ErrorCallout, INSUFFICIENT_CREDITS_ERROR, useDraggableFiles } from '../../shared'
 
 const MAX_IMAGES = 10
 
@@ -26,7 +26,7 @@ export default function ImageToPdf({ creditCost }: { creditCost: number }) {
 
     const response = await actions.credits.checkCredits({ task, requestId, creditCost })
     if (!response.data?.success) {
-      setError('Insufficient credits for this operation. Please buy more credits.')
+      setError(INSUFFICIENT_CREDITS_ERROR)
       setButtonLabel('Convert to PDF')
       setIsConverting(false)
       return
@@ -122,7 +122,7 @@ export default function ImageToPdf({ creditCost }: { creditCost: number }) {
                       <DraggableFileList files={uploadedFiles} sensors={sensors} onDragEnd={handleDragEnd} onDelete={handleDelete} />
                     </Stack>
 
-                    {error && <Callout variant="error">{error}</Callout>}
+                    {error && <ErrorCallout message={error} />}
 
                     <form onSubmit={handleSubmit}>
                       <Button type="submit" variant="solid-terra" disabled={isConverting}>
@@ -132,7 +132,7 @@ export default function ImageToPdf({ creditCost }: { creditCost: number }) {
                   </>
                 )}
 
-                {error && uploadedFiles.length === 0 && <Callout variant="error">{error}</Callout>}
+                {error && uploadedFiles.length === 0 && <ErrorCallout message={error} />}
               </>
             )}
 


### PR DESCRIPTION
## Summary
- The "Insufficient credits for this operation" error rendered as plain text with no way to act on it.
- Added a shared `ErrorCallout` (in `shared.tsx`) that appends a "Buy more credits" link to `/buy-credits` when the error matches the insufficient-credits message, deduplicating the hardcoded string into a shared constant.
- Wired into the 4 places this error can occur: merge (MultiPdfUploader), image-to-pdf, encrypt, decrypt.

Closes #181

## Test plan
- [x] Existing test suites for all 4 touched components pass (29 tests)
- [x] `tsc --noEmit` clean on touched files
- [ ] Manually trigger an insufficient-credits error in one flow and confirm the link renders and navigates to /buy-credits