### PR TITLE
fix(pdf-craft): bypass reCAPTCHA scoring for e2e contact form test

### DIFF
--- a/.github/workflows/e2e-staging.yml
+++ b/.github/workflows/e2e-staging.yml
@@ -49,6 +49,7 @@ jobs:
         env:
           BASE_URL: https://stg.pdf-craft.app
           E2E_TEST_EMAIL: ${{ secrets.E2E_TEST_EMAIL }}
+          E2E_CONTACT_BYPASS_TOKEN: ${{ secrets.E2E_CONTACT_BYPASS_TOKEN }}
           E2E_TEST_PASSWORD: ${{ secrets.E2E_TEST_PASSWORD }}
         run: pnpm test:e2e
 

--- a/apps/pdf-craft/apphosting.yaml
+++ b/apps/pdf-craft/apphosting.yaml
@@ -36,3 +36,5 @@ env:
     secret: appEnv
   - variable: RESEND_API_KEY
     secret: resendApiKey
+  - variable: E2E_CONTACT_BYPASS_TOKEN
+    secret: e2eContactBypassToken

--- a/apps/pdf-craft/e2e/contact.spec.ts
+++ b/apps/pdf-craft/e2e/contact.spec.ts
@@ -13,7 +13,11 @@ test('rejects a too-short message before hitting the network', async ({ page }) 
 });
 
 test('submits a valid message end to end through the contact action', async ({ page }) => {
-  await page.goto('/contact');
+  // Real reCAPTCHA v3 scores headless traffic too low to pass, so this token
+  // (only valid outside production) skips the score check server-side.
+  const bypassToken = process.env.E2E_CONTACT_BYPASS_TOKEN;
+  const query = bypassToken ? `?e2eBypassToken=${encodeURIComponent(bypassToken)}` : '';
+  await page.goto(`/contact${query}`);
 
   await page.getByLabel('Your name').fill('E2E Test');
   await page.getByLabel('Email address').fill('e2e-test-stg@pdf-craft.app');

--- a/apps/pdf-craft/src/actions/contact.ts
+++ b/apps/pdf-craft/src/actions/contact.ts
@@ -2,6 +2,12 @@ import { defineAction } from "astro:actions";
 import { ContactActionSchema, SUBJECT_LABELS } from "../lib/contactSchema";
 import { log } from "../utils/lib/logger";
 
+function isE2EBypass(token: string | undefined): boolean {
+  const bypassSecret = import.meta.env.E2E_CONTACT_BYPASS_TOKEN;
+  const isProduction = import.meta.env.PUBLIC_APP_ENV === "production";
+  return !isProduction && !!bypassSecret && token === bypassSecret;
+}
+
 async function verifyRecaptcha(token: string): Promise<boolean> {
   const secret = import.meta.env.PUBLIC_RECAPTCHA_SECRET_KEY;
   if (!secret) return true; // skip in environments without the key
@@ -51,12 +57,12 @@ export const contact = {
     accept: "json",
     input: ContactActionSchema,
     handler: async (input) => {
-      const { name, email, subject, message, captchaToken } = input;
+      const { name, email, subject, message, captchaToken, e2eBypassToken } = input;
       const subjectLabel = SUBJECT_LABELS[subject] ?? subject;
 
       log.event("📬 contact-form", { feature: "contact", status: "start" });
 
-      const isHuman = await verifyRecaptcha(captchaToken);
+      const isHuman = isE2EBypass(e2eBypassToken) || (await verifyRecaptcha(captchaToken));
       if (!isHuman) {
         log.warn("📬 contact-form: captcha failed", {
           feature: "contact",

--- a/apps/pdf-craft/src/components/ui/ContactForm/ContactForm.tsx
+++ b/apps/pdf-craft/src/components/ui/ContactForm/ContactForm.tsx
@@ -46,10 +46,13 @@ export default function ContactForm() {
       return
     }
 
+    const e2eBypassToken = new URLSearchParams(window.location.search).get('e2eBypassToken') ?? undefined
+
     try {
       const res = await actions.contact.sendMessage({
         ...parsed.data,
         captchaToken,
+        e2eBypassToken,
       })
 
       if (res.data?.success) {

--- a/apps/pdf-craft/src/lib/contactSchema.ts
+++ b/apps/pdf-craft/src/lib/contactSchema.ts
@@ -28,6 +28,9 @@ export const ContactFormSchema = z.object({
 
 export const ContactActionSchema = ContactFormSchema.extend({
   captchaToken: z.string().min(1),
+  // Lets e2e tests skip reCAPTCHA scoring, which scores headless traffic too
+  // low to pass. Only honored outside production — see contact.ts.
+  e2eBypassToken: z.string().optional(),
 });
 
 export type ContactFormInput = z.infer<typeof ContactFormSchema>;


### PR DESCRIPTION
## Summary
- The staging e2e happy-path test for the contact form (\`e2e/contact.spec.ts\`) consistently timed out waiting for \"Message sent!\". Confirmed via staging Cloud Run logs this is real reCAPTCHA v3 correctly scoring headless Playwright traffic below our 0.3 threshold (\`captcha failed\`) — not a product bug, the request reaches the server and is genuinely rejected by Google's score check.
- Adds an optional \`e2eBypassToken\` field to the contact action's input. The action skips reCAPTCHA verification only if the token matches a per-environment secret (\`e2eContactBypassToken\`, distinct random value in each of dev/stg/prod) **and** \`PUBLIC_APP_ENV !== \"production\"\` — so even if the wrong secret ever leaked, production traffic can't use it.
- The e2e test passes the token via a \`?e2eBypassToken=\` query param read by \`ContactForm.tsx\`; real users never set this and get full verification as before.
- Wired the new secret through \`apphosting.yaml\` (all 3 projects) and \`e2e-staging.yml\` (GitHub staging environment secret, already set).

Fixes #208

## Test plan
- [x] Unit tests pass (158/158)
- [x] \`astro build\` succeeds
- [ ] Re-run staging e2e, confirm the contact form happy-path test passes