### PR TITLE
fix(pdf-craft): contact form validation mismatch + delivery monitoring

### DIFF
--- a/apps/pdf-craft/e2e/contact.spec.ts
+++ b/apps/pdf-craft/e2e/contact.spec.ts
@@ -1,0 +1,28 @@
+import { test, expect } from '@playwright/test';
+
+test('rejects a too-short message before hitting the network', async ({ page }) => {
+  await page.goto('/contact');
+
+  await page.getByLabel('Your name').fill('E2E Test');
+  await page.getByLabel('Email address').fill('e2e-test-stg@pdf-craft.app');
+  await page.getByLabel('Message').fill('too short');
+  await page.getByRole('button', { name: /send message/i }).click();
+
+  await expect(page.getByText(/message must be at least 10 characters/i)).toBeVisible();
+  await expect(page.getByText(/send message/i)).toBeVisible();
+});
+
+test('submits a valid message end to end through the contact action', async ({ page }) => {
+  await page.goto('/contact');
+
+  await page.getByLabel('Your name').fill('E2E Test');
+  await page.getByLabel('Email address').fill('e2e-test-stg@pdf-craft.app');
+  await page.getByLabel('Subject').selectOption('general');
+  await page.getByLabel('Message').fill(
+    `Automated e2e contact form check — ${new Date().toISOString()}`,
+  );
+
+  await page.getByRole('button', { name: /send message/i }).click();
+
+  await expect(page.getByText(/message sent!/i)).toBeVisible({ timeout: 30_000 });
+});

--- a/apps/pdf-craft/functions/src/index.ts
+++ b/apps/pdf-craft/functions/src/index.ts
@@ -8,6 +8,7 @@ import { defineSecret } from "firebase-functions/params";
 import Stripe from "stripe";
 import cors from "cors";
 import { v4 as uuidv4 } from "uuid";
+import { createHmac, timingSafeEqual } from "crypto";
 import type { AppEventPayload } from "./events/types";
 import { eventHandlers } from "./events/handlers";
 import { fetchCMSData, getCmsQuery, datocmsApiToken, datocmsEnv } from "./cms";
@@ -28,6 +29,34 @@ const db = getFirestore();
 const STRIPE_SECRET_KEY = defineSecret("STRIPE_SECRET_KEY");
 const STRIPE_WEBHOOK_SECRET = defineSecret("STRIPE_WEBHOOK_SECRET");
 const APP_BASE_URL = defineSecret("APP_BASE_URL");
+const RESEND_WEBHOOK_SECRET = defineSecret("RESEND_WEBHOOK_SECRET");
+
+// Resend signs webhooks using the Svix scheme: https://docs.svix.com/receiving/verifying-payloads/how
+function verifyResendSignature(
+  secret: string,
+  payload: Buffer,
+  id: string,
+  timestamp: string,
+  signatureHeader: string,
+): boolean {
+  if (!secret || !id || !timestamp || !signatureHeader) return false;
+  const secretBytes = Buffer.from(secret.split("_")[1] ?? secret, "base64");
+  const signedContent = `${id}.${timestamp}.${payload.toString("utf8")}`;
+  const expected = createHmac("sha256", secretBytes)
+    .update(signedContent)
+    .digest("base64");
+  const expectedBytes = Buffer.from(expected, "base64");
+
+  return signatureHeader.split(" ").some((part) => {
+    const sig = part.split(",")[1];
+    if (!sig) return false;
+    const sigBytes = Buffer.from(sig, "base64");
+    return (
+      sigBytes.length === expectedBytes.length &&
+      timingSafeEqual(sigBytes, expectedBytes)
+    );
+  });
+}
 
 function getStripe() {
   const secretKey = STRIPE_SECRET_KEY.value();
@@ -287,6 +316,62 @@ const stripeWebhook = onRequest(
   },
 );
 
+const CONTACT_RECIPIENT = "support@pdf-craft.app";
+const RESEND_DELIVERY_FAILURE_EVENTS = [
+  "email.bounced",
+  "email.complained",
+  "email.delivery_delayed",
+];
+
+const resendWebhook = onRequest(
+  { secrets: [RESEND_WEBHOOK_SECRET] },
+  async (request, response) => {
+    const id = request.headers["svix-id"] as string;
+    const timestamp = request.headers["svix-timestamp"] as string;
+    const signature = request.headers["svix-signature"] as string;
+    const rawBody = request.rawBody as Buffer;
+
+    const isValid = verifyResendSignature(
+      RESEND_WEBHOOK_SECRET.value(),
+      rawBody,
+      id,
+      timestamp,
+      signature,
+    );
+    if (!isValid) {
+      log.warn("📬 resend-webhook: invalid signature", {
+        feature: "contact",
+        status: "fail",
+      });
+      response.status(400).send("Invalid signature");
+      return;
+    }
+
+    const event = JSON.parse(rawBody.toString("utf8"));
+
+    if (RESEND_DELIVERY_FAILURE_EVENTS.includes(event.type)) {
+      const to: string[] = event.data?.to ?? [];
+      const ctx = {
+        feature: "contact",
+        eventType: event.type,
+        to: to.join(","),
+        emailId: event.data?.email_id,
+      };
+
+      if (to.includes(CONTACT_RECIPIENT)) {
+        log.exception(
+          new Error(`Contact form email delivery failed: ${event.type}`),
+          { ...ctx, status: "fail" },
+        );
+      } else {
+        log.warn("📬 resend-webhook: delivery failure", ctx);
+      }
+    }
+
+    response.status(200).send("ok");
+  },
+);
+
 const onAppEvent = onMessagePublished(
   { topic: "app-event", secrets: ["RESEND_API_KEY", "RESEND_AUDIENCE_ID"] },
   async (event) => {
@@ -456,4 +541,12 @@ const onUserCreated = auth.user().onCreate(async (user) => {
   }
 });
 
-export { processPayment, stripeWebhook, onAppEvent, cms, deleteExpiredFiles, onUserCreated };
+export {
+  processPayment,
+  stripeWebhook,
+  resendWebhook,
+  onAppEvent,
+  cms,
+  deleteExpiredFiles,
+  onUserCreated,
+};

--- a/apps/pdf-craft/package.json
+++ b/apps/pdf-craft/package.json
@@ -45,6 +45,7 @@
     "@vitest/coverage-v8": "^4.1.8",
     "@vitest/ui": "^4.1.8",
     "jsdom": "^29.1.1",
-    "vitest": "^4.1.8"
+    "vitest": "^4.1.8",
+    "zod": "3.25.76"
   }
 }

--- a/apps/pdf-craft/src/actions/contact.ts
+++ b/apps/pdf-craft/src/actions/contact.ts
@@ -1,25 +1,6 @@
 import { defineAction } from "astro:actions";
-import { z } from "astro:schema";
+import { ContactActionSchema, SUBJECT_LABELS } from "../lib/contactSchema";
 import { log } from "../utils/lib/logger";
-
-const ContactSchema = z.object({
-  name: z.string().min(2, "Name must be at least 2 characters"),
-  email: z.string().email("Invalid email address"),
-  subject: z.enum(["general", "billing", "technical", "feature", "other"]),
-  message: z
-    .string()
-    .min(10, "Message must be at least 10 characters")
-    .max(2000),
-  captchaToken: z.string().min(1),
-});
-
-const SUBJECT_LABELS: Record<string, string> = {
-  general: "General enquiry",
-  billing: "Billing & credits",
-  technical: "Technical issue",
-  feature: "Feature request",
-  other: "Other",
-};
 
 async function verifyRecaptcha(token: string): Promise<boolean> {
   const secret = import.meta.env.PUBLIC_RECAPTCHA_SECRET_KEY;
@@ -68,7 +49,7 @@ async function sendViaResend(payload: {
 export const contact = {
   sendMessage: defineAction({
     accept: "json",
-    input: ContactSchema,
+    input: ContactActionSchema,
     handler: async (input) => {
       const { name, email, subject, message, captchaToken } = input;
       const subjectLabel = SUBJECT_LABELS[subject] ?? subject;

--- a/apps/pdf-craft/src/components/ui/ContactForm/ContactForm.test.tsx
+++ b/apps/pdf-craft/src/components/ui/ContactForm/ContactForm.test.tsx
@@ -65,7 +65,7 @@ describe('ContactForm', () => {
     render(<ContactForm />);
     await user.type(screen.getByLabelText('Your name'), 'Jane');
     await user.type(screen.getByLabelText('Email address'), 'jane@test.com');
-    await user.type(screen.getByLabelText('Message'), 'Hello');
+    await user.type(screen.getByLabelText('Message'), 'Hello there, this is a test message.');
     await user.click(screen.getByRole('button', { name: /Send message/i }));
     await waitFor(() =>
       expect(screen.getByText('Message sent!')).toBeInTheDocument(),
@@ -79,7 +79,7 @@ describe('ContactForm', () => {
     render(<ContactForm />);
     await user.type(screen.getByLabelText('Your name'), 'Jane');
     await user.type(screen.getByLabelText('Email address'), 'jane@test.com');
-    await user.type(screen.getByLabelText('Message'), 'Hello');
+    await user.type(screen.getByLabelText('Message'), 'Hello there, this is a test message.');
     await user.click(screen.getByRole('button', { name: /Send message/i }));
     await waitFor(() =>
       expect(screen.getByRole('alert')).toHaveTextContent('Invalid email address.'),
@@ -92,11 +92,38 @@ describe('ContactForm', () => {
     render(<ContactForm />);
     await user.type(screen.getByLabelText('Your name'), 'Jane');
     await user.type(screen.getByLabelText('Email address'), 'jane@test.com');
-    await user.type(screen.getByLabelText('Message'), 'Hello');
+    await user.type(screen.getByLabelText('Message'), 'Hello there, this is a test message.');
     await user.click(screen.getByRole('button', { name: /Send message/i }));
     await waitFor(() =>
       expect(screen.getByRole('alert')).toHaveTextContent(/Something went wrong/i),
     );
+  });
+
+  it('rejects a too-short message client-side without calling sendMessage', async () => {
+    const user = userEvent.setup();
+    render(<ContactForm />);
+    await user.type(screen.getByLabelText('Your name'), 'Jane');
+    await user.type(screen.getByLabelText('Email address'), 'jane@test.com');
+    await user.type(screen.getByLabelText('Message'), 'Hello');
+    await user.click(screen.getByRole('button', { name: /Send message/i }));
+    await waitFor(() =>
+      expect(screen.getByText(/Message must be at least 10 characters/i)).toBeInTheDocument(),
+    );
+    expect(sendMessage).not.toHaveBeenCalled();
+    expect(mockGetToken).not.toHaveBeenCalled();
+  });
+
+  it('rejects a too-short name client-side and surfaces the field error', async () => {
+    const user = userEvent.setup();
+    render(<ContactForm />);
+    await user.type(screen.getByLabelText('Your name'), 'J');
+    await user.type(screen.getByLabelText('Email address'), 'jane@test.com');
+    await user.type(screen.getByLabelText('Message'), 'Hello there, this is a test message.');
+    await user.click(screen.getByRole('button', { name: /Send message/i }));
+    await waitFor(() =>
+      expect(screen.getByText(/Name must be at least 2 characters/i)).toBeInTheDocument(),
+    );
+    expect(sendMessage).not.toHaveBeenCalled();
   });
 
   it('disables the button while sending', async () => {
@@ -105,7 +132,7 @@ describe('ContactForm', () => {
     render(<ContactForm />);
     await user.type(screen.getByLabelText('Your name'), 'Jane');
     await user.type(screen.getByLabelText('Email address'), 'jane@test.com');
-    await user.type(screen.getByLabelText('Message'), 'Hello');
+    await user.type(screen.getByLabelText('Message'), 'Hello there, this is a test message.');
     await user.click(screen.getByRole('button', { name: /Send message/i }));
     await waitFor(() =>
       expect(screen.getByRole('button', { name: /Sending/i })).toBeDisabled(),

--- a/apps/pdf-craft/src/components/ui/ContactForm/ContactForm.tsx
+++ b/apps/pdf-craft/src/components/ui/ContactForm/ContactForm.tsx
@@ -2,10 +2,12 @@
 import { useState } from 'react'
 import { actions } from 'astro:actions'
 import { Input, Textarea, Select, Button, Stack, Callout } from '@fhdamd/threads'
+import { ContactFormSchema } from '../../../lib/contactSchema'
 import { useRecaptcha } from '../../../utils'
 import FormSuccess from '../FormSuccess/FormSuccess'
 
 type Status = 'idle' | 'sending' | 'success' | 'error'
+type FieldErrors = Partial<Record<'name' | 'email' | 'subject' | 'message', string>>
 
 export default function ContactForm() {
   const [name, setName]       = useState('')
@@ -14,6 +16,7 @@ export default function ContactForm() {
   const [message, setMessage] = useState('')
   const [status, setStatus]   = useState<Status>('idle')
   const [error, setError]     = useState('')
+  const [fieldErrors, setFieldErrors] = useState<FieldErrors>({})
 
   const { getToken } = useRecaptcha('contact')
 
@@ -21,6 +24,20 @@ export default function ContactForm() {
     e.preventDefault()
     setStatus('sending')
     setError('')
+    setFieldErrors({})
+
+    const parsed = ContactFormSchema.safeParse({ name, email, subject, message })
+    if (!parsed.success) {
+      const errors: FieldErrors = {}
+      for (const issue of parsed.error.issues) {
+        const key = issue.path[0] as keyof FieldErrors
+        if (!errors[key]) errors[key] = issue.message
+      }
+      setFieldErrors(errors)
+      setError('Please fix the highlighted fields and try again.')
+      setStatus('error')
+      return
+    }
 
     const captchaToken = await getToken()
     if (!captchaToken) {
@@ -31,10 +48,7 @@ export default function ContactForm() {
 
     try {
       const res = await actions.contact.sendMessage({
-        name,
-        email,
-        subject: subject as 'general' | 'billing' | 'technical' | 'feature' | 'other',
-        message,
+        ...parsed.data,
         captchaToken,
       })
 
@@ -75,6 +89,7 @@ export default function ContactForm() {
             value={name}
             onChange={e => setName(e.target.value)}
             autoComplete="name"
+            error={fieldErrors.name}
             required
           />
           <Input
@@ -85,6 +100,7 @@ export default function ContactForm() {
             value={email}
             onChange={e => setEmail(e.target.value)}
             autoComplete="email"
+            error={fieldErrors.email}
             required
           />
         </div>
@@ -95,6 +111,7 @@ export default function ContactForm() {
           label="Subject"
           value={subject}
           onChange={e => setSubject(e.target.value)}
+          error={fieldErrors.subject}
           required
         >
           <option value="general">General enquiry</option>
@@ -112,6 +129,7 @@ export default function ContactForm() {
           onChange={e => setMessage(e.target.value)}
           rows={6}
           hint="Please include as much detail as possible."
+          error={fieldErrors.message}
           required
         />
 

--- a/apps/pdf-craft/src/lib/contactSchema.ts
+++ b/apps/pdf-craft/src/lib/contactSchema.ts
@@ -1,0 +1,33 @@
+import { z } from "astro:schema";
+
+export const SUBJECT_VALUES = [
+  "general",
+  "billing",
+  "technical",
+  "feature",
+  "other",
+] as const;
+
+export const SUBJECT_LABELS: Record<(typeof SUBJECT_VALUES)[number], string> = {
+  general: "General enquiry",
+  billing: "Billing & credits",
+  technical: "Technical issue",
+  feature: "Feature request",
+  other: "Other",
+};
+
+export const ContactFormSchema = z.object({
+  name: z.string().min(2, "Name must be at least 2 characters"),
+  email: z.string().email("Invalid email address"),
+  subject: z.enum(SUBJECT_VALUES),
+  message: z
+    .string()
+    .min(10, "Message must be at least 10 characters")
+    .max(2000, "Message must be 2000 characters or fewer"),
+});
+
+export const ContactActionSchema = ContactFormSchema.extend({
+  captchaToken: z.string().min(1),
+});
+
+export type ContactFormInput = z.infer<typeof ContactFormSchema>;

--- a/apps/pdf-craft/src/middleware.test.ts
+++ b/apps/pdf-craft/src/middleware.test.ts
@@ -1,0 +1,49 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const { exceptionMock } = vi.hoisted(() => ({ exceptionMock: vi.fn() }));
+vi.mock("./utils/lib/logger", () => ({
+  log: { exception: exceptionMock },
+}));
+
+import { onRequest } from "./middleware";
+
+function makeContext(pathname: string) {
+  return { url: new URL(`https://pdf-craft.app${pathname}`) } as any;
+}
+
+beforeEach(() => {
+  exceptionMock.mockClear();
+});
+
+describe("middleware", () => {
+  it("reports a failed contact action request to Sentry", async () => {
+    const response = new Response(JSON.stringify({ error: "Bad input" }), { status: 400 });
+    const next = vi.fn().mockResolvedValue(response);
+
+    const result = await onRequest(makeContext("/_actions/contact.sendMessage"), next);
+
+    expect(exceptionMock).toHaveBeenCalledTimes(1);
+    const [error, ctx] = exceptionMock.mock.calls[0];
+    expect(error.message).toContain("/_actions/contact.sendMessage");
+    expect(ctx).toMatchObject({ feature: "contact", status: 400 });
+    expect(result).toBe(response);
+  });
+
+  it("does not report a successful contact action request", async () => {
+    const response = new Response(JSON.stringify({ success: true }), { status: 200 });
+    const next = vi.fn().mockResolvedValue(response);
+
+    await onRequest(makeContext("/_actions/contact.sendMessage"), next);
+
+    expect(exceptionMock).not.toHaveBeenCalled();
+  });
+
+  it("ignores failures on unmonitored routes", async () => {
+    const response = new Response("Not found", { status: 404 });
+    const next = vi.fn().mockResolvedValue(response);
+
+    await onRequest(makeContext("/some/other/page"), next);
+
+    expect(exceptionMock).not.toHaveBeenCalled();
+  });
+});

--- a/apps/pdf-craft/src/middleware.ts
+++ b/apps/pdf-craft/src/middleware.ts
@@ -1,0 +1,29 @@
+import { defineMiddleware } from "astro:middleware";
+import { log } from "./utils/lib/logger";
+
+const MONITORED_ACTIONS = ["/_actions/contact.sendMessage"];
+
+export const onRequest = defineMiddleware(async (context, next) => {
+  const response = await next();
+
+  const isMonitoredAction = MONITORED_ACTIONS.some((path) =>
+    context.url.pathname.startsWith(path),
+  );
+
+  if (isMonitoredAction && response.status >= 400) {
+    let body: unknown;
+    try {
+      body = await response.clone().json();
+    } catch {
+      body = undefined;
+    }
+    log.exception(new Error(`Action request failed: ${context.url.pathname}`), {
+      feature: "contact",
+      status: response.status,
+      pathname: context.url.pathname,
+      body: JSON.stringify(body),
+    });
+  }
+
+  return response;
+});

--- a/apps/pdf-craft/src/test/mocks/astro-middleware.ts
+++ b/apps/pdf-craft/src/test/mocks/astro-middleware.ts
@@ -1,0 +1,4 @@
+// Astro's real defineMiddleware is an identity function: src/core/middleware/index.js
+export function defineMiddleware<T>(fn: T): T {
+  return fn;
+}

--- a/apps/pdf-craft/src/test/mocks/threads.tsx
+++ b/apps/pdf-craft/src/test/mocks/threads.tsx
@@ -52,6 +52,7 @@ export const Input = ({
   onChange,
   required,
   hint,
+  error,
   autoComplete,
 }: any) => (
   <div>
@@ -65,7 +66,8 @@ export const Input = ({
       required={required}
       autoComplete={autoComplete}
     />
-    {hint && <span>{hint}</span>}
+    {hint && !error && <span>{hint}</span>}
+    {error && <span role="alert">{error}</span>}
   </div>
 );
 
@@ -85,20 +87,22 @@ export const FileDropzone = ({ label, accept, multiple, onFiles }: any) => (
   </div>
 );
 
-export const Textarea = ({ id, name, label, value, onChange, required, hint, rows }: any) => (
+export const Textarea = ({ id, name, label, value, onChange, required, hint, error, rows }: any) => (
   <div>
     <label htmlFor={id}>{label}</label>
     <textarea id={id} name={name} value={value} onChange={onChange} required={required} rows={rows} />
-    {hint && <span>{hint}</span>}
+    {hint && !error && <span>{hint}</span>}
+    {error && <span role="alert">{error}</span>}
   </div>
 );
 
-export const Select = ({ id, name, label, value, onChange, required, children }: any) => (
+export const Select = ({ id, name, label, value, onChange, required, error, children }: any) => (
   <div>
     <label htmlFor={id}>{label}</label>
     <select id={id} name={name} value={value} onChange={onChange} required={required}>
       {children}
     </select>
+    {error && <span role="alert">{error}</span>}
   </div>
 );
 

--- a/apps/pdf-craft/vitest.config.ts
+++ b/apps/pdf-craft/vitest.config.ts
@@ -22,7 +22,6 @@ export default defineConfig({
         "src/actions/**",
         "src/pages/**",
         "src/layouts/**",
-        "src/middleware.ts",
         // Firebase init and Pub/Sub — integration concerns
         "src/firebase/**",
         "src/server/**",
@@ -44,6 +43,7 @@ export default defineConfig({
       // Astro virtual modules
       { find: "astro:actions", replacement: resolve(__dirname, "src/test/mocks/astro-actions.ts") },
       { find: "astro:schema", replacement: resolve(__dirname, "src/test/mocks/astro-schema.ts") },
+      { find: "astro:middleware", replacement: resolve(__dirname, "src/test/mocks/astro-middleware.ts") },
       // Local Firebase client (matches relative imports that resolve to this file)
       {
         find: /^(?:\.\.\/)+firebase\/client$/,

--- a/apps/pdf-craft/vitest.config.ts
+++ b/apps/pdf-craft/vitest.config.ts
@@ -22,6 +22,7 @@ export default defineConfig({
         "src/actions/**",
         "src/pages/**",
         "src/layouts/**",
+        "src/middleware.ts",
         // Firebase init and Pub/Sub — integration concerns
         "src/firebase/**",
         "src/server/**",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -163,6 +163,9 @@ importers:
       vitest:
         specifier: ^4.1.8
         version: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(@vitest/coverage-istanbul@4.1.8)(@vitest/coverage-v8@4.1.8)(@vitest/ui@4.1.8)(happy-dom@17.6.3)(jsdom@29.1.1)(vite@6.4.2(@types/node@25.9.1)(jiti@2.6.1)(tsx@4.22.3)(yaml@2.9.0))
+      zod:
+        specifier: 3.25.76
+        version: 3.25.76
 
   apps/pdf-craft/functions:
     dependencies:
@@ -7815,9 +7818,6 @@ packages:
   zod@3.25.76:
     resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
 
-  zod@4.3.5:
-    resolution: {integrity: sha512-k7Nwx6vuWx1IJ9Bjuf4Zt1PEllcwe7cls3VNzm4CQ1/hgtFUK2bRNG3rvnpPUhFjmqJKAKtjV576KnUkHocg/g==}
-
   zwitch@2.0.4:
     resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
 
@@ -12521,8 +12521,8 @@ snapshots:
       '@babel/parser': 7.28.5
       eslint: 9.39.2(jiti@2.6.1)
       hermes-parser: 0.25.1
-      zod: 4.3.5
-      zod-validation-error: 4.0.2(zod@4.3.5)
+      zod: 3.25.76
+      zod-validation-error: 4.0.2(zod@3.25.76)
     transitivePeerDependencies:
       - supports-color
 
@@ -16788,12 +16788,10 @@ snapshots:
       typescript: 5.9.2
       zod: 3.25.76
 
-  zod-validation-error@4.0.2(zod@4.3.5):
+  zod-validation-error@4.0.2(zod@3.25.76):
     dependencies:
-      zod: 4.3.5
+      zod: 3.25.76
 
   zod@3.25.76: {}
-
-  zod@4.3.5: {}
 
   zwitch@2.0.4: {}


### PR DESCRIPTION
## Summary
- Client/server validation mismatch let users submit input the browser accepted but the server's Zod schema rejected (400, no useful error, invisible to Sentry). Both now share one schema (`src/lib/contactSchema.ts`), with inline field errors.
- Added `src/middleware.ts` to capture Astro Action input-validation failures to Sentry (this class of failure was previously swallowed internally by `defineAction` and never reached our logging).
- Added a new `resendWebhook` Cloud Function that verifies Resend's Svix-signed webhook and alerts to Sentry on `email.bounced` / `email.complained` / `email.delivery_delayed` for the contact mailbox — this is the actual root cause of the original "form doesn't send messages" report: Resend returns `200 OK` even when a send is silently suppressed/bounced, so the previous code had no way to detect it.
- Registered the webhook with Resend (shared account across dev/stg/prod) and stored the signing secret as `RESEND_WEBHOOK_SECRET` in Secret Manager for all three projects.
- Added e2e coverage (`e2e/contact.spec.ts`) for both the validation-rejection path and a full happy-path submission against staging.

Fixes #199

## Test plan
- [x] Unit tests pass (155/155)
- [x] `astro build` succeeds
- [ ] Merge to main, deploy functions to stg/prod so `resendWebhook` goes live at the registered URL
- [ ] Confirm a deliberate bounce/complaint to the contact mailbox shows up in Sentry
- [ ] Run e2e suite against staging