### PR TITLE
fix(ci): deploy Firestore indexes alongside rules in staging/prod

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -92,9 +92,9 @@ jobs:
       - name: Install Firebase CLI
         run: pnpm add -g firebase-tools
 
-      - name: Deploy Firestore rules
+      - name: Deploy Firestore rules and indexes
         working-directory: apps/pdf-craft
-        run: firebase deploy --only firestore:rules --project pdf-craft-prd --force
+        run: firebase deploy --only firestore:rules,firestore:indexes --project pdf-craft-prd --force
 
       - name: Deploy Storage rules
         working-directory: apps/pdf-craft

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -95,9 +95,9 @@ jobs:
       - name: Install Firebase CLI
         run: pnpm add -g firebase-tools
 
-      - name: Deploy Firestore rules
+      - name: Deploy Firestore rules and indexes
         working-directory: apps/pdf-craft
-        run: firebase deploy --only firestore:rules --project pdf-craft-stg --force
+        run: firebase deploy --only firestore:rules,firestore:indexes --project pdf-craft-stg --force
 
       - name: Deploy Storage rules
         working-directory: apps/pdf-craft


### PR DESCRIPTION
## Summary
- `deleteExpiredFiles` has been failing every hourly run in staging/prod since 2026-06-25 with `FAILED_PRECONDITION: The query requires an index`
- `deploy-prod.yml` / `deploy-staging.yml` only ran `firebase deploy --only firestore:rules`, which never deploys `firestore.indexes.json`
- Switches both workflows to `--only firestore:rules,firestore:indexes`

Fixes #197

## Test plan
- [ ] Merge to main
- [ ] Tag `pdf-craft-v1.0.4-rc.1` to deploy to staging and create the missing composite index there
- [ ] Confirm `firebase functions:log --only deleteExpiredFiles --project pdf-craft-stg` shows a successful run with no index error
- [ ] Tag `pdf-craft-v1.0.4` to deploy to prod and create the index there
- [ ] Confirm prod logs show successful deletions