### PR TITLE
fix(ci): add workflow_dispatch to deploy-dev.yml

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -5,6 +5,7 @@ on:
       - main
     paths:
       - apps/pdf-craft/**
+  workflow_dispatch: {}
 
 concurrency:
   group: deploy-pdf-craft-dev


### PR DESCRIPTION
## Summary
- `deploy-dev.yml`'s push trigger is gated by `paths: apps/pdf-craft/**`, so #204 (switching dev to WIF auth) merged without ever actually running — there's no way to manually validate CI-only changes to this pipeline.
- Adds `workflow_dispatch` so it can be run on demand.

Fixes #205

## Test plan
- [ ] Merge, then manually dispatch the workflow to confirm dev deploys cleanly under the new WIF setup