### PR TITLE
fix(ci): pin firebase-tools below 15.x for staging/prod WIF deploys

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -89,8 +89,11 @@ jobs:
         working-directory: apps/pdf-craft/functions
         run: pnpm run build
 
+      # Pinned below 15.x: firebase-tools 15.x has a Workload Identity Federation
+      # auth regression that breaks `firestore:indexes` deploys in CI.
+      # https://github.com/firebase/firebase-tools/issues/10726
       - name: Install Firebase CLI
-        run: pnpm add -g firebase-tools
+        run: pnpm add -g firebase-tools@14.27.0
 
       - name: Deploy Firestore rules and indexes
         working-directory: apps/pdf-craft

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -92,8 +92,11 @@ jobs:
         working-directory: apps/pdf-craft/functions
         run: pnpm run build
 
+      # Pinned below 15.x: firebase-tools 15.x has a Workload Identity Federation
+      # auth regression that breaks `firestore:indexes` deploys in CI.
+      # https://github.com/firebase/firebase-tools/issues/10726
       - name: Install Firebase CLI
-        run: pnpm add -g firebase-tools
+        run: pnpm add -g firebase-tools@14.27.0
 
       - name: Deploy Firestore rules and indexes
         working-directory: apps/pdf-craft


### PR DESCRIPTION
## Summary
- `deploy-staging.yml`/`deploy-prod.yml` started failing at "Deploy Firestore rules and indexes" after #198 added `firestore:indexes` to that step's `--only` list.
- Root cause: [firebase-tools#10726](https://github.com/firebase/firebase-tools/issues/10726) — a 15.x regression where Workload Identity Federation credentials aren't recognized for some deploy commands. Reproduced twice in CI; confirmed working locally under real `firebase login` (not WIF), confirming it's WIF-specific and not an issue with our command syntax.
- Pins `firebase-tools` to `14.27.0` (latest pre-15.x) in both workflows. `deploy-dev.yml` uses `FIREBASE_TOKEN` instead of WIF, so it's unaffected and left unpinned.

Fixes #201

## Note
Diagnosing this locally also deployed the actual rules + missing composite index to `pdf-craft-stg` (the #197 fix), so staging is already correct independent of this PR.

## Test plan
- [x] Verified the exact deploy command succeeds locally under real OAuth
- [ ] Merge, re-tag `pdf-craft-v1.0.4-rc.1` (or `-rc.2`), confirm staging deploy succeeds in CI