### PR TITLE
feat(pdf-craft): area-scoped FAQ queries + FAQPage JSON-LD

### DIFF
--- a/apps/pdf-craft/functions/package.json
+++ b/apps/pdf-craft/functions/package.json
@@ -3,7 +3,7 @@
   "scripts": {
     "build": "tsc",
     "build:watch": "tsc --watch",
-    "serve": "npm run build && firebase emulators:start --only functions",
+    "serve": "npm run build && firebase emulators:start --only functions,pubsub --project pdf-craft-dev",
     "shell": "npm run build && firebase functions:shell",
     "start": "npm run shell",
     "deploy": "firebase deploy --only functions",

--- a/apps/pdf-craft/functions/src/cms/queries.ts
+++ b/apps/pdf-craft/functions/src/cms/queries.ts
@@ -1,5 +1,5 @@
 const HERO_FIELDS = `key eyebrow heading subheading body chips primaryCtaLabel primaryCtaHref secondaryCtaLabel secondaryCtaHref`;
-const FAQ_FIELDS = `title content id _createdAt`;
+const FAQ_FIELDS = `title content id _createdAt area`;
 const PRICING_FIELDS = `id productName price credits description`;
 const OPERATION_FIELDS = `id _createdAt title detail creditCost active actionLabel actionRoute iconKey sortOrder`;
 const TESTIMONIAL_FIELDS = `id name detail title _createdAt`;
@@ -15,8 +15,8 @@ export const CMS_QUERIES = {
     }
   `,
   faqs: `
-    query FaqsQuery {
-      allFaqs(orderBy: _createdAt_ASC) { ${FAQ_FIELDS} }
+    query FaqsQuery($area: String) {
+      allFaqs(filter: { area: { eq: $area } }, orderBy: _createdAt_ASC) { ${FAQ_FIELDS} }
     }
   `,
   pricing: `
@@ -42,7 +42,7 @@ export const CMS_QUERIES = {
   homePage: `
     query HomePageQuery {
       allHeros(filter: { key: { eq: "home" } }) { ${HERO_FIELDS} }
-      allFaqs(orderBy: _createdAt_ASC) { ${FAQ_FIELDS} }
+      allFaqs(filter: { area: { eq: "home" } }, orderBy: _createdAt_ASC) { ${FAQ_FIELDS} }
       allOperations(orderBy: sortOrder_ASC) { ${OPERATION_FIELDS} }
       allTestimonials(orderBy: sortOrder_ASC) { ${TESTIMONIAL_FIELDS} }
       allSectionHeaders(filter: { key: { matches: { pattern: "^home--" } } }) { ${SECTION_HEADER_FIELDS} }

--- a/apps/pdf-craft/src/pages/index.astro
+++ b/apps/pdf-craft/src/pages/index.astro
@@ -129,6 +129,19 @@ const ss = { marginBottom: "var(--th-space-8)" }; // shared section style
         },
       })}
     />
+    <script
+      is:inline
+      type="application/ld+json"
+      set:html={JSON.stringify({
+        "@context": "https://schema.org",
+        "@type": "FAQPage",
+        mainEntity: faqItems.map(({ question, answer }) => ({
+          "@type": "Question",
+          name: question,
+          acceptedAnswer: { "@type": "Answer", text: answer },
+        })),
+      })}
+    />
   </Fragment>
   <!-- HERO -->
   <Container>

--- a/apps/pdf-craft/src/utils/types.ts
+++ b/apps/pdf-craft/src/utils/types.ts
@@ -1,8 +1,9 @@
 export type Faq = {
+  id: string;
   title: string;
   content: string;
-  id: string;
   _createdAt: string;
+  area: string;
 };
 
 export type PricingOption = {


### PR DESCRIPTION
## Summary

Part of #214 — establishes the CMS query foundation for per-operation FAQs before the operation pages are made public.

- Adds `area: string` to the `Faq` type, matching the new DatoCMS JSON field used to scope FAQs by page/operation
- Updates the `faqs` query to accept an `$area` variable (`fetchCms("faqs", { area: "merge" })`), enabling per-operation pages to fetch only their relevant FAQs at the query level
- Scopes the `homePage` combined query's FAQ fetch to `area = "home"` directly in GraphQL — no TypeScript filtering needed
- Adds `FAQPage` JSON-LD to the homepage, making home FAQs eligible for Google FAQ rich results
- Pins the functions `serve` script to `--project pdf-craft-dev --only functions,pubsub` to prevent accidental production project targeting from local dev (fixes a safety issue discovered during this session)

## Test plan

- [ ] Start emulators and confirm homepage loads with only `area = "home"` FAQs rendered in the accordion
- [ ] Validate `FAQPage` JSON-LD with [Google's Rich Results Test](https://search.google.com/test/rich-results) against the homepage
- [ ] Confirm `fetchCms("faqs", { area: "merge" })` returns only merge-area FAQs (can test via the `/cms` function directly against the emulator)
- [ ] Confirm `functions/package.json` `serve` script starts emulators under `pdf-craft-dev` and not `pdf-craft-prd`

🤖 Generated with [Claude Code](https://claude.com/claude-code)