### PR TITLE
fix(ci): serialize pdf-craft dev deploys to avoid App Hosting 409s

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -5,6 +5,11 @@ on:
       - main
     paths:
       - apps/pdf-craft/**
+
+concurrency:
+  group: deploy-pdf-craft-dev
+  cancel-in-progress: false
+
 jobs:
   deploy:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- Merging #185, #186, and #187 in quick succession triggered overlapping `Deploy PDF-Craft Dev` runs. Firebase App Hosting only allows one active rollout per backend, so the 2nd and 3rd runs failed with `HTTP 409: unable to queue the operation`.
- Added a `concurrency` group to `deploy-dev.yml` so future pushes to main queue sequentially instead of racing.
- `deploy-staging.yml`/`deploy-prod.yml` are tag-triggered and lower-risk, left untouched — worth the same treatment later if bursts ever happen there too.

## Test plan
- [ ] Merge two PRs touching `apps/pdf-craft/**` close together and confirm the second run queues instead of failing with 409