### PR TITLE
feat(ci): sync package.json version from release tags

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -13,6 +13,7 @@ concurrency:
 jobs:
   deploy:
     runs-on: ubuntu-latest
+    if: ${{ !contains(github.event.head_commit.message, '[skip-deploy]') }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v3

--- a/.github/workflows/deploy-pdf-processor-dev.yml
+++ b/.github/workflows/deploy-pdf-processor-dev.yml
@@ -12,6 +12,7 @@ jobs:
   deploy:
     name: Deploy to Cloud Run — dev
     runs-on: ubuntu-latest
+    if: ${{ !contains(github.event.head_commit.message, '[skip-deploy]') }}
     environment: dev
     permissions:
       contents: read

--- a/.github/workflows/deploy-pdf-processor-staging.yml
+++ b/.github/workflows/deploy-pdf-processor-staging.yml
@@ -25,9 +25,43 @@ jobs:
           fi
           echo "Commit ${{ github.sha }} is on main. Proceeding."
 
+  sync-version:
+    name: Sync package.json version with release tag
+    needs: guard
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          fetch-depth: 0
+
+      - name: Bump apps/pdf-processor/package.json to the canonical release version
+        run: |
+          TAG="${{ github.ref_name }}"
+          VERSION="${TAG#pdf-processor-v}"
+          VERSION="${VERSION%-rc.*}"
+
+          git fetch origin main
+          git checkout -B main origin/main
+
+          CURRENT=$(node -p "require('./apps/pdf-processor/package.json').version")
+          if [ "$CURRENT" = "$VERSION" ]; then
+            echo "apps/pdf-processor/package.json already at $VERSION, nothing to do."
+            exit 0
+          fi
+
+          (cd apps/pdf-processor && npm pkg set version="$VERSION")
+
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add apps/pdf-processor/package.json
+          git commit -m "chore(pdf-processor): bump version to $VERSION [skip-deploy]"
+          git push origin main
+
   deploy:
     name: Deploy to Cloud Run — staging
-    needs: guard
+    needs: [guard, sync-version]
     runs-on: ubuntu-latest
     environment: staging
     permissions:

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -28,9 +28,43 @@ jobs:
           fi
           echo "Commit ${{ github.sha }} is on main. Proceeding."
 
+  sync-version:
+    name: Sync package.json version with release tag
+    needs: guard
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          fetch-depth: 0
+
+      - name: Bump apps/pdf-craft/package.json to the canonical release version
+        run: |
+          TAG="${{ github.ref_name }}"
+          VERSION="${TAG#pdf-craft-v}"
+          VERSION="${VERSION%-rc.*}"
+
+          git fetch origin main
+          git checkout -B main origin/main
+
+          CURRENT=$(node -p "require('./apps/pdf-craft/package.json').version")
+          if [ "$CURRENT" = "$VERSION" ]; then
+            echo "apps/pdf-craft/package.json already at $VERSION, nothing to do."
+            exit 0
+          fi
+
+          (cd apps/pdf-craft && npm pkg set version="$VERSION")
+
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add apps/pdf-craft/package.json
+          git commit -m "chore(pdf-craft): bump version to $VERSION [skip-deploy]"
+          git push origin main
+
   deploy:
     name: Firebase deploy — staging
-    needs: guard
+    needs: [guard, sync-version]
     runs-on: ubuntu-latest
     environment: staging
     permissions:


### PR DESCRIPTION
## Summary
- `apps/pdf-craft/package.json` and `apps/pdf-processor/package.json` were both stuck at `0.0.1` since scaffolding — real versioning has always been git-tag-driven (`pdf-craft-v1.0.1`, `pdf-processor-v1.0.0`, etc.) but never propagated into the codebase.
- Added a `sync-version` job to both staging deploy workflows (`deploy-staging.yml`, `deploy-pdf-processor-staging.yml`) that parses the canonical version out of the RC tag (stripping the `-rc.N` suffix) and commits a `package.json` bump to `main` if it differs.
- Prod tags re-deploy the exact same commit already tested via staging (enforced by the existing `e2e-gate` job), so no separate bump is needed at prod-tag time.
- Guarded `deploy-dev.yml` and `deploy-pdf-processor-dev.yml` against re-triggering off this bot commit via a `[skip-deploy]` marker in the commit message.

Note: since tags are immutable, the bump lands as a follow-up commit on `main` rather than retroactively inside the tagged/deployed commit. The field isn't read anywhere at runtime today, so this only affects `main`'s historical accuracy going forward, not the already-shipped artifact.

Closes #190

## Test plan
- [ ] Cut a new RC tag for either app and confirm the `sync-version` job runs, bumps the right `package.json`, and the `deploy-dev` workflow doesn't re-trigger off the bump commit