### PR TITLE
fix(ci): retry firebase-tools WIF auth race + align dev with staging/prod

### DIFF
--- a/.github/scripts/firebase-deploy.sh
+++ b/.github/scripts/firebase-deploy.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+# firebase-tools intermittently fails to authenticate against Workload Identity
+# Federation credentials on the first CLI invocation in a job — see #201.
+# Retrying lets the credential exchange settle.
+set -uo pipefail
+
+for attempt in 1 2 3; do
+  if firebase deploy "$@"; then
+    exit 0
+  fi
+  echo "::warning::firebase deploy attempt $attempt failed, retrying in 10s..." >&2
+  sleep 10
+done
+
+echo "::error::firebase deploy failed after 3 attempts" >&2
+exit 1

--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -13,10 +13,19 @@ concurrency:
 jobs:
   deploy:
     runs-on: ubuntu-latest
+    environment: dev
     if: ${{ !contains(github.event.head_commit.message, '[skip-deploy]') }}
+    permissions:
+      contents: read
+      id-token: write  # required for OIDC token exchange with GCP
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
+
+      - uses: google-github-actions/auth@c200f3691d83b41bf9bbd8638997a462592937ed # v2
+        with:
+          workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+          service_account: ${{ secrets.GCP_SERVICE_ACCOUNT }}
 
       - name: Set up Node.js
         uses: actions/setup-node@v3
@@ -29,10 +38,48 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
-      - name: Deploy to Firebase
-        env:
-          FIREBASE_TOKEN: ${{ secrets.FIREBASE_TOKEN }}
+      - name: Build functions
+        working-directory: apps/pdf-craft/functions
+        run: pnpm run build
+
+      - name: Install Firebase CLI
+        run: pnpm add -g firebase-tools
+
+      - name: Deploy Firestore rules
+        working-directory: apps/pdf-craft
+        run: ../../.github/scripts/firebase-deploy.sh --only firestore:rules --project pdf-craft-dev --force
+
+      # firebase-tools' firestore:indexes deploy doesn't accept Workload Identity
+      # Federation credentials ("Failed to authenticate, have you run firebase
+      # login?") even though every other deploy target in this job does — see #201.
+      # Call the Firestore Admin API directly with the WIF access token instead.
+      - name: Deploy Firestore indexes
+        working-directory: apps/pdf-craft
         run: |
-          cd apps/pdf-craft
-          pnpm add -g firebase-tools
-          firebase deploy --project pdf-craft-dev
+          TOKEN=$(gcloud auth print-access-token)
+          jq -c '.indexes[]' firestore.indexes.json | while read -r idx; do
+            COLLECTION=$(echo "$idx" | jq -r '.collectionGroup')
+            BODY=$(echo "$idx" | jq 'del(.collectionGroup)')
+            STATUS=$(curl -s -o /tmp/index-resp.json -w "%{http_code}" -X POST \
+              "https://firestore.googleapis.com/v1/projects/pdf-craft-dev/databases/(default)/collectionGroups/$COLLECTION/indexes" \
+              -H "Authorization: Bearer $TOKEN" \
+              -H "Content-Type: application/json" \
+              -d "$BODY")
+            if [ "$STATUS" != "200" ] && ! grep -q ALREADY_EXISTS /tmp/index-resp.json; then
+              echo "::error::Failed to deploy index on $COLLECTION (HTTP $STATUS)"
+              cat /tmp/index-resp.json
+              exit 1
+            fi
+          done
+
+      - name: Deploy Storage rules
+        working-directory: apps/pdf-craft
+        run: ../../.github/scripts/firebase-deploy.sh --only storage --project pdf-craft-dev --force
+
+      - name: Deploy Cloud Functions
+        working-directory: apps/pdf-craft
+        run: ../../.github/scripts/firebase-deploy.sh --only functions --project pdf-craft-dev --force
+
+      - name: Deploy App Hosting
+        working-directory: apps/pdf-craft
+        run: ../../.github/scripts/firebase-deploy.sh --only apphosting --project pdf-craft-dev --force

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -94,7 +94,7 @@ jobs:
 
       - name: Deploy Firestore rules
         working-directory: apps/pdf-craft
-        run: firebase deploy --only firestore:rules --project pdf-craft-prd --force
+        run: ../../.github/scripts/firebase-deploy.sh --only firestore:rules --project pdf-craft-prd --force
 
       # firebase-tools' firestore:indexes deploy doesn't accept Workload Identity
       # Federation credentials ("Failed to authenticate, have you run firebase
@@ -121,15 +121,15 @@ jobs:
 
       - name: Deploy Storage rules
         working-directory: apps/pdf-craft
-        run: firebase deploy --only storage --project pdf-craft-prd --force
+        run: ../../.github/scripts/firebase-deploy.sh --only storage --project pdf-craft-prd --force
 
       - name: Deploy Cloud Functions
         working-directory: apps/pdf-craft
-        run: firebase deploy --only functions --project pdf-craft-prd --force
+        run: ../../.github/scripts/firebase-deploy.sh --only functions --project pdf-craft-prd --force
 
       - name: Deploy App Hosting
         working-directory: apps/pdf-craft
-        run: firebase deploy --only apphosting --project pdf-craft-prd --force
+        run: ../../.github/scripts/firebase-deploy.sh --only apphosting --project pdf-craft-prd --force
 
   release:
     name: Publish GitHub Release

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -97,7 +97,7 @@ jobs:
 
       - name: Deploy Firestore rules
         working-directory: apps/pdf-craft
-        run: firebase deploy --only firestore:rules --project pdf-craft-stg --force
+        run: ../../.github/scripts/firebase-deploy.sh --only firestore:rules --project pdf-craft-stg --force
 
       # firebase-tools' firestore:indexes deploy doesn't accept Workload Identity
       # Federation credentials ("Failed to authenticate, have you run firebase
@@ -124,15 +124,15 @@ jobs:
 
       - name: Deploy Storage rules
         working-directory: apps/pdf-craft
-        run: firebase deploy --only storage --project pdf-craft-stg --force
+        run: ../../.github/scripts/firebase-deploy.sh --only storage --project pdf-craft-stg --force
 
       - name: Deploy Cloud Functions
         working-directory: apps/pdf-craft
-        run: firebase deploy --only functions --project pdf-craft-stg --force
+        run: ../../.github/scripts/firebase-deploy.sh --only functions --project pdf-craft-stg --force
 
       - name: Deploy App Hosting
         working-directory: apps/pdf-craft
-        run: firebase deploy --only apphosting --project pdf-craft-stg --force
+        run: ../../.github/scripts/firebase-deploy.sh --only apphosting --project pdf-craft-stg --force
 
   trigger-e2e:
     name: Trigger E2E tests


### PR DESCRIPTION
## Summary
- Across 4 consecutive CI runs, the WIF auth failure hit whichever firebase CLI command happened to run **first** in the job (combined `firestore:rules,firestore:indexes`, then `firestore:rules` alone) — not specifically `firestore:indexes`. That points to a timing race in firebase-tools' credential resolution against Workload Identity Federation, not a command-specific incompatibility (the REST-bypass in #203 happened to work around it by coincidence, not because indexes was uniquely broken).
- Replaces the REST-bypass approach with a retry wrapper (`.github/scripts/firebase-deploy.sh`, 3 attempts with backoff) around every `firebase deploy` call in both workflows. Indexes still deploy via direct REST call (kept from #203, still useful as a parallel mitigation) but rules/storage/functions/apphosting now retry through firebase-tools itself.
- Also switches `deploy-dev.yml` from `FIREBASE_TOKEN` to the same WIF setup as staging/prod (the `dev` GitHub Environment already had `GCP_WORKLOAD_IDENTITY_PROVIDER`/`GCP_SERVICE_ACCOUNT` provisioned, just never wired up), with the same explicit per-target deploy steps — so this class of auth issue surfaces in dev before reaching staging.

Fixes #201

## Test plan
- [ ] Merge, tag a new RC, confirm staging deploy succeeds end to end
- [ ] Confirm a push to main deploys cleanly to dev under the new WIF setup