### PR TITLE
fix(pdf-craft): scope Firestore rules to document owner

### DIFF
--- a/apps/pdf-craft/firestore.rules
+++ b/apps/pdf-craft/firestore.rules
@@ -2,8 +2,14 @@ rules_version = '2';
 
 service cloud.firestore {
   match /databases/{database}/documents {
-    match /{document=**} {
-      allow read, write: if request.auth != null;
+    match /users/{userId} {
+      allow read: if request.auth != null && request.auth.uid == userId;
+      allow write: if false;
+
+      match /files/{fileId} {
+        allow read: if request.auth != null && request.auth.uid == userId;
+        allow write: if false;
+      }
     }
   }
 }


### PR DESCRIPTION
## Summary
- Firestore rules previously granted any authenticated user read/write access to every document (`allow read, write: if request.auth != null` on `{document=**}`).
- Scopes `users/{userId}` and its `files` subcollection to the owning `uid` for reads; denies client writes outright since all writes already go through the Admin SDK (SSR actions in `operations.ts`/`credits.ts`, Cloud Functions webhook/cleanup), which bypasses security rules anyway.

Fixes #192

## Test plan
- [ ] Deploy to dev and verify a logged-in user can read their own profile/files in the Dashboard
- [ ] Verify a second user account cannot read the first user's `users/{userId}` doc or files via the client SDK
- [ ] Verify existing server-side flows (credit deduction, file creation, Stripe webhook, cleanup cron) still work — these use the Admin SDK and bypass rules