### PR TITLE
feat(pdf-craft): consume @fhdamd/threads@0.4.0's generic brand slot

### DIFF
--- a/apps/pdf-craft/package.json
+++ b/apps/pdf-craft/package.json
@@ -20,7 +20,7 @@
     "@dnd-kit/core": "^6.3.1",
     "@dnd-kit/sortable": "^10.0.0",
     "@dnd-kit/utilities": "^3.2.2",
-    "@fhdamd/threads": "^0.3.1",
+    "@fhdamd/threads": "^0.4.0",
     "@google-cloud/pubsub": "^5.3.0",
     "@sentry/astro": "^10.56.0",
     "astro": "^5.18.1",

--- a/apps/pdf-craft/src/components/ui/Brand/Brand.tsx
+++ b/apps/pdf-craft/src/components/ui/Brand/Brand.tsx
@@ -1,0 +1,7 @@
+export function RiqaWordmark({ inverse = false }: { inverse?: boolean }) {
+  return (
+    <span className={inverse ? 'brand-wordmark brand-wordmark--inverse' : 'brand-wordmark'}>
+      Riqa<em className="brand-wordmark-accent">.</em>
+    </span>
+  )
+}

--- a/apps/pdf-craft/src/components/ui/Footer/Footer.tsx
+++ b/apps/pdf-craft/src/components/ui/Footer/Footer.tsx
@@ -1,9 +1,11 @@
 import { SiteFooter } from '@fhdamd/threads'
+import { RiqaWordmark } from '../Brand/Brand'
 
 export default function Footer() {
   return (
     <SiteFooter
-      site="pdf-craft"
+      brand={<RiqaWordmark inverse />}
+      copyright={`© ${new Date().getFullYear()} Riqa. All rights reserved.`}
       tagline="Simple tools. Honest pricing."
       columns={[
         {

--- a/apps/pdf-craft/src/components/ui/Header/Header.tsx
+++ b/apps/pdf-craft/src/components/ui/Header/Header.tsx
@@ -6,6 +6,7 @@ import * as Sentry from '@sentry/astro'
 import { auth } from '../../../firebase/client'
 import { SiteNav } from '@fhdamd/threads'
 import type { NavCta } from '@fhdamd/threads'
+import { RiqaWordmark } from '../Brand/Brand'
 
 export default function Header() {
   const [isLoggedIn, setIsLoggedIn] = useState(false)
@@ -71,7 +72,8 @@ export default function Header() {
 
   return (
     <SiteNav
-      site="pdf-craft"
+      brand={<RiqaWordmark />}
+      brandLabel="Riqa home"
       links={navLinks}
       ctas={ctas}
       homeHref="/"

--- a/apps/pdf-craft/src/styles/global.css
+++ b/apps/pdf-craft/src/styles/global.css
@@ -68,6 +68,28 @@ img {
   border-radius: 4px;
 }
 
+/* ─── BRAND WORDMARK ─────────────────────────────────────────────────────── */
+/* Passed as the `brand` slot to SiteNav/SiteFooter — Threads no longer
+   bundles app-specific wordmarks, so each app owns its own. */
+
+.brand-wordmark {
+  font-family: var(--th-font-serif);
+  font-weight: 300;
+  font-style: italic;
+  font-size: var(--th-text-lg);
+  color: var(--th-color-text-1);
+  white-space: nowrap;
+}
+
+.brand-wordmark--inverse {
+  color: var(--th-color-text-inverse);
+}
+
+.brand-wordmark-accent {
+  font-style: normal;
+  color: var(--th-color-accent);
+}
+
 /* ─── LEGACY PAGE HELPERS ─────────────────────────────────────────────────── */
 /* Retained for pages not yet migrated to Threads components (dashboard etc.) */
 

--- a/apps/pdf-craft/src/test/mocks/threads.tsx
+++ b/apps/pdf-craft/src/test/mocks/threads.tsx
@@ -156,8 +156,9 @@ export const PriceCard = ({ credits, price, priceNote, featured, cta, onCtaClick
   </div>
 );
 
-export const SiteNav = ({ links, ctas }: any) => (
+export const SiteNav = ({ brand, brandLabel, homeHref, links, ctas }: any) => (
   <nav>
+    <a href={homeHref ?? "/"} aria-label={brandLabel ?? "Home"}>{brand}</a>
     {links?.map((l: any) => (
       <a key={l.href} href={l.href}>{l.label}</a>
     ))}
@@ -171,8 +172,9 @@ export const SiteNav = ({ links, ctas }: any) => (
   </nav>
 );
 
-export const SiteFooter = ({ tagline, columns, bottomRight }: any) => (
+export const SiteFooter = ({ brand, tagline, columns, bottomRight, copyright }: any) => (
   <footer>
+    {brand}
     {tagline && <p>{tagline}</p>}
     {columns?.map((col: any) => (
       <div key={col.title}>
@@ -183,6 +185,7 @@ export const SiteFooter = ({ tagline, columns, bottomRight }: any) => (
       </div>
     ))}
     {bottomRight && <span>{bottomRight}</span>}
+    {copyright && <p>{copyright}</p>}
   </footer>
 );
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -91,8 +91,8 @@ importers:
         specifier: ^3.2.2
         version: 3.2.2(react@19.2.6)
       '@fhdamd/threads':
-        specifier: ^0.3.1
-        version: 0.3.1
+        specifier: ^0.4.0
+        version: 0.4.0
       '@google-cloud/pubsub':
         specifier: ^5.3.0
         version: 5.3.0
@@ -1356,8 +1356,8 @@ packages:
   '@fastify/busboy@3.2.0':
     resolution: {integrity: sha512-m9FVDXU3GT2ITSe0UaMA5rU3QkfC/UXtCU8y0gSN/GugTqtVldOBWIB5V6V3sbmenVZUIpU6f+mPEO2+m5iTaA==}
 
-  '@fhdamd/threads@0.3.1':
-    resolution: {integrity: sha512-uEbq8hGQrArWvQPgwQhM9UKf+wbp2M7v6Y1iSLOEcb6iE0Arl7DptwvZgUuW7dr4shDSAYmhHSdPGurMwahmFw==}
+  '@fhdamd/threads@0.4.0':
+    resolution: {integrity: sha512-DeAVPkJl1qcHrlxhJ92boVgNISbRGWyCvOQfuZulbRetoenoJCl5AnuLEuHLliWRuRWnwdCs4uri4+rlpKldMw==}
 
   '@firebase/ai@2.12.0':
     resolution: {integrity: sha512-b+OL4vdyiSLZL/7dLd67V55CjKJvU9MpNmwnday7eA6GG2+J4iwUEsEHgw0/jKY3A41FfkF0SrnYFvtKbQZ65A==}
@@ -8798,7 +8798,7 @@ snapshots:
 
   '@fastify/busboy@3.2.0': {}
 
-  '@fhdamd/threads@0.3.1':
+  '@fhdamd/threads@0.4.0':
     dependencies:
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)


### PR DESCRIPTION
## Summary
- Bumps \`@fhdamd/threads\` to \`^0.4.0\` — the version where \`SiteNav\`/\`SiteFooter\` no longer hardcode app-specific branding (#229/#231, already published to npm).
- Adds \`apps/pdf-craft/src/components/ui/Brand/Brand.tsx\` — a small \`RiqaWordmark\` component (with an \`inverse\` variant for the footer's dark background), since the wordmark markup now lives in the consuming app, not the design system.
- \`Header.tsx\`/\`Footer.tsx\` now pass \`brand\`/\`brandLabel\`/\`copyright\` explicitly instead of relying on the old \`site="pdf-craft"\` prop and its baked-in defaults.
- Updated the Threads test mock (\`src/test/mocks/threads.tsx\`) to actually render \`brand\`/\`copyright\` — it previously ignored them entirely, which is why the unit tests wouldn't have caught a regression here.

This is the last piece of #229 — once merged, the rebrand's nav/footer will correctly show "Riqa" instead of the old "PDF-Craft" wordmark, clearing the way to cut the \`riqa-v1.0.5\` rebrand release.

## Test plan
- [x] Unit tests pass (158/158), using the updated mock
- [x] \`astro build\` succeeds against the real published \`@fhdamd/threads@0.4.0\`
- [x] Verified visually via local dev server — wordmark renders correctly in both nav (\`brand-wordmark\`) and footer (\`brand-wordmark--inverse\`) contexts