### PR TITLE
feat(pdf-craft): anonymous operation flow + public landing pages

### DIFF
--- a/apps/pdf-craft/apphosting.yaml
+++ b/apps/pdf-craft/apphosting.yaml
@@ -38,3 +38,5 @@ env:
     secret: resendApiKey
   - variable: E2E_CONTACT_BYPASS_TOKEN
     secret: e2eContactBypassToken
+  - variable: CLAIM_SECRET
+    secret: CLAIM_SECRET

--- a/apps/pdf-craft/e2e/auth.spec.ts
+++ b/apps/pdf-craft/e2e/auth.spec.ts
@@ -11,7 +11,19 @@ test('unauthenticated user is redirected from /dashboard to /signin', async ({ p
   await expect(page).toHaveURL(/\/signin/);
 });
 
-test('unauthenticated user is redirected from /encryptpdf to /signin', async ({ page }) => {
+// Operation pages are now public — unauthenticated visitors see the tool, not a redirect.
+// The file <input> is hidden by CSS inside the FileDropzone — check the visible heading and
+// the dropzone button text instead.
+test('unauthenticated user can access /encryptpdf without being redirected', async ({ page }) => {
   await page.goto('/encryptpdf');
-  await expect(page).toHaveURL(/\/signin/);
+  await expect(page).toHaveURL('/encryptpdf');
+  await expect(page.getByRole('heading', { name: /protect pdf/i })).toBeVisible();
+  await expect(page.getByText(/drag and drop or click to browse/i)).toBeVisible();
+});
+
+test('unauthenticated user can access /mergepdf without being redirected', async ({ page }) => {
+  await page.goto('/mergepdf');
+  await expect(page).toHaveURL('/mergepdf');
+  await expect(page.getByRole('heading', { name: /merge pdfs/i })).toBeVisible();
+  await expect(page.getByText(/drag and drop or click to browse/i)).toBeVisible();
 });

--- a/apps/pdf-craft/package.json
+++ b/apps/pdf-craft/package.json
@@ -12,6 +12,7 @@
     "test:ui": "vitest --ui",
     "test:coverage": "vitest run --coverage",
     "test:e2e": "playwright test",
+    "test:e2e:local": "BASE_URL=http://localhost:4321 playwright test",
     "test:e2e:report": "playwright show-report"
   },
   "dependencies": {

--- a/apps/pdf-craft/playwright.config.ts
+++ b/apps/pdf-craft/playwright.config.ts
@@ -1,4 +1,31 @@
 import { defineConfig, devices } from '@playwright/test';
+import { existsSync, readFileSync } from 'fs';
+import { resolve } from 'path';
+
+// Load .env.local for local runs — Playwright doesn't auto-load it the way Astro/Vite does.
+// Only handles simple single-line key=value pairs; multi-line values (e.g. the service-account
+// JSON block) are skipped — set FIREBASE_SERVICE_ACCOUNT_KEY in your shell for those.
+// Never runs in CI/staging (no .env.local present there).
+function loadEnvLocal() {
+  const envPath = resolve(process.cwd(), '.env.local');
+  if (!existsSync(envPath)) return;
+  for (const line of readFileSync(envPath, 'utf8').split('\n')) {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith('#')) continue;
+    const eq = trimmed.indexOf('=');
+    if (eq === -1) continue;
+    const key = trimmed.slice(0, eq).trim();
+    const raw = trimmed.slice(eq + 1).trim();
+    // Skip multi-line values — they start with an opening quote but don't close on the same line
+    if ((raw.startsWith("'") && !raw.endsWith("'")) || (raw.startsWith('"') && !raw.endsWith('"'))) continue;
+    const value = raw.replace(/^['"]|['"]$/g, '');
+    if (!(key in process.env)) process.env[key] = value;
+  }
+}
+
+const LOCAL_URL = 'http://localhost:4321';
+const isLocal = !process.env.CI && (!process.env.BASE_URL || process.env.BASE_URL.includes('localhost'));
+if (isLocal) loadEnvLocal();
 
 export default defineConfig({
   testDir: './e2e',
@@ -12,10 +39,17 @@ export default defineConfig({
     ? [['github'], ['html', { open: 'never', outputFolder: 'playwright-report' }]]
     : [['html', { outputFolder: 'playwright-report' }]],
   use: {
-    baseURL: process.env.BASE_URL ?? 'https://stg.riqa.app',
+    baseURL: process.env.BASE_URL ?? (isLocal ? LOCAL_URL : 'https://stg.riqa.app'),
     trace: 'on-first-retry',
     screenshot: 'only-on-failure',
   },
+  // Auto-start the Astro dev server when running locally (no BASE_URL or localhost BASE_URL)
+  webServer: isLocal ? {
+    command: 'pnpm --filter pdf-craft dev',
+    url: LOCAL_URL,
+    reuseExistingServer: true, // attach to an already-running server if present
+    timeout: 120_000,
+  } : undefined,
   projects: [
     // Unauthenticated — tests auth redirect behaviour, no stored session
     {

--- a/apps/pdf-craft/src/actions/claims.ts
+++ b/apps/pdf-craft/src/actions/claims.ts
@@ -1,0 +1,178 @@
+import { defineAction } from 'astro:actions';
+import { z } from 'astro:schema';
+import admin from 'firebase-admin';
+import { getFirebaseAuth, getFirebaseApp } from '../firebase/server';
+import { verifyClaimToken } from '../utils/lib/claimToken';
+import { log } from '../utils/lib/logger';
+
+getFirebaseApp();
+const firestore = admin.firestore();
+const bucket = admin.storage().bucket();
+
+async function getSessionUid(context: { request: Request }, auth: admin.auth.Auth): Promise<string | null> {
+  const cookieHeader = context.request.headers.get('cookie') || '';
+  const sessionCookie = cookieHeader.split('; ').find((c) => c.startsWith('__session='))?.split('=')[1];
+  if (!sessionCookie) return null;
+  try {
+    const decoded = await auth.verifySessionCookie(sessionCookie, true);
+    if (decoded.firebase.sign_in_provider === 'anonymous') return null;
+    return decoded.uid;
+  } catch {
+    return null;
+  }
+}
+
+export const claims = {
+  // Moves an anonymous user's pending file to a real account — no credit deduction.
+  // For same-UID (link preserved): no-op, file is already there.
+  // For different-UID (sign-in to existing account): copies Storage + Firestore record.
+  migrateFile: defineAction({
+    accept: 'json',
+    input: z.object({ claimToken: z.string() }),
+    handler: async (input, context) => {
+      const auth = await getFirebaseAuth();
+      const realUid = await getSessionUid(context, auth);
+      if (!realUid) return { success: false, error: 'Unauthorized' };
+
+      const payload = verifyClaimToken(input.claimToken);
+      if (!payload) return { success: false, error: 'Invalid or expired claim token' };
+
+      const { fileId, anonUid } = payload;
+
+      const anonFileRef = firestore.collection('users').doc(anonUid).collection('files').doc(fileId);
+      const anonFileDoc = await anonFileRef.get();
+      if (!anonFileDoc.exists) return { success: true }; // already migrated or expired
+
+      const fileData = anonFileDoc.data()!;
+      if (['claimed', 'migrated'].includes(fileData.status)) return { success: true };
+
+      if (anonUid === realUid) {
+        // File is already under this user's UID via linkWithCredential — nothing to copy
+        log.event('📥 file-migration-same-uid', { feature: 'migrate-file', fileId, uid: realUid });
+        return { success: true };
+      }
+
+      // Different UID — copy Storage object and create Firestore record under real user
+      const storagePath: string = fileData.storagePath;
+      const destPath = storagePath.replace(`users/${anonUid}/`, `users/${realUid}/`);
+
+      await bucket.file(storagePath).copy(bucket.file(destPath));
+
+      // Generate a correct fileUrl for the real user's storage path
+      const downloadToken = fileData.fileUrl?.split('token=')[1] ?? '';
+      const destFileUrl = `https://firebasestorage.googleapis.com/v0/b/${bucket.name}/o/${encodeURIComponent(destPath)}?alt=media&token=${downloadToken}`;
+
+      const realFileRef = firestore.collection('users').doc(realUid).collection('files').doc(fileId);
+      await firestore.runTransaction(async (tx) => {
+        tx.set(realFileRef, {
+          ...fileData,
+          storagePath: destPath,
+          fileUrl: destFileUrl,
+          status: 'migrated',
+          migratedAt: admin.firestore.FieldValue.serverTimestamp(),
+        });
+        tx.update(anonFileRef, { status: 'claimed' });
+      });
+
+      log.event('📥 file-migrated', { feature: 'migrate-file', fileId, anonUid, realUid });
+      return { success: true };
+    },
+  }),
+
+  // Downloads a pending/migrated file already under the user's account.
+  // Deducts credits atomically, then generates a signed download URL.
+  claimFile: defineAction({
+    accept: 'json',
+    input: z.object({ fileId: z.string() }),
+    handler: async (input, context) => {
+      const auth = await getFirebaseAuth();
+      const realUid = await getSessionUid(context, auth);
+      if (!realUid) return { success: false, error: 'Unauthorized' };
+
+      const fileRef = firestore.collection('users').doc(realUid).collection('files').doc(input.fileId);
+      const fileDoc = await fileRef.get();
+
+      if (!fileDoc.exists) return { success: false, error: 'File not found' };
+
+      const fileData = fileDoc.data()!;
+
+      log.debug('claim-file: status check', {
+        feature: 'claim-file',
+        fileId: input.fileId,
+        status: String(fileData.status ?? 'undefined'),
+        creditCost: String(fileData.creditCost ?? 'undefined'),
+      });
+
+      if (!['pending', 'migrated'].includes(fileData.status)) {
+        return { success: false, error: 'File is not awaiting payment' };
+      }
+
+      const creditCost: number = Number(fileData.creditCost);
+      if (!creditCost || creditCost <= 0) {
+        return { success: false, error: 'Invalid credit cost on file' };
+      }
+
+      const userRef = firestore.collection('users').doc(realUid);
+      const storagePath: string = fileData.storagePath;
+
+      // Run the Firestore transaction first — no side effects inside
+      try {
+        await firestore.runTransaction(async (tx) => {
+          const userDoc = await tx.get(userRef);
+          const fileDocInTx = await tx.get(fileRef);
+
+          if (!userDoc.exists) throw new Error('User not found');
+          if (!fileDocInTx.exists) throw new Error('File not found');
+
+          const currentStatus: string = fileDocInTx.data()?.status;
+          if (!['pending', 'migrated'].includes(currentStatus)) {
+            throw new Error('File is not awaiting payment');
+          }
+
+          const currentCredits: number = userDoc.data()?.profile?.credits ?? 0;
+          if (currentCredits < creditCost) throw new Error('Insufficient credits');
+
+          tx.update(fileRef, {
+            status: 'ready',
+            claimedAt: admin.firestore.FieldValue.serverTimestamp(),
+          });
+          tx.update(userRef, {
+            'profile.credits': admin.firestore.FieldValue.increment(-creditCost),
+          });
+        });
+      } catch (error: any) {
+        const known = ['Insufficient credits', 'File is not awaiting payment', 'User not found', 'File not found'];
+        if (known.includes(error.message)) {
+          return { success: false, error: error.message };
+        }
+        log.exception(error as Error, { feature: 'claim-file', fileId: input.fileId });
+        return { success: false, error: 'Failed to download file' };
+      }
+
+      // Transaction committed — now generate the signed URL as a separate step
+      try {
+        const expiresAt = new Date(
+          typeof fileData.expiresAt?.toDate === 'function'
+            ? fileData.expiresAt.toDate()
+            : fileData.expiresAt
+        );
+
+        const [downloadUrl] = await bucket.file(storagePath).getSignedUrl({
+          action: 'read',
+          expires: expiresAt,
+        });
+
+        // Store the signed URL so the dashboard Download link works after claiming
+        await fileRef.update({ fileUrl: downloadUrl });
+
+        log.business('📥 file-claimed', { feature: 'claim-file', fileId: input.fileId, realUid, creditCost });
+        return { success: true, payload: { downloadUrl } };
+      } catch (error) {
+        // Transaction already committed — file is marked ready, credits deducted.
+        // The signed URL generation failed but the credit deduction is done.
+        log.exception(error as Error, { feature: 'claim-file-url', fileId: input.fileId });
+        return { success: false, error: 'File claimed but download URL generation failed. Contact support.' };
+      }
+    },
+  }),
+};

--- a/apps/pdf-craft/src/actions/index.ts
+++ b/apps/pdf-craft/src/actions/index.ts
@@ -2,10 +2,12 @@ import { user } from './user';
 import { operations } from './operations';
 import { credits } from './credits';
 import { contact } from './contact';
+import { claims } from './claims';
 
 export const server = {
   user,
   operations,
   credits,
   contact,
+  claims,
 };

--- a/apps/pdf-craft/src/actions/operations.ts
+++ b/apps/pdf-craft/src/actions/operations.ts
@@ -7,7 +7,6 @@ import { v4 as uuidv4 } from "uuid";
 import { getFirebaseAuth, getFirebaseApp } from "../firebase/server";
 import { publish } from "../server/pubsub/publisher";
 import { log } from "../utils/lib/logger";
-import { generateClaimToken } from "../utils/lib/claimToken";
 
 async function callProcessor(path: string, form: FormData): Promise<Response> {
   const processorUrl = import.meta.env.PDF_PROCESSOR_URL;
@@ -35,6 +34,76 @@ getFirebaseApp();
 const firestore = admin.firestore();
 const bucket = admin.storage().bucket();
 
+// ── Shared helpers used by all four operation handlers ────────────────────────
+
+interface AuthedContext {
+  userId: string;
+  isAnonymous: boolean;
+  email?: string;
+}
+
+/** Extracts and verifies the __session cookie. Returns null when unauthorized. */
+async function resolveAuth(
+  context: { request: Request },
+  requestId: string,
+  task: string,
+): Promise<AuthedContext | null> {
+  const cookieHeader = context.request.headers.get("cookie") || "";
+  const sessionCookie = cookieHeader
+    .split("; ")
+    .find((c) => c.startsWith("__session="))
+    ?.split("=")[1];
+  if (!sessionCookie) {
+    log.warn("app-operation: unauthorized", { requestId, feature: task, status: "fail" });
+    return null;
+  }
+  const auth = await getFirebaseAuth();
+  const decoded = await auth.verifySessionCookie(sessionCookie, true);
+  const isAnonymous = decoded.firebase.sign_in_provider === "anonymous";
+  log.debug("app-operation: user authenticated", {
+    requestId, feature: task, userId: decoded.uid,
+    anonymous: isAnonymous ? "yes" : "no",
+  });
+  return { userId: decoded.uid, isAnonymous, email: decoded.email };
+}
+
+/** Returns the pending-anonymous action response (used when caller is anon). */
+function anonPending(
+  fileId: string,
+  userId: string,
+  requestId: string,
+  task: string,
+): { success: true; data: { claimToken: string } } {
+  const claimToken = generateClaimToken(fileId, userId);
+  log.event("📄 app-operation: pending-anonymous", { requestId, feature: task, userId, fileId });
+  return { success: true, data: { claimToken } };
+}
+
+/** Publishes the app-event and deducts credits after a successful operation. */
+async function finaliseOperation(params: {
+  userId: string;
+  email?: string;
+  fileId: string;
+  fileName: string;
+  fileUrl: string;
+  eventType: string;
+  creditCost: number;
+  requestId: string;
+  task: string;
+}): Promise<void> {
+  const { userId, email, fileId, fileName, fileUrl, eventType, creditCost, requestId, task } = params;
+  await publish(
+    "app-event",
+    { userId, userEmail: email, fileId, fileName, fileUrl, eventType, timestamp: Date.now(), requestId },
+    requestId, task,
+  );
+  await firestore.collection("users").doc(userId).update({
+    "profile.credits": FieldValue.increment(-creditCost),
+  });
+  log.business("💰 credit-deducted", { requestId, feature: task, userId, fileId, creditCost });
+  log.business("📄 app-operation", { requestId, feature: task, userId, fileId, creditCost, status: "success" });
+}
+
 const mergePdfsSchema = z.object({
   files: z.array(z.instanceof(File)),
   requestId: z.string(),
@@ -57,149 +126,51 @@ export const operations = {
     input: mergePdfsSchema,
     handler: async (input, context) => {
       const { files, requestId, task, creditCost } = input;
-      const cookieHeader = context.request.headers.get("cookie") || "";
-      const sessionCookie = cookieHeader
-        .split("; ")
-        .find((c) => c.startsWith("__session="))
-        ?.split("=")[1];
-
-      log.event("📄 app-operation", {
-        requestId,
-        feature: task,
-        status: "start",
-      });
-
+      log.event("📄 app-operation", { requestId, feature: task, status: "start" });
       try {
-        if (!sessionCookie) {
-          log.warn("app-operation: unauthorized", {
-            requestId,
-            feature: task,
-            status: "fail",
-          });
-          return { success: false, error: "Unauthorized" };
-        }
+        const ctx = await resolveAuth(context, requestId, task);
+        if (!ctx) return { success: false, error: "Unauthorized" };
+        const { userId, isAnonymous } = ctx;
 
-        const auth = await getFirebaseAuth();
-        const decodedToken = await auth.verifySessionCookie(
-          sessionCookie,
-          true,
-        );
-        const userId = decodedToken.uid;
-        const isAnonymous = decodedToken.firebase.sign_in_provider === 'anonymous';
-        log.debug("app-operation: user authenticated", {
-          requestId,
-          feature: task,
-          userId,
-          anonymous: isAnonymous ? 'yes' : 'no',
-        });
+        const fileId = firestore.collection("users").doc(userId).collection("files").doc().id;
 
-        const fileId = firestore
-          .collection("users")
-          .doc(userId)
-          .collection("files")
-          .doc().id;
-
-        // Merge PDFs
         const mergedPdf = await PDFDocument.create();
         for (const pdfFile of files) {
           const pdfBytes = await pdfFile.arrayBuffer();
-          const pdf = await PDFDocument.load(pdfBytes, {
-            ignoreEncryption: true,
-          });
-          const copiedPages = await mergedPdf.copyPages(
-            pdf,
-            pdf.getPageIndices(),
-          );
+          const pdf = await PDFDocument.load(pdfBytes, { ignoreEncryption: true });
+          const copiedPages = await mergedPdf.copyPages(pdf, pdf.getPageIndices());
           copiedPages.forEach((page) => mergedPdf.addPage(page));
         }
 
         const mergedPdfBytes = await mergedPdf.save();
         const mergedFileName = `merged-${Date.now()}.pdf`;
         const storagePath = `users/${userId}/${mergedFileName}`;
-        const fileRef = bucket.file(storagePath);
-
         const downloadToken = uuidv4();
 
-        await fileRef.save(Buffer.from(mergedPdfBytes), {
-          metadata: {
-            contentType: "application/pdf",
-            metadata: { firebaseStorageDownloadTokens: downloadToken },
-          },
+        await bucket.file(storagePath).save(Buffer.from(mergedPdfBytes), {
+          metadata: { contentType: "application/pdf", metadata: { firebaseStorageDownloadTokens: downloadToken } },
         });
 
         const fileUrl = `https://firebasestorage.googleapis.com/v0/b/${bucket.name}/o/${encodeURIComponent(storagePath)}?alt=media&token=${downloadToken}`;
-
-        const retentionMs = 24 * 60 * 60 * 1000;
-        const expiresAt = new Date(Date.now() + retentionMs);
+        const expiresAt = new Date(Date.now() + 24 * 60 * 60 * 1000);
         log.debug("app-operation: file uploaded", { requestId, feature: task, userId, fileId });
 
-        await firestore
-          .collection("users")
-          .doc(userId)
-          .collection("files")
-          .doc(fileId)
-          .set({
-            fileId,
-            fileName: mergedFileName,
-            storagePath,
-            fileUrl,
-            operation: "merge",
-            status: isAnonymous ? "pending" : "ready",
-            creditCost,
-            createdAt: FieldValue.serverTimestamp(),
-            updatedAt: FieldValue.serverTimestamp(),
-            expiresAt,
-            deleted: false,
-            deletedAt: null,
-            deletionReason: null,
-          });
+        await firestore.collection("users").doc(userId).collection("files").doc(fileId).set({
+          fileId, fileName: mergedFileName, storagePath, fileUrl, operation: "merge",
+          status: isAnonymous ? "pending" : "ready", creditCost,
+          createdAt: FieldValue.serverTimestamp(), updatedAt: FieldValue.serverTimestamp(),
+          expiresAt, deleted: false, deletedAt: null, deletionReason: null,
+        });
         log.debug("app-operation: file metadata saved", { requestId, feature: task, userId, fileId });
 
-        if (isAnonymous) {
-          const claimToken = generateClaimToken(fileId, userId);
-          log.event("📄 app-operation: pending-anonymous", { requestId, feature: task, userId, fileId });
-          return { success: true, data: { claimToken } };
-        }
+        if (isAnonymous) return anonPending(fileId, userId, requestId, task);
 
-        // Publish event
-        await publish(
-          "app-event",
-          {
-            userId,
-            userEmail: decodedToken.email,
-            fileId,
-            fileName: mergedFileName,
-            fileUrl,
-            eventType: "pdf-merge",
-            timestamp: Date.now(),
-            requestId,
-          },
-          requestId,
-          task,
-        );
-        await firestore.collection("users").doc(userId).update({
-          "profile.credits": FieldValue.increment(-creditCost),
-        });
-        log.business("💰 credit-deducted", { requestId, feature: task, userId, fileId, creditCost });
-        log.business("📄 app-operation", { requestId, feature: task, userId, fileId, creditCost, status: "success" });
-
-        return {
-          success: true,
-          message: "Files merged successfully",
-          data: { fileUrl },
-        };
+        await finaliseOperation({ userId, email: ctx.email, fileId, fileName: mergedFileName, fileUrl, eventType: "pdf-merge", creditCost, requestId, task });
+        return { success: true, message: "Files merged successfully", data: { fileUrl } };
       } catch (error) {
         if (error instanceof z.ZodError) {
-          log.warn("app-operation: validation error", {
-            requestId,
-            feature: task,
-            issues: error.issues,
-          });
-          return {
-            success: false,
-            error: "validation error",
-            issues: error.issues,
-          };
+          log.warn("app-operation: validation error", { requestId, feature: task, issues: error.issues });
+          return { success: false, error: "validation error", issues: error.issues };
         }
         log.exception(error as Error, { requestId, feature: task });
         return { success: false, error: "Issue merging files" };
@@ -212,206 +183,65 @@ export const operations = {
     input: imageToPdfSchema,
     handler: async (input, context) => {
       const { images, requestId, task, creditCost } = input;
-      const cookieHeader = context.request.headers.get("cookie") || "";
-      const sessionCookie = cookieHeader
-        .split("; ")
-        .find((c) => c.startsWith("__session="))
-        ?.split("=")[1];
-
-      log.event("📄 app-operation", {
-        requestId,
-        feature: task,
-        status: "start",
-      });
-
-      if (!sessionCookie) {
-        log.warn("app-operation: unauthorized", {
-          requestId,
-          feature: task,
-          status: "fail",
-        });
-        return { success: false, error: "Unauthorized" };
-      }
-
+      log.event("📄 app-operation", { requestId, feature: task, status: "start" });
       try {
-        const auth = await getFirebaseAuth();
-        const decodedToken = await auth.verifySessionCookie(
-          sessionCookie,
-          true,
-        );
-        const userId = decodedToken.uid;
-        const isAnonymous = decodedToken.firebase.sign_in_provider === 'anonymous';
-        log.debug("app-operation: user authenticated", {
-          requestId,
-          feature: task,
-          userId,
-          anonymous: isAnonymous ? 'yes' : 'no',
-        });
+        const ctx = await resolveAuth(context, requestId, task);
+        if (!ctx) return { success: false, error: "Unauthorized" };
+        const { userId, isAnonymous } = ctx;
 
-        // Validate images
         for (const image of images) {
           if (image.size > MAX_IMAGE_SIZE) {
-            log.warn("app-operation: image size exceeds limit", {
-              requestId,
-              feature: task,
-              imageName: image.name,
-            });
-
-            return {
-              success: false,
-              error: `Image ${image.name} exceeds the maximum size of 10MB.`,
-            };
+            log.warn("app-operation: image size exceeds limit", { requestId, feature: task, imageName: image.name });
+            return { success: false, error: `Image ${image.name} exceeds the maximum size of 10MB.` };
           }
           if (!["image/jpeg", "image/png"].includes(image.type)) {
-            log.warn("app-operation: unsupported image format", {
-              requestId,
-              feature: task,
-              imageName: image.name,
-              imageType: image.type,
-            });
-            return {
-              success: false,
-              error: `Image ${image.name} is not a supported format. Only JPEG and PNG are allowed.`,
-            };
+            log.warn("app-operation: unsupported image format", { requestId, feature: task, imageName: image.name, imageType: image.type });
+            return { success: false, error: `Image ${image.name} is not a supported format. Only JPEG and PNG are allowed.` };
           }
         }
 
-        // Create PDF from images
         const pdfDoc = await PDFDocument.create();
         for (const imageFile of images) {
           const imageBytes = await imageFile.arrayBuffer();
-          let pdfImage;
-          if (imageFile.type === "image/jpeg")
-            pdfImage = await pdfDoc.embedJpg(imageBytes);
-          else if (imageFile.type === "image/png")
-            pdfImage = await pdfDoc.embedPng(imageBytes);
-
-          if (pdfImage) {
-            const page = pdfDoc.addPage();
-            const { width, height } = pdfImage.scale(1);
-            page.setSize(width, height);
-            page.drawImage(pdfImage, { x: 0, y: 0, width, height });
-          } else {
-            log.warn("app-operation: failed to embed image", {
-              requestId,
-              feature: task,
-              imageName: imageFile.name,
-            });
-            return {
-              success: false,
-              error: `Failed to embed image ${imageFile.name}.`,
-            };
+          const pdfImage = imageFile.type === "image/jpeg"
+            ? await pdfDoc.embedJpg(imageBytes)
+            : imageFile.type === "image/png" ? await pdfDoc.embedPng(imageBytes) : null;
+          if (!pdfImage) {
+            log.warn("app-operation: failed to embed image", { requestId, feature: task, imageName: imageFile.name });
+            return { success: false, error: `Failed to embed image ${imageFile.name}.` };
           }
+          const page = pdfDoc.addPage();
+          const { width, height } = pdfImage.scale(1);
+          page.setSize(width, height);
+          page.drawImage(pdfImage, { x: 0, y: 0, width, height });
         }
 
         const pdfBytes = await pdfDoc.save();
-
-        // Upload PDF to Firebase Storage
-        const fileId = firestore
-          .collection("users")
-          .doc(userId)
-          .collection("files")
-          .doc().id;
+        const fileId = firestore.collection("users").doc(userId).collection("files").doc().id;
         const pdfFileName = `images-${Date.now()}.pdf`;
         const storagePath = `users/${userId}/${pdfFileName}`;
-        const fileRef = bucket.file(storagePath);
         const downloadToken = uuidv4();
 
-        await fileRef.save(Buffer.from(pdfBytes), {
-          metadata: {
-            contentType: "application/pdf",
-            metadata: { firebaseStorageDownloadTokens: downloadToken },
-          },
+        await bucket.file(storagePath).save(Buffer.from(pdfBytes), {
+          metadata: { contentType: "application/pdf", metadata: { firebaseStorageDownloadTokens: downloadToken } },
         });
 
-        const fileUrl = `https://firebasestorage.googleapis.com/v0/b/${bucket.name}/o/${encodeURIComponent(
-          storagePath,
-        )}?alt=media&token=${downloadToken}`;
-        log.debug("app-operation: PDF uploaded to Firebase Storage", {
-          requestId,
-          feature: task,
-          userId,
-          fileId,
-        });
+        const fileUrl = `https://firebasestorage.googleapis.com/v0/b/${bucket.name}/o/${encodeURIComponent(storagePath)}?alt=media&token=${downloadToken}`;
+        const expiresAt = new Date(Date.now() + 24 * 60 * 60 * 1000);
+        log.debug("app-operation: PDF uploaded to Firebase Storage", { requestId, feature: task, userId, fileId });
 
-        // Determine retention period (24h for free users, configurable later)
-        const retentionMs = 24 * 60 * 60 * 1000;
-        const expiresAt = new Date(Date.now() + retentionMs);
-
-        // Save metadata to Firestore
-        await firestore
-          .collection("users")
-          .doc(userId)
-          .collection("files")
-          .doc(fileId)
-          .set({
-            fileId,
-            fileName: pdfFileName,
-            storagePath,
-            fileUrl,
-            operation: "image-to-pdf",
-            status: isAnonymous ? "pending" : "ready",
-            creditCost,
-            createdAt: FieldValue.serverTimestamp(),
-            updatedAt: FieldValue.serverTimestamp(),
-            expiresAt,
-            deleted: false,
-            deletedAt: null,
-            deletionReason: null,
-          });
-        log.debug("app-operation: file metadata saved", {
-          requestId,
-          feature: task,
-          userId,
-          fileId,
+        await firestore.collection("users").doc(userId).collection("files").doc(fileId).set({
+          fileId, fileName: pdfFileName, storagePath, fileUrl, operation: "image-to-pdf",
+          status: isAnonymous ? "pending" : "ready", creditCost,
+          createdAt: FieldValue.serverTimestamp(), updatedAt: FieldValue.serverTimestamp(),
+          expiresAt, deleted: false, deletedAt: null, deletionReason: null,
         });
+        log.debug("app-operation: file metadata saved", { requestId, feature: task, userId, fileId });
 
-        if (isAnonymous) {
-          const claimToken = generateClaimToken(fileId, userId);
-          log.event("📄 app-operation: pending-anonymous", { requestId, feature: task, userId, fileId });
-          return { success: true, data: { claimToken } };
-        }
+        if (isAnonymous) return anonPending(fileId, userId, requestId, task);
 
-        // Publish event to Pub/Sub
-        await publish(
-          "app-event",
-          {
-            userId,
-            userEmail: decodedToken.email,
-            fileId,
-            fileName: pdfFileName,
-            fileUrl,
-            eventType: "image-to-pdf",
-            timestamp: Date.now(),
-            requestId,
-          },
-          requestId,
-          task,
-        );
-        await firestore.collection("users").doc(userId).update({
-          "profile.credits": FieldValue.increment(-creditCost),
-        });
-        log.business("💰 credit-deducted", {
-          requestId,
-          feature: task,
-          userId,
-          fileId,
-          creditCost,
-        });
-        log.business("📄 app-operation", {
-          requestId,
-          feature: task,
-          userId,
-          fileId,
-          creditCost,
-          status: "success",
-        });
-
-        return {
-          success: true,
-          message: "Images converted to PDF successfully",
-          data: { fileUrl },
-        };
+        await finaliseOperation({ userId, email: ctx.email, fileId, fileName: pdfFileName, fileUrl, eventType: "image-to-pdf", creditCost, requestId, task });
+        return { success: true, message: "Images converted to PDF successfully", data: { fileUrl } };
       } catch (error) {
         log.exception(error as Error, { requestId, feature: task });
         return { success: false, error: "Failed to convert images to PDF" };
@@ -432,25 +262,11 @@ export const operations = {
     }),
     handler: async (input, context) => {
       const { file, userPassword, ownerPassword, permissions, requestId, task, creditCost } = input;
-      const cookieHeader = context.request.headers.get("cookie") || "";
-      const sessionCookie = cookieHeader
-        .split("; ")
-        .find((c) => c.startsWith("__session="))
-        ?.split("=")[1];
-
       log.event("📄 app-operation", { requestId, feature: task, status: "start" });
-
-      if (!sessionCookie) {
-        log.warn("app-operation: unauthorized", { requestId, feature: task, status: "fail" });
-        return { success: false, error: "Unauthorized" };
-      }
-
       try {
-        const auth = await getFirebaseAuth();
-        const decodedToken = await auth.verifySessionCookie(sessionCookie, true);
-        const userId = decodedToken.uid;
-        const isAnonymous = decodedToken.firebase.sign_in_provider === 'anonymous';
-        log.debug("app-operation: user authenticated", { requestId, feature: task, userId, anonymous: isAnonymous ? 'yes' : 'no' });
+        const ctx = await resolveAuth(context, requestId, task);
+        if (!ctx) return { success: false, error: "Unauthorized" };
+        const { userId, isAnonymous } = ctx;
 
         const fileId = firestore.collection("users").doc(userId).collection("files").doc().id;
 
@@ -470,63 +286,26 @@ export const operations = {
         const pdfBytes = Buffer.from(await processorRes.arrayBuffer());
         const encryptedFileName = `encrypted-${Date.now()}.pdf`;
         const storagePath = `users/${userId}/${encryptedFileName}`;
-        const fileRef = bucket.file(storagePath);
         const downloadToken = uuidv4();
 
-        await fileRef.save(pdfBytes, {
-          metadata: {
-            contentType: "application/pdf",
-            metadata: { firebaseStorageDownloadTokens: downloadToken },
-          },
+        await bucket.file(storagePath).save(pdfBytes, {
+          metadata: { contentType: "application/pdf", metadata: { firebaseStorageDownloadTokens: downloadToken } },
         });
 
         const fileUrl = `https://firebasestorage.googleapis.com/v0/b/${bucket.name}/o/${encodeURIComponent(storagePath)}?alt=media&token=${downloadToken}`;
         const expiresAt = new Date(Date.now() + 24 * 60 * 60 * 1000);
 
         await firestore.collection("users").doc(userId).collection("files").doc(fileId).set({
-          fileId,
-          fileName: encryptedFileName,
-          storagePath,
-          fileUrl,
-          operation: "encrypt",
-          status: isAnonymous ? "pending" : "ready",
-          creditCost,
-          createdAt: FieldValue.serverTimestamp(),
-          updatedAt: FieldValue.serverTimestamp(),
-          expiresAt,
-          deleted: false,
-          deletedAt: null,
-          deletionReason: null,
+          fileId, fileName: encryptedFileName, storagePath, fileUrl, operation: "encrypt",
+          status: isAnonymous ? "pending" : "ready", creditCost,
+          createdAt: FieldValue.serverTimestamp(), updatedAt: FieldValue.serverTimestamp(),
+          expiresAt, deleted: false, deletedAt: null, deletionReason: null,
         });
         log.debug("app-operation: file metadata saved", { requestId, feature: task, userId, fileId });
 
-        if (isAnonymous) {
-          const claimToken = generateClaimToken(fileId, userId);
-          log.event("📄 app-operation: pending-anonymous", { requestId, feature: task, userId, fileId });
-          return { success: true, data: { claimToken } };
-        }
+        if (isAnonymous) return anonPending(fileId, userId, requestId, task);
 
-        await publish(
-          "app-event",
-          {
-            userId,
-            userEmail: decodedToken.email,
-            fileId,
-            fileName: encryptedFileName,
-            fileUrl,
-            eventType: "pdf-encrypt",
-            timestamp: Date.now(),
-            requestId,
-          },
-          requestId,
-          task,
-        );
-        await firestore.collection("users").doc(userId).update({
-          "profile.credits": FieldValue.increment(-creditCost),
-        });
-        log.business("💰 credit-deducted", { requestId, feature: task, userId, fileId, creditCost });
-        log.business("📄 app-operation", { requestId, feature: task, userId, fileId, creditCost, status: "success" });
-
+        await finaliseOperation({ userId, email: ctx.email, fileId, fileName: encryptedFileName, fileUrl, eventType: "pdf-encrypt", creditCost, requestId, task });
         return { success: true, message: "PDF encrypted successfully", data: { fileUrl } };
       } catch (error) {
         log.exception(error as Error, { requestId, feature: task });
@@ -546,25 +325,11 @@ export const operations = {
     }),
     handler: async (input, context) => {
       const { file, password, requestId, task, creditCost } = input;
-      const cookieHeader = context.request.headers.get("cookie") || "";
-      const sessionCookie = cookieHeader
-        .split("; ")
-        .find((c) => c.startsWith("__session="))
-        ?.split("=")[1];
-
       log.event("📄 app-operation", { requestId, feature: task, status: "start" });
-
-      if (!sessionCookie) {
-        log.warn("app-operation: unauthorized", { requestId, feature: task, status: "fail" });
-        return { success: false, error: "Unauthorized" };
-      }
-
       try {
-        const auth = await getFirebaseAuth();
-        const decodedToken = await auth.verifySessionCookie(sessionCookie, true);
-        const userId = decodedToken.uid;
-        const isAnonymous = decodedToken.firebase.sign_in_provider === 'anonymous';
-        log.debug("app-operation: user authenticated", { requestId, feature: task, userId, anonymous: isAnonymous ? 'yes' : 'no' });
+        const ctx = await resolveAuth(context, requestId, task);
+        if (!ctx) return { success: false, error: "Unauthorized" };
+        const { userId, isAnonymous } = ctx;
 
         const fileId = firestore.collection("users").doc(userId).collection("files").doc().id;
 
@@ -582,63 +347,26 @@ export const operations = {
         const pdfBytes = Buffer.from(await processorRes.arrayBuffer());
         const decryptedFileName = `decrypted-${Date.now()}.pdf`;
         const storagePath = `users/${userId}/${decryptedFileName}`;
-        const fileRef = bucket.file(storagePath);
         const downloadToken = uuidv4();
 
-        await fileRef.save(pdfBytes, {
-          metadata: {
-            contentType: "application/pdf",
-            metadata: { firebaseStorageDownloadTokens: downloadToken },
-          },
+        await bucket.file(storagePath).save(pdfBytes, {
+          metadata: { contentType: "application/pdf", metadata: { firebaseStorageDownloadTokens: downloadToken } },
         });
 
         const fileUrl = `https://firebasestorage.googleapis.com/v0/b/${bucket.name}/o/${encodeURIComponent(storagePath)}?alt=media&token=${downloadToken}`;
         const expiresAt = new Date(Date.now() + 24 * 60 * 60 * 1000);
 
         await firestore.collection("users").doc(userId).collection("files").doc(fileId).set({
-          fileId,
-          fileName: decryptedFileName,
-          storagePath,
-          fileUrl,
-          operation: "decrypt",
-          status: isAnonymous ? "pending" : "ready",
-          creditCost,
-          createdAt: FieldValue.serverTimestamp(),
-          updatedAt: FieldValue.serverTimestamp(),
-          expiresAt,
-          deleted: false,
-          deletedAt: null,
-          deletionReason: null,
+          fileId, fileName: decryptedFileName, storagePath, fileUrl, operation: "decrypt",
+          status: isAnonymous ? "pending" : "ready", creditCost,
+          createdAt: FieldValue.serverTimestamp(), updatedAt: FieldValue.serverTimestamp(),
+          expiresAt, deleted: false, deletedAt: null, deletionReason: null,
         });
         log.debug("app-operation: file metadata saved", { requestId, feature: task, userId, fileId });
 
-        if (isAnonymous) {
-          const claimToken = generateClaimToken(fileId, userId);
-          log.event("📄 app-operation: pending-anonymous", { requestId, feature: task, userId, fileId });
-          return { success: true, data: { claimToken } };
-        }
+        if (isAnonymous) return anonPending(fileId, userId, requestId, task);
 
-        await publish(
-          "app-event",
-          {
-            userId,
-            userEmail: decodedToken.email,
-            fileId,
-            fileName: decryptedFileName,
-            fileUrl,
-            eventType: "pdf-decrypt",
-            timestamp: Date.now(),
-            requestId,
-          },
-          requestId,
-          task,
-        );
-        await firestore.collection("users").doc(userId).update({
-          "profile.credits": FieldValue.increment(-creditCost),
-        });
-        log.business("💰 credit-deducted", { requestId, feature: task, userId, fileId, creditCost });
-        log.business("📄 app-operation", { requestId, feature: task, userId, fileId, creditCost, status: "success" });
-
+        await finaliseOperation({ userId, email: ctx.email, fileId, fileName: decryptedFileName, fileUrl, eventType: "pdf-decrypt", creditCost, requestId, task });
         return { success: true, message: "PDF decrypted successfully", data: { fileUrl } };
       } catch (error) {
         log.exception(error as Error, { requestId, feature: task });

--- a/apps/pdf-craft/src/actions/operations.ts
+++ b/apps/pdf-craft/src/actions/operations.ts
@@ -7,6 +7,7 @@ import { v4 as uuidv4 } from "uuid";
 import { getFirebaseAuth, getFirebaseApp } from "../firebase/server";
 import { publish } from "../server/pubsub/publisher";
 import { log } from "../utils/lib/logger";
+import { generateClaimToken } from "../utils/lib/claimToken";
 
 async function callProcessor(path: string, form: FormData): Promise<Response> {
   const processorUrl = import.meta.env.PDF_PROCESSOR_URL;
@@ -84,10 +85,12 @@ export const operations = {
           true,
         );
         const userId = decodedToken.uid;
+        const isAnonymous = decodedToken.firebase.sign_in_provider === 'anonymous';
         log.debug("app-operation: user authenticated", {
           requestId,
           feature: task,
           userId,
+          anonymous: isAnonymous ? 'yes' : 'no',
         });
 
         const fileId = firestore
@@ -126,17 +129,10 @@ export const operations = {
 
         const fileUrl = `https://firebasestorage.googleapis.com/v0/b/${bucket.name}/o/${encodeURIComponent(storagePath)}?alt=media&token=${downloadToken}`;
 
-        // Determine retention (24h for free users)
-        const retentionMs = 24 * 60 * 60 * 1000; // adjust per subscription plan
+        const retentionMs = 24 * 60 * 60 * 1000;
         const expiresAt = new Date(Date.now() + retentionMs);
-        log.debug("app-operation: file uploaded", {
-          requestId,
-          feature: task,
-          userId,
-          fileId,
-        });
+        log.debug("app-operation: file uploaded", { requestId, feature: task, userId, fileId });
 
-        // Save Firestore metadata
         await firestore
           .collection("users")
           .doc(userId)
@@ -148,6 +144,8 @@ export const operations = {
             storagePath,
             fileUrl,
             operation: "merge",
+            status: isAnonymous ? "pending" : "ready",
+            creditCost,
             createdAt: FieldValue.serverTimestamp(),
             updatedAt: FieldValue.serverTimestamp(),
             expiresAt,
@@ -155,12 +153,13 @@ export const operations = {
             deletedAt: null,
             deletionReason: null,
           });
-        log.debug("app-operation: file metadata saved", {
-          requestId,
-          feature: task,
-          userId,
-          fileId,
-        });
+        log.debug("app-operation: file metadata saved", { requestId, feature: task, userId, fileId });
+
+        if (isAnonymous) {
+          const claimToken = generateClaimToken(fileId, userId);
+          log.event("📄 app-operation: pending-anonymous", { requestId, feature: task, userId, fileId });
+          return { success: true, data: { claimToken } };
+        }
 
         // Publish event
         await publish(
@@ -181,21 +180,8 @@ export const operations = {
         await firestore.collection("users").doc(userId).update({
           "profile.credits": FieldValue.increment(-creditCost),
         });
-        log.business("💰 credit-deducted", {
-          requestId,
-          feature: task,
-          userId,
-          fileId,
-          creditCost,
-        });
-        log.business("📄 app-operation", {
-          requestId,
-          feature: task,
-          userId,
-          fileId,
-          creditCost,
-          status: "success",
-        });
+        log.business("💰 credit-deducted", { requestId, feature: task, userId, fileId, creditCost });
+        log.business("📄 app-operation", { requestId, feature: task, userId, fileId, creditCost, status: "success" });
 
         return {
           success: true,
@@ -254,10 +240,12 @@ export const operations = {
           true,
         );
         const userId = decodedToken.uid;
+        const isAnonymous = decodedToken.firebase.sign_in_provider === 'anonymous';
         log.debug("app-operation: user authenticated", {
           requestId,
           feature: task,
           userId,
+          anonymous: isAnonymous ? 'yes' : 'no',
         });
 
         // Validate images
@@ -362,6 +350,8 @@ export const operations = {
             storagePath,
             fileUrl,
             operation: "image-to-pdf",
+            status: isAnonymous ? "pending" : "ready",
+            creditCost,
             createdAt: FieldValue.serverTimestamp(),
             updatedAt: FieldValue.serverTimestamp(),
             expiresAt,
@@ -375,6 +365,12 @@ export const operations = {
           userId,
           fileId,
         });
+
+        if (isAnonymous) {
+          const claimToken = generateClaimToken(fileId, userId);
+          log.event("📄 app-operation: pending-anonymous", { requestId, feature: task, userId, fileId });
+          return { success: true, data: { claimToken } };
+        }
 
         // Publish event to Pub/Sub
         await publish(
@@ -453,7 +449,8 @@ export const operations = {
         const auth = await getFirebaseAuth();
         const decodedToken = await auth.verifySessionCookie(sessionCookie, true);
         const userId = decodedToken.uid;
-        log.debug("app-operation: user authenticated", { requestId, feature: task, userId });
+        const isAnonymous = decodedToken.firebase.sign_in_provider === 'anonymous';
+        log.debug("app-operation: user authenticated", { requestId, feature: task, userId, anonymous: isAnonymous ? 'yes' : 'no' });
 
         const fileId = firestore.collection("users").doc(userId).collection("files").doc().id;
 
@@ -492,6 +489,8 @@ export const operations = {
           storagePath,
           fileUrl,
           operation: "encrypt",
+          status: isAnonymous ? "pending" : "ready",
+          creditCost,
           createdAt: FieldValue.serverTimestamp(),
           updatedAt: FieldValue.serverTimestamp(),
           expiresAt,
@@ -500,6 +499,12 @@ export const operations = {
           deletionReason: null,
         });
         log.debug("app-operation: file metadata saved", { requestId, feature: task, userId, fileId });
+
+        if (isAnonymous) {
+          const claimToken = generateClaimToken(fileId, userId);
+          log.event("📄 app-operation: pending-anonymous", { requestId, feature: task, userId, fileId });
+          return { success: true, data: { claimToken } };
+        }
 
         await publish(
           "app-event",
@@ -558,7 +563,8 @@ export const operations = {
         const auth = await getFirebaseAuth();
         const decodedToken = await auth.verifySessionCookie(sessionCookie, true);
         const userId = decodedToken.uid;
-        log.debug("app-operation: user authenticated", { requestId, feature: task, userId });
+        const isAnonymous = decodedToken.firebase.sign_in_provider === 'anonymous';
+        log.debug("app-operation: user authenticated", { requestId, feature: task, userId, anonymous: isAnonymous ? 'yes' : 'no' });
 
         const fileId = firestore.collection("users").doc(userId).collection("files").doc().id;
 
@@ -595,6 +601,8 @@ export const operations = {
           storagePath,
           fileUrl,
           operation: "decrypt",
+          status: isAnonymous ? "pending" : "ready",
+          creditCost,
           createdAt: FieldValue.serverTimestamp(),
           updatedAt: FieldValue.serverTimestamp(),
           expiresAt,
@@ -603,6 +611,12 @@ export const operations = {
           deletionReason: null,
         });
         log.debug("app-operation: file metadata saved", { requestId, feature: task, userId, fileId });
+
+        if (isAnonymous) {
+          const claimToken = generateClaimToken(fileId, userId);
+          log.event("📄 app-operation: pending-anonymous", { requestId, feature: task, userId, fileId });
+          return { success: true, data: { claimToken } };
+        }
 
         await publish(
           "app-event",

--- a/apps/pdf-craft/src/actions/user.ts
+++ b/apps/pdf-craft/src/actions/user.ts
@@ -286,4 +286,80 @@ export const user = {
       return { success: true };
     },
   }),
+
+  // Creates a short-lived session cookie for an anonymous Firebase user so
+  // server-side actions can verify them via verifySessionCookie as usual.
+  createAnonymousSession: defineAction({
+    accept: 'json',
+    input: z.object({ idToken: z.string() }),
+    handler: async (input, context) => {
+      const auth = await getFirebaseAuth();
+      try {
+        const decoded = await auth.verifyIdToken(input.idToken);
+        if (decoded.firebase.sign_in_provider !== 'anonymous') {
+          return { success: false, error: 'Invalid token type' };
+        }
+        const oneHour = 60 * 60 * 1000;
+        const sessionCookie = await auth.createSessionCookie(input.idToken, { expiresIn: oneHour });
+        context.cookies.set('__session', sessionCookie, {
+          path: '/',
+          httpOnly: true,
+          secure: import.meta.env.NODE_ENV === 'production',
+          sameSite: 'strict',
+          maxAge: 60 * 60,
+        });
+        log.event("👤 anon-session-created", { feature: "anonymous-auth", userId: decoded.uid });
+        return { success: true };
+      } catch (error) {
+        log.exception(error as Error, { feature: "anonymous-auth" });
+        return { success: false, error: 'Failed to create anonymous session' };
+      }
+    },
+  }),
+
+  // Called after linkWithCredential succeeds client-side. Creates a real
+  // session cookie for the now-permanent account and initialises their
+  // Firestore profile if it doesn't exist yet (anon users have none).
+  finalizeLinkedUser: defineAction({
+    accept: 'json',
+    input: z.object({ idToken: z.string(), name: z.string().optional() }),
+    handler: async (input, context) => {
+      const auth = await getFirebaseAuth();
+      try {
+        const decoded = await auth.verifyIdToken(input.idToken);
+        if (decoded.firebase.sign_in_provider === 'anonymous') {
+          return { success: false, error: 'Token is still anonymous' };
+        }
+
+        const firestore = await getFirebaseFirestore();
+        const userRef = firestore.collection('users').doc(decoded.uid);
+        const userDoc = await userRef.get();
+        if (!userDoc.exists) {
+          await userRef.set({
+            profile: {
+              name: input.name ?? decoded.name ?? decoded.email ?? 'Riqa user',
+              isSubscriber: false,
+              credits: 0,
+            },
+          });
+        }
+
+        const fiveDays = 60 * 60 * 24 * 5 * 1000;
+        const sessionCookie = await auth.createSessionCookie(input.idToken, { expiresIn: fiveDays });
+        context.cookies.set('__session', sessionCookie, {
+          path: '/',
+          httpOnly: true,
+          secure: import.meta.env.NODE_ENV === 'production',
+          sameSite: 'strict',
+          maxAge: 60 * 60 * 24 * 5,
+        });
+
+        log.business("🔐 user-linked", { feature: "anonymous-upgrade", userId: decoded.uid });
+        return { success: true };
+      } catch (error) {
+        log.exception(error as Error, { feature: "anonymous-upgrade" });
+        return { success: false, error: 'Failed to finalise account' };
+      }
+    },
+  }),
 };

--- a/apps/pdf-craft/src/components/shared.test.tsx
+++ b/apps/pdf-craft/src/components/shared.test.tsx
@@ -1,0 +1,127 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { ErrorCallout, INSUFFICIENT_CREDITS_ERROR, useDraggableFiles } from "./shared";
+
+// Test harness that exposes useDraggableFiles state and functions via rendered output
+function FileListHarness({ maxFiles }: { maxFiles: number }) {
+  const { uploadedFiles, handleFiles, handleDelete, handleDragEnd } = useDraggableFiles(maxFiles);
+  return (
+    <div>
+      <input
+        data-testid="file-input"
+        type="file"
+        multiple
+        onChange={(e) => handleFiles(Array.from(e.target.files ?? []))}
+      />
+      {uploadedFiles.map((f) => (
+        <div key={f.name} data-testid={`file-${f.name}`}>
+          {f.name}
+          <button onClick={() => handleDelete(f.name)}>Remove {f.name}</button>
+        </div>
+      ))}
+      <span data-testid="count">{uploadedFiles.length}</span>
+      <button
+        data-testid="drag-a-b"
+        onClick={() => handleDragEnd({ active: { id: "a.pdf" }, over: { id: "b.pdf" } } as any)}
+      >
+        Drag a→b
+      </button>
+      <button
+        data-testid="drag-same"
+        onClick={() => handleDragEnd({ active: { id: "a.pdf" }, over: { id: "a.pdf" } } as any)}
+      >
+        Drag same
+      </button>
+    </div>
+  );
+}
+
+function makeFile(name: string) {
+  return new File(["content"], name, { type: "application/pdf" });
+}
+
+describe("ErrorCallout", () => {
+  it("renders the provided message", () => {
+    render(<ErrorCallout message="Something went wrong" />);
+    expect(screen.getByRole("alert")).toHaveTextContent("Something went wrong");
+  });
+
+  it("does not show a Buy credits link for generic errors", () => {
+    render(<ErrorCallout message="Generic error" />);
+    expect(screen.queryByRole("link", { name: /Buy more credits/i })).not.toBeInTheDocument();
+  });
+
+  it("shows a Buy more credits link for the INSUFFICIENT_CREDITS_ERROR", () => {
+    render(<ErrorCallout message={INSUFFICIENT_CREDITS_ERROR} />);
+    const link = screen.getByRole("link", { name: /Buy more credits/i });
+    expect(link).toBeInTheDocument();
+    expect(link).toHaveAttribute("href", "/buy-credits");
+  });
+});
+
+describe("useDraggableFiles", () => {
+  it("adds files up to the maxFiles limit", async () => {
+    const user = userEvent.setup();
+    render(<FileListHarness maxFiles={3} />);
+    const input = screen.getByTestId("file-input");
+    const files = [makeFile("a.pdf"), makeFile("b.pdf"), makeFile("c.pdf"), makeFile("d.pdf")];
+    Object.defineProperty(input, "files", { value: files, configurable: true });
+    fireEvent.change(input);
+    await waitFor(() => expect(screen.getByTestId("count")).toHaveTextContent("3"));
+    expect(screen.queryByTestId("file-d.pdf")).not.toBeInTheDocument();
+  });
+
+  it("removes a file when handleDelete is called", async () => {
+    const user = userEvent.setup();
+    render(<FileListHarness maxFiles={5} />);
+    const input = screen.getByTestId("file-input");
+    Object.defineProperty(input, "files", { value: [makeFile("x.pdf"), makeFile("y.pdf")], configurable: true });
+    fireEvent.change(input);
+    await waitFor(() => screen.getByTestId("file-x.pdf"));
+    await user.click(screen.getByRole("button", { name: /Remove x.pdf/i }));
+    await waitFor(() => expect(screen.queryByTestId("file-x.pdf")).not.toBeInTheDocument());
+    expect(screen.getByTestId("file-y.pdf")).toBeInTheDocument();
+  });
+
+  it("reorders files when handleDragEnd is called with different active and over ids", async () => {
+    const user = userEvent.setup();
+    render(<FileListHarness maxFiles={5} />);
+    const input = screen.getByTestId("file-input");
+    Object.defineProperty(input, "files", { value: [makeFile("a.pdf"), makeFile("b.pdf")], configurable: true });
+    fireEvent.change(input);
+    await waitFor(() => screen.getByTestId("file-a.pdf"));
+    // Trigger a drag where a.pdf moves to b.pdf's position
+    await user.click(screen.getByTestId("drag-a-b"));
+    // Both files should still be present (just reordered)
+    await waitFor(() => expect(screen.getByTestId("file-a.pdf")).toBeInTheDocument());
+    expect(screen.getByTestId("file-b.pdf")).toBeInTheDocument();
+  });
+
+  it("does not reorder files when handleDragEnd is called with the same id", async () => {
+    const user = userEvent.setup();
+    render(<FileListHarness maxFiles={5} />);
+    const input = screen.getByTestId("file-input");
+    Object.defineProperty(input, "files", { value: [makeFile("a.pdf"), makeFile("b.pdf")], configurable: true });
+    fireEvent.change(input);
+    await waitFor(() => screen.getByTestId("file-a.pdf"));
+    await user.click(screen.getByTestId("drag-same"));
+    expect(screen.getByTestId("file-a.pdf")).toBeInTheDocument();
+    expect(screen.getByTestId("file-b.pdf")).toBeInTheDocument();
+    expect(screen.getByTestId("count")).toHaveTextContent("2");
+  });
+
+  it("respects remaining capacity when adding to an existing list", async () => {
+    render(<FileListHarness maxFiles={2} />);
+    const input = screen.getByTestId("file-input");
+    Object.defineProperty(input, "files", { value: [makeFile("a.pdf")], configurable: true });
+    fireEvent.change(input);
+    await waitFor(() => screen.getByTestId("file-a.pdf"));
+    // Try adding 2 more — only 1 slot remaining
+    Object.defineProperty(input, "files", { value: [makeFile("b.pdf"), makeFile("c.pdf")], configurable: true });
+    fireEvent.change(input);
+    await waitFor(() => screen.getByTestId("file-b.pdf"));
+    expect(screen.queryByTestId("file-c.pdf")).not.toBeInTheDocument();
+    expect(screen.getByTestId("count")).toHaveTextContent("2");
+  });
+});

--- a/apps/pdf-craft/src/components/slices/MultiPdfUploader/MultiPdfUploader.test.tsx
+++ b/apps/pdf-craft/src/components/slices/MultiPdfUploader/MultiPdfUploader.test.tsx
@@ -2,10 +2,16 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, screen, waitFor, fireEvent } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
+const mockSignInAnonymously = vi.fn();
+vi.mock("firebase/auth", () => ({
+  signInAnonymously: (...args: unknown[]) => mockSignInAnonymously(...args),
+}));
+
 vi.mock("../../../utils/lib/analytics", () => ({ logEvent: vi.fn() }));
 
 import MultiPdfUploader from "./MultiPdfUploader";
-import { checkCredits, mergePdfs } from "../../../test/mocks/astro-actions";
+import { checkCredits, mergePdfs, createAnonymousSession } from "../../../test/mocks/astro-actions";
+import { auth } from "../../../firebase/client";
 
 function makeFile(name: string) {
   return new File(["pdf"], name, { type: "application/pdf" });
@@ -17,20 +23,28 @@ function addFiles(files: File[]) {
   fireEvent.change(input);
 }
 
+const mockAnonUser = { uid: "anon-uid", isAnonymous: true, getIdToken: vi.fn().mockResolvedValue("anon-id-token") };
+
 beforeEach(() => {
   vi.clearAllMocks();
+  // Default: real signed-in user (skips anonymous flow)
+  (auth as any).currentUser = { uid: "test-uid", isAnonymous: false };
   checkCredits.mockResolvedValue({ data: { success: true }, error: null });
   mergePdfs.mockResolvedValue({ data: { data: { fileUrl: "https://cdn.test/merged.pdf" } }, error: null });
+  createAnonymousSession.mockResolvedValue({ data: { success: true }, error: null });
+  mockSignInAnonymously.mockResolvedValue({ user: mockAnonUser });
+  vi.stubGlobal("sessionStorage", { getItem: vi.fn(() => null), setItem: vi.fn(), removeItem: vi.fn() });
+  vi.stubGlobal("location", { href: "" });
 });
 
 describe("MultiPdfUploader", () => {
   it("renders the file dropzone initially", () => {
-    render(<MultiPdfUploader creditCost={2} />);
+    render(<MultiPdfUploader creditCost={2} isAuthenticated />);
     expect(screen.getByTestId("file-input")).toBeInTheDocument();
   });
 
   it("shows uploaded file names after adding files", async () => {
-    render(<MultiPdfUploader creditCost={2} />);
+    render(<MultiPdfUploader creditCost={2} isAuthenticated />);
     addFiles([makeFile("a.pdf"), makeFile("b.pdf")]);
     await waitFor(() => {
       expect(screen.getByText("a.pdf")).toBeInTheDocument();
@@ -39,7 +53,7 @@ describe("MultiPdfUploader", () => {
   });
 
   it("shows the max-files callout and hides the dropzone at 5 files", async () => {
-    render(<MultiPdfUploader creditCost={2} />);
+    render(<MultiPdfUploader creditCost={2} isAuthenticated />);
     addFiles([1, 2, 3, 4, 5].map((n) => makeFile(`file${n}.pdf`)));
     await waitFor(() =>
       expect(screen.getByRole("alert")).toHaveTextContent(/Maximum of 5 files reached/i),
@@ -49,7 +63,7 @@ describe("MultiPdfUploader", () => {
 
   it("removes a file when its remove button is clicked", async () => {
     const user = userEvent.setup();
-    render(<MultiPdfUploader creditCost={2} />);
+    render(<MultiPdfUploader creditCost={2} isAuthenticated />);
     addFiles([makeFile("a.pdf"), makeFile("b.pdf")]);
     await waitFor(() => screen.getByText("a.pdf"));
     await user.click(screen.getByRole("button", { name: /Remove a\.pdf/i }));
@@ -58,7 +72,7 @@ describe("MultiPdfUploader", () => {
   });
 
   it("disables the merge button when fewer than 2 files are added", async () => {
-    render(<MultiPdfUploader creditCost={2} />);
+    render(<MultiPdfUploader creditCost={2} isAuthenticated />);
     addFiles([makeFile("only.pdf")]);
     await waitFor(() => screen.getByText("only.pdf"));
     expect(screen.getByRole("button", { name: /Merge PDFs/i })).toBeDisabled();
@@ -67,7 +81,7 @@ describe("MultiPdfUploader", () => {
   it("shows insufficient credits error", async () => {
     checkCredits.mockResolvedValue({ data: { success: false } });
     const user = userEvent.setup();
-    render(<MultiPdfUploader creditCost={2} />);
+    render(<MultiPdfUploader creditCost={2} isAuthenticated />);
     addFiles([makeFile("a.pdf"), makeFile("b.pdf")]);
     await waitFor(() => screen.getByText("a.pdf"));
     await user.click(screen.getByRole("button", { name: /Merge PDFs/i }));
@@ -78,7 +92,7 @@ describe("MultiPdfUploader", () => {
 
   it("shows download link after a successful merge", async () => {
     const user = userEvent.setup();
-    render(<MultiPdfUploader creditCost={2} />);
+    render(<MultiPdfUploader creditCost={2} isAuthenticated />);
     addFiles([makeFile("a.pdf"), makeFile("b.pdf")]);
     await waitFor(() => screen.getByText("a.pdf"));
     await user.click(screen.getByRole("button", { name: /Merge PDFs/i }));
@@ -92,12 +106,116 @@ describe("MultiPdfUploader", () => {
 
   it("resets to the dropzone when Merge more PDFs is clicked", async () => {
     const user = userEvent.setup();
-    render(<MultiPdfUploader creditCost={2} />);
+    render(<MultiPdfUploader creditCost={2} isAuthenticated />);
     addFiles([makeFile("a.pdf"), makeFile("b.pdf")]);
     await waitFor(() => screen.getByText("a.pdf"));
     await user.click(screen.getByRole("button", { name: /Merge PDFs/i }));
     await waitFor(() => screen.getByRole("link", { name: /Download merged PDF/i }));
     await user.click(screen.getByRole("button", { name: /Merge more PDFs/i }));
     await waitFor(() => expect(screen.getByTestId("file-input")).toBeInTheDocument());
+  });
+
+  // ── Anonymous user flow ───────────────────────────────────────────────────
+
+  it("calls signInAnonymously and createAnonymousSession when currentUser is null", async () => {
+    (auth as any).currentUser = null;
+    const user = userEvent.setup();
+    render(<MultiPdfUploader creditCost={2} isAuthenticated={false} />);
+    addFiles([makeFile("a.pdf"), makeFile("b.pdf")]);
+    await waitFor(() => screen.getByText("a.pdf"));
+    await user.click(screen.getByRole("button", { name: /Merge PDFs/i }));
+    await waitFor(() => expect(mockSignInAnonymously).toHaveBeenCalled());
+    await waitFor(() => expect(createAnonymousSession).toHaveBeenCalledWith({ idToken: "anon-id-token" }));
+  });
+
+  it("does not call checkCredits for an anonymous user", async () => {
+    (auth as any).currentUser = null;
+    const user = userEvent.setup();
+    render(<MultiPdfUploader creditCost={2} isAuthenticated={false} />);
+    addFiles([makeFile("a.pdf"), makeFile("b.pdf")]);
+    await waitFor(() => screen.getByText("a.pdf"));
+    await user.click(screen.getByRole("button", { name: /Merge PDFs/i }));
+    await waitFor(() => expect(mergePdfs).toHaveBeenCalled());
+    expect(checkCredits).not.toHaveBeenCalled();
+  });
+
+  it("shows pending UI with sign-up and sign-in buttons when mergePdfs returns a claimToken", async () => {
+    mergePdfs.mockResolvedValue({ data: { data: { claimToken: "tok-abc" } }, error: null });
+    const user = userEvent.setup();
+    render(<MultiPdfUploader creditCost={2} isAuthenticated={false} />);
+    addFiles([makeFile("a.pdf"), makeFile("b.pdf")]);
+    await waitFor(() => screen.getByText("a.pdf"));
+    await user.click(screen.getByRole("button", { name: /Merge PDFs/i }));
+    await waitFor(() =>
+      expect(screen.getByRole("button", { name: /Sign up to download/i })).toBeInTheDocument(),
+    );
+    expect(screen.getByRole("button", { name: /Already have an account/i })).toBeInTheDocument();
+  });
+
+  it("stores the claimToken in sessionStorage and navigates to /signup when 'Sign up to download' is clicked", async () => {
+    mergePdfs.mockResolvedValue({ data: { data: { claimToken: "tok-abc" } }, error: null });
+    const user = userEvent.setup();
+    render(<MultiPdfUploader creditCost={2} isAuthenticated={false} />);
+    addFiles([makeFile("a.pdf"), makeFile("b.pdf")]);
+    await waitFor(() => screen.getByText("a.pdf"));
+    await user.click(screen.getByRole("button", { name: /Merge PDFs/i }));
+    await waitFor(() => screen.getByRole("button", { name: /Sign up to download/i }));
+    await user.click(screen.getByRole("button", { name: /Sign up to download/i }));
+    expect(globalThis.sessionStorage.setItem).toHaveBeenCalledWith("pendingClaimToken", "tok-abc");
+    expect(globalThis.location.href).toBe("/signup");
+  });
+
+  it("stores the claimToken and navigates to /signin when 'Already have an account?' is clicked", async () => {
+    mergePdfs.mockResolvedValue({ data: { data: { claimToken: "tok-abc" } }, error: null });
+    const user = userEvent.setup();
+    render(<MultiPdfUploader creditCost={2} isAuthenticated={false} />);
+    addFiles([makeFile("a.pdf"), makeFile("b.pdf")]);
+    await waitFor(() => screen.getByText("a.pdf"));
+    await user.click(screen.getByRole("button", { name: /Merge PDFs/i }));
+    await waitFor(() => screen.getByRole("button", { name: /Already have an account/i }));
+    await user.click(screen.getByRole("button", { name: /Already have an account/i }));
+    expect(globalThis.sessionStorage.setItem).toHaveBeenCalledWith("pendingClaimToken", "tok-abc");
+    expect(globalThis.location.href).toBe("/signin");
+  });
+
+  it("shows an error when createAnonymousSession fails", async () => {
+    (auth as any).currentUser = null;
+    createAnonymousSession.mockResolvedValue({ data: { success: false, error: "Session error" }, error: null });
+    const user = userEvent.setup();
+    render(<MultiPdfUploader creditCost={2} isAuthenticated={false} />);
+    addFiles([makeFile("a.pdf"), makeFile("b.pdf")]);
+    await waitFor(() => screen.getByText("a.pdf"));
+    await user.click(screen.getByRole("button", { name: /Merge PDFs/i }));
+    await waitFor(() =>
+      expect(screen.getByRole("alert")).toHaveTextContent(/Failed to start session/i),
+    );
+    expect(mergePdfs).not.toHaveBeenCalled();
+  });
+
+  it("shows an error when createAnonymousSession throws", async () => {
+    (auth as any).currentUser = null;
+    createAnonymousSession.mockRejectedValue(new Error("Network error"));
+    const user = userEvent.setup();
+    render(<MultiPdfUploader creditCost={2} isAuthenticated={false} />);
+    addFiles([makeFile("a.pdf"), makeFile("b.pdf")]);
+    await waitFor(() => screen.getByText("a.pdf"));
+    await user.click(screen.getByRole("button", { name: /Merge PDFs/i }));
+    await waitFor(() =>
+      expect(screen.getByRole("alert")).toHaveTextContent(/Failed to start session/i),
+    );
+    expect(mergePdfs).not.toHaveBeenCalled();
+  });
+
+  it("shows an error when signInAnonymously throws", async () => {
+    (auth as any).currentUser = null;
+    mockSignInAnonymously.mockRejectedValue(new Error("Auth failed"));
+    const user = userEvent.setup();
+    render(<MultiPdfUploader creditCost={2} isAuthenticated={false} />);
+    addFiles([makeFile("a.pdf"), makeFile("b.pdf")]);
+    await waitFor(() => screen.getByText("a.pdf"));
+    await user.click(screen.getByRole("button", { name: /Merge PDFs/i }));
+    await waitFor(() =>
+      expect(screen.getByRole("alert")).toHaveTextContent(/Failed to start session/i),
+    );
   });
 });

--- a/apps/pdf-craft/src/components/slices/MultiPdfUploader/MultiPdfUploader.tsx
+++ b/apps/pdf-craft/src/components/slices/MultiPdfUploader/MultiPdfUploader.tsx
@@ -1,39 +1,81 @@
 'use client'
 import { useState } from "react"
 import { actions } from 'astro:actions'
+import { signInAnonymously } from 'firebase/auth'
 import {
   Container, Stack, Text, Button, FileDropzone, Callout, Card, Divider,
 } from '@fhdamd/threads'
 import * as Sentry from '@sentry/astro'
+import { auth } from '../../../firebase/client'
 import { logEvent } from '../../../utils/lib/analytics'
 import { DownloadIcon, DraggableFileList, ErrorCallout, INSUFFICIENT_CREDITS_ERROR, useDraggableFiles } from '../../shared'
 
 const MAX_FILES = 5
 
-export default function MultiPdfUploader({ creditCost }: { creditCost: number }) {
+export default function MultiPdfUploader({ creditCost, isAuthenticated = false }: { creditCost: number; isAuthenticated?: boolean }) {
   const { uploadedFiles, setUploadedFiles, error, setError, handleFiles, sensors, handleDragEnd, handleDelete } = useDraggableFiles(MAX_FILES)
-  const [isMerging, setIsMerging]         = useState(false)
-  const [downloadLink, setDownloadLink]   = useState<string | null>(null)
-  const [buttonLabel, setButtonLabel]     = useState('Merge PDFs')
+  const [isMerging, setIsMerging]       = useState(false)
+  const [downloadLink, setDownloadLink] = useState<string | null>(null)
+  const [claimToken, setClaimToken]     = useState<string | null>(null)
+  const [buttonLabel, setButtonLabel]   = useState('Merge PDFs')
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault()
     const requestId = crypto.randomUUID()
     const task = 'merge'
     setError(null)
-    setButtonLabel('Checking credits...')
     setIsMerging(true)
 
-    const response = await actions.credits.checkCredits({ task, requestId, creditCost })
-    if (!response.data?.success) {
-      setError(INSUFFICIENT_CREDITS_ERROR)
-      setButtonLabel('Merge PDFs')
-      setIsMerging(false)
-      return
+    const currentUser = auth.currentUser
+    const isAnon = !isAuthenticated
+
+    if (isAnon) {
+      setButtonLabel('Processing...')
+      if (!currentUser) {
+        let idToken: string
+        try {
+          const credential = await signInAnonymously(auth)
+          idToken = await credential.user.getIdToken()
+        } catch (err: any) {
+          console.error('[anon-auth] signInAnonymously failed:', err?.code, err?.message)
+          setError('Failed to start session. Please try again.')
+          setButtonLabel('Merge PDFs')
+          setIsMerging(false)
+          Sentry.captureException(err)
+          return
+        }
+        try {
+          const sessionRes = await actions.user.createAnonymousSession({ idToken })
+          if (!sessionRes.data?.success) {
+            console.error('[anon-auth] createAnonymousSession returned failure:', sessionRes.data?.error)
+            setError('Failed to start session. Please try again.')
+            setButtonLabel('Merge PDFs')
+            setIsMerging(false)
+            return
+          }
+        } catch (err) {
+          console.error('[anon-auth] createAnonymousSession threw:', err)
+          setError('Failed to start session. Please try again.')
+          setButtonLabel('Merge PDFs')
+          setIsMerging(false)
+          Sentry.captureException(err)
+          return
+        }
+      }
+    } else {
+      setButtonLabel('Checking credits...')
+      const response = await actions.credits.checkCredits({ task, requestId, creditCost })
+      if (!response.data?.success) {
+        setError(INSUFFICIENT_CREDITS_ERROR)
+        setButtonLabel('Merge PDFs')
+        setIsMerging(false)
+        return
+      }
     }
 
     logEvent('pdf_operation_started', { operation_type: task, file_count: uploadedFiles.length })
     setButtonLabel('Merging PDFs...')
+
     const formData = new FormData()
     uploadedFiles.forEach(file => formData.append('files', file))
     formData.append('requestId', requestId)
@@ -44,7 +86,12 @@ export default function MultiPdfUploader({ creditCost }: { creditCost: number })
       const mergeResponse = await actions.operations.mergePdfs(formData)
       if (mergeResponse.data) {
         logEvent('pdf_operation_completed', { operation_type: task, file_count: uploadedFiles.length })
-        setDownloadLink(mergeResponse.data?.data?.fileUrl || null)
+        const token = mergeResponse.data?.data?.claimToken
+        if (token) {
+          setClaimToken(token)
+        } else {
+          setDownloadLink(mergeResponse.data?.data?.fileUrl || null)
+        }
       } else if (mergeResponse.error) {
         logEvent('pdf_operation_failed', { operation_type: task })
         setError(
@@ -57,7 +104,6 @@ export default function MultiPdfUploader({ creditCost }: { creditCost: number })
     } catch (err) {
       logEvent('pdf_operation_failed', { operation_type: task })
       setError('An unexpected error occurred. Please try again.')
-      console.error('Error merging PDFs:', err)
       Sentry.captureException(err)
     } finally {
       setButtonLabel('Merge PDFs')
@@ -65,8 +111,18 @@ export default function MultiPdfUploader({ creditCost }: { creditCost: number })
     }
   }
 
-  const reset = () => { setDownloadLink(null); setUploadedFiles([]); setError(null) }
+  const reset = () => { setDownloadLink(null); setClaimToken(null); setUploadedFiles([]); setError(null) }
   const atLimit = uploadedFiles.length >= MAX_FILES
+
+  const goToSignup = () => {
+    if (claimToken) sessionStorage.setItem('pendingClaimToken', claimToken)
+    window.location.href = '/signup'
+  }
+
+  const goToSignin = () => {
+    if (claimToken) sessionStorage.setItem('pendingClaimToken', claimToken)
+    window.location.href = '/signin'
+  }
 
   return (
     <Container>
@@ -83,7 +139,17 @@ export default function MultiPdfUploader({ creditCost }: { creditCost: number })
         <Card variant="elevated">
           <Stack gap={5} style={{ padding: 'var(--th-space-6)' }}>
 
-            {downloadLink ? (
+            {claimToken ? (
+              <Stack gap={4} align="center" style={{ paddingBlock: 'var(--th-space-4)' }}>
+                <Callout variant="success" title="Merge complete">
+                  Create a free account to download your merged PDF — no credit card required.
+                </Callout>
+                <div style={{ display: 'flex', gap: 'var(--th-space-3)', flexWrap: 'wrap' }}>
+                  <Button variant="solid-terra" onClick={goToSignup}>Sign up to download</Button>
+                  <Button variant="ghost" onClick={goToSignin}>Already have an account?</Button>
+                </div>
+              </Stack>
+            ) : downloadLink ? (
               <Stack gap={4} align="center" style={{ paddingBlock: 'var(--th-space-4)' }}>
                 <Callout variant="success" title="Merge complete">
                   Your PDFs have been combined into a single file.

--- a/apps/pdf-craft/src/components/slices/MultiPdfUploader/MultiPdfUploader.tsx
+++ b/apps/pdf-craft/src/components/slices/MultiPdfUploader/MultiPdfUploader.tsx
@@ -12,12 +12,47 @@ import { DownloadIcon, DraggableFileList, ErrorCallout, INSUFFICIENT_CREDITS_ERR
 
 const MAX_FILES = 5
 
-export default function MultiPdfUploader({ creditCost, isAuthenticated = false }: { creditCost: number; isAuthenticated?: boolean }) {
+export default function MultiPdfUploader({ creditCost, isAuthenticated = false }: { readonly creditCost: number; readonly isAuthenticated?: boolean }) {
   const { uploadedFiles, setUploadedFiles, error, setError, handleFiles, sensors, handleDragEnd, handleDelete } = useDraggableFiles(MAX_FILES)
   const [isMerging, setIsMerging]       = useState(false)
   const [downloadLink, setDownloadLink] = useState<string | null>(null)
   const [claimToken, setClaimToken]     = useState<string | null>(null)
   const [buttonLabel, setButtonLabel]   = useState('Merge PDFs')
+
+  const prepareSession = async (task: string, requestId: string): Promise<boolean> => {
+    if (!isAuthenticated) {
+      setButtonLabel('Processing...')
+      if (!auth.currentUser) {
+        try {
+          const credential = await signInAnonymously(auth)
+          const idToken = await credential.user.getIdToken()
+          const sessionRes = await actions.user.createAnonymousSession({ idToken })
+          if (!sessionRes.data?.success) {
+            setError('Failed to start session. Please try again.')
+            setButtonLabel('Merge PDFs')
+            setIsMerging(false)
+            return false
+          }
+        } catch (err) {
+          setError('Failed to start session. Please try again.')
+          setButtonLabel('Merge PDFs')
+          setIsMerging(false)
+          Sentry.captureException(err)
+          return false
+        }
+      }
+      return true
+    }
+    setButtonLabel('Checking credits...')
+    const response = await actions.credits.checkCredits({ task, requestId, creditCost })
+    if (!response.data?.success) {
+      setError(INSUFFICIENT_CREDITS_ERROR)
+      setButtonLabel('Merge PDFs')
+      setIsMerging(false)
+      return false
+    }
+    return true
+  }
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault()
@@ -26,52 +61,7 @@ export default function MultiPdfUploader({ creditCost, isAuthenticated = false }
     setError(null)
     setIsMerging(true)
 
-    const currentUser = auth.currentUser
-    const isAnon = !isAuthenticated
-
-    if (isAnon) {
-      setButtonLabel('Processing...')
-      if (!currentUser) {
-        let idToken: string
-        try {
-          const credential = await signInAnonymously(auth)
-          idToken = await credential.user.getIdToken()
-        } catch (err: any) {
-          console.error('[anon-auth] signInAnonymously failed:', err?.code, err?.message)
-          setError('Failed to start session. Please try again.')
-          setButtonLabel('Merge PDFs')
-          setIsMerging(false)
-          Sentry.captureException(err)
-          return
-        }
-        try {
-          const sessionRes = await actions.user.createAnonymousSession({ idToken })
-          if (!sessionRes.data?.success) {
-            console.error('[anon-auth] createAnonymousSession returned failure:', sessionRes.data?.error)
-            setError('Failed to start session. Please try again.')
-            setButtonLabel('Merge PDFs')
-            setIsMerging(false)
-            return
-          }
-        } catch (err) {
-          console.error('[anon-auth] createAnonymousSession threw:', err)
-          setError('Failed to start session. Please try again.')
-          setButtonLabel('Merge PDFs')
-          setIsMerging(false)
-          Sentry.captureException(err)
-          return
-        }
-      }
-    } else {
-      setButtonLabel('Checking credits...')
-      const response = await actions.credits.checkCredits({ task, requestId, creditCost })
-      if (!response.data?.success) {
-        setError(INSUFFICIENT_CREDITS_ERROR)
-        setButtonLabel('Merge PDFs')
-        setIsMerging(false)
-        return
-      }
-    }
+    if (!await prepareSession(task, requestId)) return
 
     logEvent('pdf_operation_started', { operation_type: task, file_count: uploadedFiles.length })
     setButtonLabel('Merging PDFs...')
@@ -116,18 +106,80 @@ export default function MultiPdfUploader({ creditCost, isAuthenticated = false }
 
   const goToSignup = () => {
     if (claimToken) sessionStorage.setItem('pendingClaimToken', claimToken)
-    window.location.href = '/signup'
+    globalThis.location.href = '/signup'
   }
 
   const goToSignin = () => {
     if (claimToken) sessionStorage.setItem('pendingClaimToken', claimToken)
-    window.location.href = '/signin'
+    globalThis.location.href = '/signin'
+  }
+
+  const renderContent = () => {
+    if (claimToken) return (
+      <Stack gap={4} align="center" style={{ paddingBlock: 'var(--th-space-4)' }}>
+        <Callout variant="success" title="Merge complete">
+          Create a free account to download your merged PDF — no credit card required.
+        </Callout>
+        <div style={{ display: 'flex', gap: 'var(--th-space-3)', flexWrap: 'wrap' }}>
+          <Button variant="solid-terra" onClick={goToSignup}>Sign up to download</Button>
+          <Button variant="ghost" onClick={goToSignin}>Already have an account?</Button>
+        </div>
+      </Stack>
+    )
+    if (downloadLink) return (
+      <Stack gap={4} align="center" style={{ paddingBlock: 'var(--th-space-4)' }}>
+        <Callout variant="success" title="Merge complete">
+          Your PDFs have been combined into a single file.
+        </Callout>
+        <div style={{ display: 'flex', gap: 'var(--th-space-3)', flexWrap: 'wrap' }}>
+          <Button href={downloadLink} variant="solid-terra" icon={<DownloadIcon />}>
+            Download merged PDF
+          </Button>
+          <Button variant="ghost" onClick={reset}>Merge more PDFs</Button>
+        </div>
+      </Stack>
+    )
+    return (
+      <>
+        {!atLimit ? (
+          <FileDropzone
+            label="Upload PDFs"
+            hint={`Drag and drop or click to browse — PDF files only, up to ${MAX_FILES} (${uploadedFiles.length}/${MAX_FILES} added)`}
+            accept="application/pdf"
+            multiple
+            onFiles={handleFiles}
+          />
+        ) : (
+          <Callout variant="info">
+            Maximum of {MAX_FILES} files reached. Remove a file to add another.
+          </Callout>
+        )}
+        {uploadedFiles.length > 0 && (
+          <>
+            <Divider />
+            <Stack gap={3}>
+              <Stack gap={1}>
+                <Text size="sm" color="1" weight={600}>Files to merge ({uploadedFiles.length})</Text>
+                <Text size="xs" color="2">Drag to reorder — files will be merged top to bottom</Text>
+              </Stack>
+              <DraggableFileList files={uploadedFiles} sensors={sensors} onDragEnd={handleDragEnd} onDelete={handleDelete} />
+            </Stack>
+            {error && <ErrorCallout message={error} />}
+            <form onSubmit={handleSubmit}>
+              <Button type="submit" variant="solid-terra" disabled={isMerging || uploadedFiles.length < 2}>
+                {buttonLabel}
+              </Button>
+            </form>
+          </>
+        )}
+        {error && uploadedFiles.length === 0 && <ErrorCallout message={error} />}
+      </>
+    )
   }
 
   return (
     <Container>
       <Stack gap={6} style={{ paddingBlock: 'var(--th-space-8)' }}>
-
         <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', flexWrap: 'wrap', gap: 'var(--th-space-3)' }}>
           <Stack gap={1}>
             <Text as="h1" size="2xl" color="1" weight={650} width={90}>Merge PDFs</Text>
@@ -135,80 +187,11 @@ export default function MultiPdfUploader({ creditCost, isAuthenticated = false }
           </Stack>
           <Button href="/dashboard" variant="ghost" size="sm">Back to dashboard</Button>
         </div>
-
         <Card variant="elevated">
           <Stack gap={5} style={{ padding: 'var(--th-space-6)' }}>
-
-            {claimToken ? (
-              <Stack gap={4} align="center" style={{ paddingBlock: 'var(--th-space-4)' }}>
-                <Callout variant="success" title="Merge complete">
-                  Create a free account to download your merged PDF — no credit card required.
-                </Callout>
-                <div style={{ display: 'flex', gap: 'var(--th-space-3)', flexWrap: 'wrap' }}>
-                  <Button variant="solid-terra" onClick={goToSignup}>Sign up to download</Button>
-                  <Button variant="ghost" onClick={goToSignin}>Already have an account?</Button>
-                </div>
-              </Stack>
-            ) : downloadLink ? (
-              <Stack gap={4} align="center" style={{ paddingBlock: 'var(--th-space-4)' }}>
-                <Callout variant="success" title="Merge complete">
-                  Your PDFs have been combined into a single file.
-                </Callout>
-                <div style={{ display: 'flex', gap: 'var(--th-space-3)', flexWrap: 'wrap' }}>
-                  <Button href={downloadLink} variant="solid-terra" icon={<DownloadIcon />}>
-                    Download merged PDF
-                  </Button>
-                  <Button variant="ghost" onClick={reset}>Merge more PDFs</Button>
-                </div>
-              </Stack>
-            ) : (
-              <>
-                {!atLimit ? (
-                  <FileDropzone
-                    label="Upload PDFs"
-                    hint={`Drag and drop or click to browse — PDF files only, up to ${MAX_FILES} (${uploadedFiles.length}/${MAX_FILES} added)`}
-                    accept="application/pdf"
-                    multiple
-                    onFiles={handleFiles}
-                  />
-                ) : (
-                  <Callout variant="info">
-                    Maximum of {MAX_FILES} files reached. Remove a file to add another.
-                  </Callout>
-                )}
-
-                {uploadedFiles.length > 0 && (
-                  <>
-                    <Divider />
-                    <Stack gap={3}>
-                      <Stack gap={1}>
-                        <Text size="sm" color="1" weight={600}>Files to merge ({uploadedFiles.length})</Text>
-                        <Text size="xs" color="2">Drag to reorder — files will be merged top to bottom</Text>
-                      </Stack>
-                      <DraggableFileList files={uploadedFiles} sensors={sensors} onDragEnd={handleDragEnd} onDelete={handleDelete} />
-                    </Stack>
-
-                    {error && <ErrorCallout message={error} />}
-
-                    <form onSubmit={handleSubmit}>
-                      <Button
-                        type="submit"
-                        variant="solid-terra"
-                        disabled={isMerging || uploadedFiles.length < 2}
-                      >
-                        {buttonLabel}
-                      </Button>
-                    </form>
-                  </>
-                )}
-
-                {error && uploadedFiles.length === 0 && <ErrorCallout message={error} />}
-              </>
-            )}
-
+            {renderContent()}
           </Stack>
         </Card>
-
       </Stack>
     </Container>
   )

--- a/apps/pdf-craft/src/components/slices/MultiPdfUploader/MultiPdfUploader.tsx
+++ b/apps/pdf-craft/src/components/slices/MultiPdfUploader/MultiPdfUploader.tsx
@@ -1,14 +1,12 @@
 'use client'
 import { useState } from "react"
 import { actions } from 'astro:actions'
-import { signInAnonymously } from 'firebase/auth'
 import {
   Container, Stack, Text, Button, FileDropzone, Callout, Card, Divider,
 } from '@fhdamd/threads'
-import * as Sentry from '@sentry/astro'
-import { auth } from '../../../firebase/client'
 import { logEvent } from '../../../utils/lib/analytics'
-import { DownloadIcon, DraggableFileList, ErrorCallout, INSUFFICIENT_CREDITS_ERROR, useDraggableFiles } from '../../shared'
+import { buildPrepareSession } from '../../../utils/lib/operationSession'
+import { DownloadIcon, DraggableFileList, ErrorCallout, useDraggableFiles } from '../../shared'
 
 const MAX_FILES = 5
 
@@ -19,40 +17,10 @@ export default function MultiPdfUploader({ creditCost, isAuthenticated = false }
   const [claimToken, setClaimToken]     = useState<string | null>(null)
   const [buttonLabel, setButtonLabel]   = useState('Merge PDFs')
 
-  const prepareSession = async (task: string, requestId: string): Promise<boolean> => {
-    if (!isAuthenticated) {
-      setButtonLabel('Processing...')
-      if (!auth.currentUser) {
-        try {
-          const credential = await signInAnonymously(auth)
-          const idToken = await credential.user.getIdToken()
-          const sessionRes = await actions.user.createAnonymousSession({ idToken })
-          if (!sessionRes.data?.success) {
-            setError('Failed to start session. Please try again.')
-            setButtonLabel('Merge PDFs')
-            setIsMerging(false)
-            return false
-          }
-        } catch (err) {
-          setError('Failed to start session. Please try again.')
-          setButtonLabel('Merge PDFs')
-          setIsMerging(false)
-          Sentry.captureException(err)
-          return false
-        }
-      }
-      return true
-    }
-    setButtonLabel('Checking credits...')
-    const response = await actions.credits.checkCredits({ task, requestId, creditCost })
-    if (!response.data?.success) {
-      setError(INSUFFICIENT_CREDITS_ERROR)
-      setButtonLabel('Merge PDFs')
-      setIsMerging(false)
-      return false
-    }
-    return true
-  }
+  const prepareSession = buildPrepareSession({
+    isAuthenticated, creditCost, defaultLabel: 'Merge PDFs',
+    setButtonLabel, setError: (e) => setError(e), setProcessing: setIsMerging,
+  })
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault()

--- a/apps/pdf-craft/src/components/slices/UserFileList/UserFileList.test.tsx
+++ b/apps/pdf-craft/src/components/slices/UserFileList/UserFileList.test.tsx
@@ -1,6 +1,15 @@
-import { describe, it, expect } from "vitest";
-import { render, screen } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import UserFileList from "./UserFileList";
+import { claimFile } from "../../../test/mocks/astro-actions";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  claimFile.mockResolvedValue({ data: { success: true, payload: { downloadUrl: "https://cdn.test/claimed.pdf" } } });
+  vi.stubGlobal("open", vi.fn());
+  vi.stubGlobal("location", { href: "" });
+});
 
 const makeDate = (iso = "2024-01-15T10:00:00Z") => ({ toDate: () => new Date(iso) });
 
@@ -68,5 +77,65 @@ describe("UserFileList", () => {
   it("falls back to the raw operation string for unknown operation keys", () => {
     render(<UserFileList files={[makeFile({ operation: "unknown-op" })]} />);
     expect(screen.getByText("unknown-op")).toBeInTheDocument();
+  });
+
+  // ── Pending / migrated file download flow ────────────────────────────────
+
+  it("shows a credit-cost button for a pending file instead of a direct link", () => {
+    render(<UserFileList files={[makeFile({ status: "pending", creditCost: 2 })]} />);
+    expect(screen.getByRole("button", { name: /Download — 2 credits/i })).toBeInTheDocument();
+    expect(screen.queryByRole("link", { name: /Download/ })).not.toBeInTheDocument();
+  });
+
+  it("shows a credit-cost button for a migrated file", () => {
+    render(<UserFileList files={[makeFile({ status: "migrated", creditCost: 3 })]} />);
+    expect(screen.getByRole("button", { name: /Download — 3 credits/i })).toBeInTheDocument();
+  });
+
+  it("uses singular 'credit' label when creditCost is 1", () => {
+    render(<UserFileList files={[makeFile({ status: "pending", creditCost: 1 })]} />);
+    expect(screen.getByRole("button", { name: /Download — 1 credit$/i })).toBeInTheDocument();
+  });
+
+  it("calls claimFile with the file id when the credit button is clicked", async () => {
+    const user = userEvent.setup();
+    render(<UserFileList files={[makeFile({ id: "file-99", status: "pending", creditCost: 2 })]} />);
+    await user.click(screen.getByRole("button", { name: /Download — 2 credits/i }));
+    await waitFor(() => expect(claimFile).toHaveBeenCalledWith({ fileId: "file-99" }));
+  });
+
+  it("opens the download URL in a new tab on success", async () => {
+    const user = userEvent.setup();
+    render(<UserFileList files={[makeFile({ status: "pending", creditCost: 2 })]} />);
+    await user.click(screen.getByRole("button", { name: /Download — 2 credits/i }));
+    await waitFor(() => expect(globalThis.open).toHaveBeenCalledWith("https://cdn.test/claimed.pdf", "_blank"));
+  });
+
+  it("redirects to /buy-credits when claimFile returns Insufficient credits", async () => {
+    claimFile.mockResolvedValue({ data: { success: false, error: "Insufficient credits" } });
+    const user = userEvent.setup();
+    render(<UserFileList files={[makeFile({ status: "pending", creditCost: 2 })]} />);
+    await user.click(screen.getByRole("button", { name: /Download — 2 credits/i }));
+    await waitFor(() => expect(globalThis.location.href).toBe("/buy-credits"));
+  });
+
+  it("shows an inline error when claimFile returns a non-credits failure", async () => {
+    claimFile.mockResolvedValue({ data: { success: false, error: "File not found" } });
+    const user = userEvent.setup();
+    render(<UserFileList files={[makeFile({ status: "pending", creditCost: 2 })]} />);
+    await user.click(screen.getByRole("button", { name: /Download — 2 credits/i }));
+    await waitFor(() => expect(screen.getByText("File not found")).toBeInTheDocument());
+  });
+
+  it("shows a regular download link for a ready file (status: ready)", () => {
+    render(<UserFileList files={[makeFile({ status: "ready", fileUrl: "https://cdn.test/ready.pdf" })]} />);
+    expect(screen.getByRole("link", { name: /Download/ })).toHaveAttribute("href", "https://cdn.test/ready.pdf");
+    expect(screen.queryByRole("button", { name: /credits/i })).not.toBeInTheDocument();
+  });
+
+  it("shows a regular download link when status is undefined (legacy file)", () => {
+    const { status: _omit, ...fileWithoutStatus } = makeFile({ fileUrl: "https://cdn.test/legacy.pdf" });
+    render(<UserFileList files={[fileWithoutStatus]} />);
+    expect(screen.getByRole("link", { name: /Download/ })).toBeInTheDocument();
   });
 });

--- a/apps/pdf-craft/src/components/slices/UserFileList/UserFileList.tsx
+++ b/apps/pdf-craft/src/components/slices/UserFileList/UserFileList.tsx
@@ -27,8 +27,8 @@ interface FileRow extends Record<string, unknown> {
 }
 
 interface UserFileListProps {
-  files?: any[]
-  mode?: string
+  readonly files?: any[]
+  readonly mode?: string
 }
 
 function DownloadCell({ row }: { row: FileRow }) {
@@ -66,11 +66,11 @@ function DownloadCell({ row }: { row: FileRow }) {
     try {
       const res = await actions.claims.claimFile({ fileId: row.id })
       if (res.data?.success && res.data.payload?.downloadUrl) {
-        window.open(res.data.payload.downloadUrl, '_blank')
+        globalThis.open(res.data.payload.downloadUrl, '_blank')
       } else {
         const msg = res.data?.error ?? 'Failed to download'
         if (msg === 'Insufficient credits') {
-          window.location.href = '/buy-credits'
+          globalThis.location.href = '/buy-credits'
         } else {
           setError(msg)
         }

--- a/apps/pdf-craft/src/components/slices/UserFileList/UserFileList.tsx
+++ b/apps/pdf-craft/src/components/slices/UserFileList/UserFileList.tsx
@@ -31,7 +31,7 @@ interface UserFileListProps {
   readonly mode?: string
 }
 
-function DownloadCell({ row }: { row: FileRow }) {
+function DownloadCell({ row }: { readonly row: FileRow }) {
   const [loading, setLoading] = useState(false)
   const [error, setError]     = useState<string | null>(null)
 
@@ -101,7 +101,7 @@ function DownloadCell({ row }: { row: FileRow }) {
           textUnderlineOffset: '3px',
         }}
       >
-        {loading ? 'Processing…' : `Download — ${row.creditCost} credit${row.creditCost === 1 ? '' : 's'}`}
+        {loading ? 'Processing…' : `Download — ${row.creditCost} ${row.creditCost === 1 ? 'credit' : 'credits'}`}
       </button>
       {error && (
         <span style={{ color: 'var(--th-color-error)', fontSize: 'var(--th-text-xs)' }}>

--- a/apps/pdf-craft/src/components/slices/UserFileList/UserFileList.tsx
+++ b/apps/pdf-craft/src/components/slices/UserFileList/UserFileList.tsx
@@ -1,10 +1,13 @@
+'use client'
+import { useState } from 'react'
+import { actions } from 'astro:actions'
 import { DataTable, Badge, type DataTableColumn, type BadgeVariant } from '@fhdamd/threads'
 
 const OP_META: Record<string, { label: string; variant: BadgeVariant }> = {
-  'merge':       { label: 'Merge',       variant: 'terra'   },
-  'image-to-pdf':{ label: 'Image to PDF',variant: 'sage'    },
-  'encrypt':     { label: 'Protect',     variant: 'info'    },
-  'decrypt':     { label: 'Unlock',      variant: 'neutral' },
+  'merge':        { label: 'Merge',        variant: 'terra'   },
+  'image-to-pdf': { label: 'Image to PDF', variant: 'sage'    },
+  'encrypt':      { label: 'Protect',      variant: 'info'    },
+  'decrypt':      { label: 'Unlock',       variant: 'neutral' },
 }
 
 function OperationBadge({ op }: { op: string }) {
@@ -19,6 +22,8 @@ interface FileRow extends Record<string, unknown> {
   createdAt: string
   fileUrl: string
   expiresAt: string
+  status: string
+  creditCost: number
 }
 
 interface UserFileListProps {
@@ -26,14 +31,97 @@ interface UserFileListProps {
   mode?: string
 }
 
+function DownloadCell({ row }: { row: FileRow }) {
+  const [loading, setLoading] = useState(false)
+  const [error, setError]     = useState<string | null>(null)
+
+  const isPending = row.status === 'pending' || row.status === 'migrated'
+
+  if (!isPending) {
+    return (
+      <a
+        href={row.fileUrl}
+        target="_blank"
+        rel="noopener noreferrer"
+        style={{
+          display: 'inline-flex',
+          alignItems: 'center',
+          gap: '6px',
+          color: 'var(--th-color-accent-text)',
+          fontSize: 'var(--th-text-sm)',
+          textDecoration: 'none',
+        }}
+        onMouseEnter={e => (e.currentTarget.style.textDecoration = 'underline')}
+        onMouseLeave={e => (e.currentTarget.style.textDecoration = 'none')}
+      >
+        <img src="/icons/icon-download.svg" alt="" width={14} height={14} />
+        Download
+      </a>
+    )
+  }
+
+  const handleClaim = async () => {
+    setLoading(true)
+    setError(null)
+    try {
+      const res = await actions.claims.claimFile({ fileId: row.id })
+      if (res.data?.success && res.data.payload?.downloadUrl) {
+        window.open(res.data.payload.downloadUrl, '_blank')
+      } else {
+        const msg = res.data?.error ?? 'Failed to download'
+        if (msg === 'Insufficient credits') {
+          window.location.href = '/buy-credits'
+        } else {
+          setError(msg)
+        }
+      }
+    } catch {
+      setError('An error occurred. Please try again.')
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: '4px' }}>
+      <button
+        onClick={handleClaim}
+        disabled={loading}
+        style={{
+          display: 'inline-flex',
+          alignItems: 'center',
+          gap: '6px',
+          background: 'none',
+          border: 'none',
+          padding: 0,
+          cursor: loading ? 'wait' : 'pointer',
+          color: 'var(--th-color-accent-text)',
+          fontSize: 'var(--th-text-sm)',
+          textDecoration: 'underline',
+          textUnderlineOffset: '3px',
+        }}
+      >
+        {loading ? 'Processing…' : `Download — ${row.creditCost} credit${row.creditCost === 1 ? '' : 's'}`}
+      </button>
+      {error && (
+        <span style={{ color: 'var(--th-color-error)', fontSize: 'var(--th-text-xs)' }}>
+          {error}
+        </span>
+      )}
+    </div>
+  )
+}
+
 export default function UserFileList({ files = [], mode }: UserFileListProps) {
   const rows: FileRow[] = files.map(file => ({
-    id:        file.id,
-    fileName:  file.fileName,
-    operation: file.operation as string,
-    createdAt: file.createdAt.toDate().toLocaleString(),
-    fileUrl:   file.fileUrl ?? '',
-    expiresAt: file.expiresAt ? file.expiresAt.toDate().toLocaleString() : '',
+    id:         file.id,
+    fileName:   file.fileName,
+    operation:  file.operation as string,
+    createdAt:  file.createdAt?.toDate?.()?.toLocaleString?.() ?? '—',
+    fileUrl:    file.fileUrl ?? '',
+    expiresAt:  file.expiresAt?.toDate?.()?.toLocaleString?.() ?? '',
+    status:     file.status ?? 'ready',
+    creditCost: file.creditCost ?? 0,
   }))
 
   const columns: DataTableColumn<FileRow>[] = [
@@ -44,7 +132,7 @@ export default function UserFileList({ files = [], mode }: UserFileListProps) {
       sortable: true,
       render: (row) => <OperationBadge op={row.operation} />,
     },
-    { key: 'createdAt', header: 'Created At',  sortable: true },
+    { key: 'createdAt', header: 'Created At', sortable: true },
     {
       key: 'fileUrl',
       header: mode === 'trash' ? 'Expires At' : 'Actions',
@@ -54,24 +142,7 @@ export default function UserFileList({ files = [], mode }: UserFileListProps) {
             {row.expiresAt}
           </span>
         ) : (
-          <a
-            href={row.fileUrl}
-            target="_blank"
-            rel="noopener noreferrer"
-            style={{
-              display: 'inline-flex',
-              alignItems: 'center',
-              gap: '6px',
-              color: 'var(--th-color-accent-text)',
-              fontSize: 'var(--th-text-sm)',
-              textDecoration: 'none',
-            }}
-            onMouseEnter={e => (e.currentTarget.style.textDecoration = 'underline')}
-            onMouseLeave={e => (e.currentTarget.style.textDecoration = 'none')}
-          >
-            <img src="/icons/icon-download.svg" alt="" width={14} height={14} />
-            Download
-          </a>
+          <DownloadCell row={row} />
         ),
     },
   ]

--- a/apps/pdf-craft/src/components/views/Dashboard/Dashboard.test.tsx
+++ b/apps/pdf-craft/src/components/views/Dashboard/Dashboard.test.tsx
@@ -91,4 +91,32 @@ describe("Dashboard", () => {
     await user.click(screen.getByRole("tab", { name: "History" }));
     expect(screen.getByRole("tab", { name: "History" })).toHaveAttribute("aria-selected", "true");
   });
+
+  it("still renders profile when files fetch throws", async () => {
+    (onAuthStateChanged as any).mockImplementation((_auth: any, callback: Function) => {
+      callback({ uid: "user-1" });
+      return () => {};
+    });
+    (getDocs as any).mockRejectedValue(new Error("permission-denied"));
+    (getDoc as any).mockResolvedValue({
+      exists: () => true,
+      data: () => ({ profile: { name: "Bob", credits: 5 } }),
+    });
+    render(<Dashboard operations={mockOperations} />);
+    await waitFor(() => expect(screen.getByText(/Welcome, Bob/)).toBeInTheDocument());
+    expect(screen.getByText(/5 credits remaining/i)).toBeInTheDocument();
+  });
+
+  it("still renders tabs when profile fetch throws", async () => {
+    (onAuthStateChanged as any).mockImplementation((_auth: any, callback: Function) => {
+      callback({ uid: "user-1" });
+      return () => {};
+    });
+    (getDocs as any).mockResolvedValue({ docs: [] });
+    (getDoc as any).mockRejectedValue(new Error("permission-denied"));
+    render(<Dashboard operations={mockOperations} />);
+    await waitFor(() => expect(screen.getByRole("tab", { name: "Files" })).toBeInTheDocument());
+    // Welcome without name when profile unavailable
+    expect(screen.getByText("Welcome")).toBeInTheDocument();
+  });
 });

--- a/apps/pdf-craft/src/components/views/Dashboard/Dashboard.tsx
+++ b/apps/pdf-craft/src/components/views/Dashboard/Dashboard.tsx
@@ -17,21 +17,26 @@ export default function Dashboard({ operations }: { operations: Operation[] }) {
   useEffect(() => {
     const unsubscribe = onAuthStateChanged(auth, async (user) => {
       if (user) {
+        // Fetch files and profile independently so a failure in one doesn't block the other
         try {
-          const filesRef  = collection(db, 'users', user.uid, 'files');
-          const snapshot  = await getDocs(filesRef);
+          const filesRef = collection(db, 'users', user.uid, 'files');
+          const snapshot = await getDocs(filesRef);
           setFiles(snapshot.docs.map(d => ({ id: d.id, ...d.data() })));
+        } catch (error) {
+          console.error('Error fetching files:', error);
+          Sentry.captureException(error);
+          setFiles([]);
+        }
 
-          const profileRef  = doc(db, 'users', user.uid);
-          const profileSnap = await getDoc(profileRef);
+        try {
+          const profileSnap = await getDoc(doc(db, 'users', user.uid));
           if (profileSnap.exists()) {
             const data = profileSnap.data();
             if (data.profile) setProfile(data.profile);
           }
         } catch (error) {
-          console.error('Error fetching dashboard data:', error);
+          console.error('Error fetching profile:', error);
           Sentry.captureException(error);
-          setFiles([]);
         }
       }
       setLoading(false);

--- a/apps/pdf-craft/src/components/views/DecryptPdf/DecryptPdf.test.tsx
+++ b/apps/pdf-craft/src/components/views/DecryptPdf/DecryptPdf.test.tsx
@@ -2,10 +2,18 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, screen, waitFor, fireEvent } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
+const mockSignInAnonymously = vi.fn();
+vi.mock("firebase/auth", () => ({
+  signInAnonymously: (...args: unknown[]) => mockSignInAnonymously(...args),
+}));
+
 vi.mock("../../../utils/lib/analytics", () => ({ logEvent: vi.fn() }));
 
 import DecryptPdf from "./DecryptPdf";
-import { checkCredits, decryptPdf } from "../../../test/mocks/astro-actions";
+import { checkCredits, decryptPdf, createAnonymousSession } from "../../../test/mocks/astro-actions";
+import { auth } from "../../../firebase/client";
+
+const mockAnonUser = { uid: "anon-uid", isAnonymous: true, getIdToken: vi.fn().mockResolvedValue("anon-token") };
 
 const pdfFile = new File(["pdf"], "locked.pdf", { type: "application/pdf" });
 
@@ -17,18 +25,23 @@ function selectFile(file = pdfFile) {
 
 beforeEach(() => {
   vi.clearAllMocks();
+  (auth as any).currentUser = { uid: "test-uid", isAnonymous: false };
   checkCredits.mockResolvedValue({ data: { success: true }, error: null });
   decryptPdf.mockResolvedValue({ data: { success: true, data: { fileUrl: "https://cdn.test/dec.pdf" } } });
+  createAnonymousSession.mockResolvedValue({ data: { success: true }, error: null });
+  mockSignInAnonymously.mockResolvedValue({ user: mockAnonUser });
+  vi.stubGlobal("sessionStorage", { getItem: vi.fn(() => null), setItem: vi.fn(), removeItem: vi.fn() });
+  vi.stubGlobal("location", { href: "" });
 });
 
 describe("DecryptPdf", () => {
   it("renders the file dropzone initially", () => {
-    render(<DecryptPdf creditCost={2} />);
+    render(<DecryptPdf creditCost={2} isAuthenticated />);
     expect(screen.getByTestId("file-input")).toBeInTheDocument();
   });
 
   it("shows file name and password form after file selection", async () => {
-    render(<DecryptPdf creditCost={2} />);
+    render(<DecryptPdf creditCost={2} isAuthenticated />);
     selectFile();
     await waitFor(() => expect(screen.getByText("locked.pdf")).toBeInTheDocument());
     expect(screen.getByLabelText("PDF password")).toBeInTheDocument();
@@ -36,7 +49,7 @@ describe("DecryptPdf", () => {
 
   it("removes the file when the remove button is clicked", async () => {
     const user = userEvent.setup();
-    render(<DecryptPdf creditCost={2} />);
+    render(<DecryptPdf creditCost={2} isAuthenticated />);
     selectFile();
     await waitFor(() => screen.getByText("locked.pdf"));
     await user.click(screen.getByRole("button", { name: /Remove file/i }));
@@ -46,7 +59,7 @@ describe("DecryptPdf", () => {
   it("shows insufficient credits error when checkCredits fails", async () => {
     checkCredits.mockResolvedValue({ data: { success: false } });
     const user = userEvent.setup();
-    render(<DecryptPdf creditCost={2} />);
+    render(<DecryptPdf creditCost={2} isAuthenticated />);
     selectFile();
     await waitFor(() => screen.getByLabelText("PDF password"));
     await user.type(screen.getByLabelText("PDF password"), "secret");
@@ -58,7 +71,7 @@ describe("DecryptPdf", () => {
 
   it("shows the download link after a successful decrypt", async () => {
     const user = userEvent.setup();
-    render(<DecryptPdf creditCost={2} />);
+    render(<DecryptPdf creditCost={2} isAuthenticated />);
     selectFile();
     await waitFor(() => screen.getByLabelText("PDF password"));
     await user.type(screen.getByLabelText("PDF password"), "secret");
@@ -74,7 +87,7 @@ describe("DecryptPdf", () => {
   it("shows an error callout when decryptPdf returns a failure", async () => {
     decryptPdf.mockResolvedValue({ data: { success: false, error: "Wrong password." } });
     const user = userEvent.setup();
-    render(<DecryptPdf creditCost={2} />);
+    render(<DecryptPdf creditCost={2} isAuthenticated />);
     selectFile();
     await waitFor(() => screen.getByLabelText("PDF password"));
     await user.type(screen.getByLabelText("PDF password"), "wrong");
@@ -82,5 +95,106 @@ describe("DecryptPdf", () => {
     await waitFor(() =>
       expect(screen.getByRole("alert")).toHaveTextContent("Wrong password."),
     );
+  });
+
+  // ── Anonymous user flow ───────────────────────────────────────────────────
+
+  it("shows an error when signInAnonymously throws", async () => {
+    (auth as any).currentUser = null;
+    mockSignInAnonymously.mockRejectedValue(new Error("Auth failed"));
+    const user = userEvent.setup();
+    render(<DecryptPdf creditCost={2} isAuthenticated={false} />);
+    selectFile();
+    await waitFor(() => screen.getByLabelText("PDF password"));
+    await user.type(screen.getByLabelText("PDF password"), "secret");
+    await user.click(screen.getByRole("button", { name: /Unlock PDF/i }));
+    await waitFor(() =>
+      expect(screen.getByRole("alert")).toHaveTextContent(/Failed to start session/i),
+    );
+    expect(checkCredits).not.toHaveBeenCalled();
+  });
+
+  it("shows an error when createAnonymousSession returns failure", async () => {
+    (auth as any).currentUser = null;
+    createAnonymousSession.mockResolvedValue({ data: { success: false }, error: null });
+    const user = userEvent.setup();
+    render(<DecryptPdf creditCost={2} isAuthenticated={false} />);
+    selectFile();
+    await waitFor(() => screen.getByLabelText("PDF password"));
+    await user.type(screen.getByLabelText("PDF password"), "secret");
+    await user.click(screen.getByRole("button", { name: /Unlock PDF/i }));
+    await waitFor(() =>
+      expect(screen.getByRole("alert")).toHaveTextContent(/Failed to start session/i),
+    );
+    expect(checkCredits).not.toHaveBeenCalled();
+  });
+
+  it("shows an error when createAnonymousSession throws", async () => {
+    (auth as any).currentUser = null;
+    createAnonymousSession.mockRejectedValue(new Error("Network error"));
+    const user = userEvent.setup();
+    render(<DecryptPdf creditCost={2} isAuthenticated={false} />);
+    selectFile();
+    await waitFor(() => screen.getByLabelText("PDF password"));
+    await user.type(screen.getByLabelText("PDF password"), "secret");
+    await user.click(screen.getByRole("button", { name: /Unlock PDF/i }));
+    await waitFor(() =>
+      expect(screen.getByRole("alert")).toHaveTextContent(/Failed to start session/i),
+    );
+  });
+
+  it("calls signInAnonymously and createAnonymousSession when currentUser is null", async () => {
+    (auth as any).currentUser = null;
+    const user = userEvent.setup();
+    render(<DecryptPdf creditCost={2} isAuthenticated={false} />);
+    selectFile();
+    await waitFor(() => screen.getByLabelText("PDF password"));
+    await user.type(screen.getByLabelText("PDF password"), "secret");
+    await user.click(screen.getByRole("button", { name: /Unlock PDF/i }));
+    await waitFor(() => expect(mockSignInAnonymously).toHaveBeenCalled());
+    expect(createAnonymousSession).toHaveBeenCalledWith({ idToken: "anon-token" });
+    expect(checkCredits).not.toHaveBeenCalled();
+  });
+
+  it("shows pending UI with sign-up/sign-in buttons when decryptPdf returns a claimToken", async () => {
+    decryptPdf.mockResolvedValue({ data: { success: true, data: { claimToken: "tok-xyz" } } });
+    const user = userEvent.setup();
+    render(<DecryptPdf creditCost={2} isAuthenticated={false} />);
+    selectFile();
+    await waitFor(() => screen.getByLabelText("PDF password"));
+    await user.type(screen.getByLabelText("PDF password"), "secret");
+    await user.click(screen.getByRole("button", { name: /Unlock PDF/i }));
+    await waitFor(() =>
+      expect(screen.getByRole("button", { name: /Sign up to download/i })).toBeInTheDocument(),
+    );
+    expect(screen.getByRole("button", { name: /Already have an account/i })).toBeInTheDocument();
+  });
+
+  it("stores claimToken and navigates to /signup on 'Sign up to download'", async () => {
+    decryptPdf.mockResolvedValue({ data: { success: true, data: { claimToken: "tok-xyz" } } });
+    const user = userEvent.setup();
+    render(<DecryptPdf creditCost={2} isAuthenticated={false} />);
+    selectFile();
+    await waitFor(() => screen.getByLabelText("PDF password"));
+    await user.type(screen.getByLabelText("PDF password"), "secret");
+    await user.click(screen.getByRole("button", { name: /Unlock PDF/i }));
+    await waitFor(() => screen.getByRole("button", { name: /Sign up to download/i }));
+    await user.click(screen.getByRole("button", { name: /Sign up to download/i }));
+    expect(globalThis.sessionStorage.setItem).toHaveBeenCalledWith("pendingClaimToken", "tok-xyz");
+    expect(globalThis.location.href).toBe("/signup");
+  });
+
+  it("stores claimToken and navigates to /signin on 'Already have an account?'", async () => {
+    decryptPdf.mockResolvedValue({ data: { success: true, data: { claimToken: "tok-xyz" } } });
+    const user = userEvent.setup();
+    render(<DecryptPdf creditCost={2} isAuthenticated={false} />);
+    selectFile();
+    await waitFor(() => screen.getByLabelText("PDF password"));
+    await user.type(screen.getByLabelText("PDF password"), "secret");
+    await user.click(screen.getByRole("button", { name: /Unlock PDF/i }));
+    await waitFor(() => screen.getByRole("button", { name: /Already have an account/i }));
+    await user.click(screen.getByRole("button", { name: /Already have an account/i }));
+    expect(globalThis.sessionStorage.setItem).toHaveBeenCalledWith("pendingClaimToken", "tok-xyz");
+    expect(globalThis.location.href).toBe("/signin");
   });
 });

--- a/apps/pdf-craft/src/components/views/DecryptPdf/DecryptPdf.tsx
+++ b/apps/pdf-craft/src/components/views/DecryptPdf/DecryptPdf.tsx
@@ -1,14 +1,12 @@
 'use client'
 import { useState } from 'react'
 import { actions } from 'astro:actions'
-import { signInAnonymously } from 'firebase/auth'
 import {
   Container, Stack, Text, Button, Input, FileDropzone, Callout, Card, Divider,
 } from '@fhdamd/threads'
-import * as Sentry from '@sentry/astro'
-import { auth } from '../../../firebase/client'
 import { logEvent } from '../../../utils/lib/analytics'
-import { XIcon, DownloadIcon, ErrorCallout, INSUFFICIENT_CREDITS_ERROR } from '../../shared'
+import { buildPrepareSession } from '../../../utils/lib/operationSession'
+import { XIcon, DownloadIcon, ErrorCallout } from '../../shared'
 
 export default function DecryptPdf({ creditCost, isAuthenticated = false }: { readonly creditCost: number; readonly isAuthenticated?: boolean }) {
   const [file, setFile]                 = useState<File | null>(null)
@@ -28,40 +26,10 @@ export default function DecryptPdf({ creditCost, isAuthenticated = false }: { re
     }
   }
 
-  const prepareSession = async (task: string, requestId: string): Promise<boolean> => {
-    if (!isAuthenticated) {
-      setButtonLabel('Processing...')
-      if (!auth.currentUser) {
-        try {
-          const credential = await signInAnonymously(auth)
-          const idToken = await credential.user.getIdToken()
-          const sessionRes = await actions.user.createAnonymousSession({ idToken })
-          if (!sessionRes.data?.success) {
-            setError('Failed to start session. Please try again.')
-            setButtonLabel('Unlock PDF')
-            setIsProcessing(false)
-            return false
-          }
-        } catch (err) {
-          setError('Failed to start session. Please try again.')
-          setButtonLabel('Unlock PDF')
-          setIsProcessing(false)
-          Sentry.captureException(err)
-          return false
-        }
-      }
-      return true
-    }
-    setButtonLabel('Checking credits...')
-    const creditsResponse = await actions.credits.checkCredits({ task, requestId, creditCost })
-    if (!creditsResponse.data?.success) {
-      setError(INSUFFICIENT_CREDITS_ERROR)
-      setButtonLabel('Unlock PDF')
-      setIsProcessing(false)
-      return false
-    }
-    return true
-  }
+  const prepareSession = buildPrepareSession({
+    isAuthenticated, creditCost, defaultLabel: 'Unlock PDF',
+    setButtonLabel, setError: (e) => setError(e), setProcessing: setIsProcessing,
+  })
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault()

--- a/apps/pdf-craft/src/components/views/DecryptPdf/DecryptPdf.tsx
+++ b/apps/pdf-craft/src/components/views/DecryptPdf/DecryptPdf.tsx
@@ -1,18 +1,21 @@
 'use client'
 import { useState } from 'react'
 import { actions } from 'astro:actions'
+import { signInAnonymously } from 'firebase/auth'
 import {
   Container, Stack, Text, Button, Input, FileDropzone, Callout, Card, Divider,
 } from '@fhdamd/threads'
 import * as Sentry from '@sentry/astro'
+import { auth } from '../../../firebase/client'
 import { logEvent } from '../../../utils/lib/analytics'
 import { XIcon, DownloadIcon, ErrorCallout, INSUFFICIENT_CREDITS_ERROR } from '../../shared'
 
-export default function DecryptPdf({ creditCost }: { creditCost: number }) {
+export default function DecryptPdf({ creditCost, isAuthenticated = false }: { creditCost: number; isAuthenticated?: boolean }) {
   const [file, setFile]                 = useState<File | null>(null)
   const [password, setPassword]         = useState('')
   const [isProcessing, setIsProcessing] = useState(false)
   const [downloadLink, setDownloadLink] = useState<string | null>(null)
+  const [claimToken, setClaimToken]     = useState<string | null>(null)
   const [error, setError]               = useState<string | null>(null)
   const [buttonLabel, setButtonLabel]   = useState('Unlock PDF')
 
@@ -20,6 +23,7 @@ export default function DecryptPdf({ creditCost }: { creditCost: number }) {
     if (files.length > 0) {
       setFile(files[0])
       setDownloadLink(null)
+      setClaimToken(null)
       setError(null)
     }
   }
@@ -31,19 +35,46 @@ export default function DecryptPdf({ creditCost }: { creditCost: number }) {
     const requestId = crypto.randomUUID()
     const task = 'pdf-decrypt'
     setError(null)
-    setButtonLabel('Checking credits...')
     setIsProcessing(true)
 
-    const creditsResponse = await actions.credits.checkCredits({ task, requestId, creditCost })
-    if (!creditsResponse.data?.success) {
-      setError(INSUFFICIENT_CREDITS_ERROR)
-      setButtonLabel('Unlock PDF')
-      setIsProcessing(false)
-      return
+    const currentUser = auth.currentUser
+    const isAnon = !isAuthenticated
+
+    if (isAnon) {
+      setButtonLabel('Processing...')
+      if (!currentUser) {
+        try {
+          const credential = await signInAnonymously(auth)
+          const idToken = await credential.user.getIdToken()
+          const sessionRes = await actions.user.createAnonymousSession({ idToken })
+          if (!sessionRes.data?.success) {
+            setError('Failed to start session. Please try again.')
+            setButtonLabel('Unlock PDF')
+            setIsProcessing(false)
+            return
+          }
+        } catch (err) {
+          setError('Failed to start session. Please try again.')
+          setButtonLabel('Unlock PDF')
+          setIsProcessing(false)
+          Sentry.captureException(err)
+          return
+        }
+      }
+    } else {
+      setButtonLabel('Checking credits...')
+      const creditsResponse = await actions.credits.checkCredits({ task, requestId, creditCost })
+      if (!creditsResponse.data?.success) {
+        setError(INSUFFICIENT_CREDITS_ERROR)
+        setButtonLabel('Unlock PDF')
+        setIsProcessing(false)
+        return
+      }
     }
 
     logEvent('pdf_operation_started', { operation_type: task })
     setButtonLabel('Unlocking...')
+
     const formData = new FormData()
     formData.append('file', file)
     formData.append('password', password)
@@ -55,7 +86,12 @@ export default function DecryptPdf({ creditCost }: { creditCost: number }) {
       const response = await actions.operations.decryptPdf(formData)
       if (response.data?.success) {
         logEvent('pdf_operation_completed', { operation_type: task })
-        setDownloadLink(response.data.data?.fileUrl || null)
+        const token = response.data.data?.claimToken
+        if (token) {
+          setClaimToken(token)
+        } else {
+          setDownloadLink(response.data.data?.fileUrl || null)
+        }
       } else {
         logEvent('pdf_operation_failed', { operation_type: task })
         setError(response.data?.error || 'Failed to unlock PDF.')
@@ -70,7 +106,17 @@ export default function DecryptPdf({ creditCost }: { creditCost: number }) {
     }
   }
 
-  const reset = () => { setDownloadLink(null); setFile(null); setPassword(''); setError(null) }
+  const reset = () => { setDownloadLink(null); setClaimToken(null); setFile(null); setPassword(''); setError(null) }
+
+  const goToSignup = () => {
+    if (claimToken) sessionStorage.setItem('pendingClaimToken', claimToken)
+    window.location.href = '/signup'
+  }
+
+  const goToSignin = () => {
+    if (claimToken) sessionStorage.setItem('pendingClaimToken', claimToken)
+    window.location.href = '/signin'
+  }
 
   return (
     <Container>
@@ -87,7 +133,17 @@ export default function DecryptPdf({ creditCost }: { creditCost: number }) {
         <Card variant="elevated">
           <Stack gap={5} style={{ padding: 'var(--th-space-6)' }}>
 
-            {downloadLink ? (
+            {claimToken ? (
+              <Stack gap={4} align="center" style={{ paddingBlock: 'var(--th-space-4)' }}>
+                <Callout variant="success" title="Your PDF is unlocked">
+                  Create a free account to download it — no credit card required.
+                </Callout>
+                <div style={{ display: 'flex', gap: 'var(--th-space-3)', flexWrap: 'wrap' }}>
+                  <Button variant="solid-terra" onClick={goToSignup}>Sign up to download</Button>
+                  <Button variant="ghost" onClick={goToSignin}>Already have an account?</Button>
+                </div>
+              </Stack>
+            ) : downloadLink ? (
               <Stack gap={4} align="center" style={{ paddingBlock: 'var(--th-space-4)' }}>
                 <Callout variant="success" title="Your PDF is unlocked">
                   The password protection has been removed successfully.

--- a/apps/pdf-craft/src/components/views/DecryptPdf/DecryptPdf.tsx
+++ b/apps/pdf-craft/src/components/views/DecryptPdf/DecryptPdf.tsx
@@ -10,7 +10,7 @@ import { auth } from '../../../firebase/client'
 import { logEvent } from '../../../utils/lib/analytics'
 import { XIcon, DownloadIcon, ErrorCallout, INSUFFICIENT_CREDITS_ERROR } from '../../shared'
 
-export default function DecryptPdf({ creditCost, isAuthenticated = false }: { creditCost: number; isAuthenticated?: boolean }) {
+export default function DecryptPdf({ creditCost, isAuthenticated = false }: { readonly creditCost: number; readonly isAuthenticated?: boolean }) {
   const [file, setFile]                 = useState<File | null>(null)
   const [password, setPassword]         = useState('')
   const [isProcessing, setIsProcessing] = useState(false)
@@ -28,6 +28,41 @@ export default function DecryptPdf({ creditCost, isAuthenticated = false }: { cr
     }
   }
 
+  const prepareSession = async (task: string, requestId: string): Promise<boolean> => {
+    if (!isAuthenticated) {
+      setButtonLabel('Processing...')
+      if (!auth.currentUser) {
+        try {
+          const credential = await signInAnonymously(auth)
+          const idToken = await credential.user.getIdToken()
+          const sessionRes = await actions.user.createAnonymousSession({ idToken })
+          if (!sessionRes.data?.success) {
+            setError('Failed to start session. Please try again.')
+            setButtonLabel('Unlock PDF')
+            setIsProcessing(false)
+            return false
+          }
+        } catch (err) {
+          setError('Failed to start session. Please try again.')
+          setButtonLabel('Unlock PDF')
+          setIsProcessing(false)
+          Sentry.captureException(err)
+          return false
+        }
+      }
+      return true
+    }
+    setButtonLabel('Checking credits...')
+    const creditsResponse = await actions.credits.checkCredits({ task, requestId, creditCost })
+    if (!creditsResponse.data?.success) {
+      setError(INSUFFICIENT_CREDITS_ERROR)
+      setButtonLabel('Unlock PDF')
+      setIsProcessing(false)
+      return false
+    }
+    return true
+  }
+
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault()
     if (!file || !password) return
@@ -37,40 +72,7 @@ export default function DecryptPdf({ creditCost, isAuthenticated = false }: { cr
     setError(null)
     setIsProcessing(true)
 
-    const currentUser = auth.currentUser
-    const isAnon = !isAuthenticated
-
-    if (isAnon) {
-      setButtonLabel('Processing...')
-      if (!currentUser) {
-        try {
-          const credential = await signInAnonymously(auth)
-          const idToken = await credential.user.getIdToken()
-          const sessionRes = await actions.user.createAnonymousSession({ idToken })
-          if (!sessionRes.data?.success) {
-            setError('Failed to start session. Please try again.')
-            setButtonLabel('Unlock PDF')
-            setIsProcessing(false)
-            return
-          }
-        } catch (err) {
-          setError('Failed to start session. Please try again.')
-          setButtonLabel('Unlock PDF')
-          setIsProcessing(false)
-          Sentry.captureException(err)
-          return
-        }
-      }
-    } else {
-      setButtonLabel('Checking credits...')
-      const creditsResponse = await actions.credits.checkCredits({ task, requestId, creditCost })
-      if (!creditsResponse.data?.success) {
-        setError(INSUFFICIENT_CREDITS_ERROR)
-        setButtonLabel('Unlock PDF')
-        setIsProcessing(false)
-        return
-      }
-    }
+    if (!await prepareSession(task, requestId)) return
 
     logEvent('pdf_operation_started', { operation_type: task })
     setButtonLabel('Unlocking...')
@@ -110,12 +112,78 @@ export default function DecryptPdf({ creditCost, isAuthenticated = false }: { cr
 
   const goToSignup = () => {
     if (claimToken) sessionStorage.setItem('pendingClaimToken', claimToken)
-    window.location.href = '/signup'
+    globalThis.location.href = '/signup'
   }
 
   const goToSignin = () => {
     if (claimToken) sessionStorage.setItem('pendingClaimToken', claimToken)
-    window.location.href = '/signin'
+    globalThis.location.href = '/signin'
+  }
+
+  const renderContent = () => {
+    if (claimToken) return (
+      <Stack gap={4} align="center" style={{ paddingBlock: 'var(--th-space-4)' }}>
+        <Callout variant="success" title="Your PDF is unlocked">
+          Create a free account to download it — no credit card required.
+        </Callout>
+        <div style={{ display: 'flex', gap: 'var(--th-space-3)', flexWrap: 'wrap' }}>
+          <Button variant="solid-terra" onClick={goToSignup}>Sign up to download</Button>
+          <Button variant="ghost" onClick={goToSignin}>Already have an account?</Button>
+        </div>
+      </Stack>
+    )
+    if (downloadLink) return (
+      <Stack gap={4} align="center" style={{ paddingBlock: 'var(--th-space-4)' }}>
+        <Callout variant="success" title="Your PDF is unlocked">
+          The password protection has been removed successfully.
+        </Callout>
+        <div style={{ display: 'flex', gap: 'var(--th-space-3)', flexWrap: 'wrap' }}>
+          <Button href={downloadLink} variant="solid-terra" icon={<DownloadIcon />}>
+            Download unlocked PDF
+          </Button>
+          <Button variant="ghost" onClick={reset}>Unlock another PDF</Button>
+        </div>
+      </Stack>
+    )
+    return (
+      <>
+        {!file ? (
+          <FileDropzone label="Upload PDF" hint="Drag and drop or click to browse — one PDF file"
+            accept="application/pdf" onFiles={handleFiles} />
+        ) : (
+          <Stack gap={3}>
+            <Text size="sm" color="2" weight={500}>Selected file</Text>
+            <div style={{
+              display: 'flex', alignItems: 'center', justifyContent: 'space-between',
+              padding: 'var(--th-space-3) var(--th-space-4)',
+              borderRadius: 'var(--th-radius-md)',
+              border: '1px solid var(--th-color-border)',
+              background: 'var(--th-color-surface-2)',
+            }}>
+              <Text size="sm" color="1">{file.name}</Text>
+              <Button type="button" variant="ghost" size="sm" onClick={() => setFile(null)} aria-label="Remove file"><XIcon /></Button>
+            </div>
+          </Stack>
+        )}
+        {file && (
+          <>
+            <Divider />
+            <form onSubmit={handleSubmit}>
+              <Stack gap={4}>
+                <Input type="password" name="password" id="password" label="PDF password"
+                  hint="Enter the password that protects this file" value={password}
+                  onChange={e => setPassword(e.target.value)} autoComplete="current-password" required />
+                {error && <ErrorCallout message={error} />}
+                <Button type="submit" variant="solid-terra" disabled={isProcessing || !password}
+                  style={{ alignSelf: 'flex-start' }}>
+                  {buttonLabel}
+                </Button>
+              </Stack>
+            </form>
+          </>
+        )}
+      </>
+    )
   }
 
   return (
@@ -132,87 +200,7 @@ export default function DecryptPdf({ creditCost, isAuthenticated = false }: { cr
 
         <Card variant="elevated">
           <Stack gap={5} style={{ padding: 'var(--th-space-6)' }}>
-
-            {claimToken ? (
-              <Stack gap={4} align="center" style={{ paddingBlock: 'var(--th-space-4)' }}>
-                <Callout variant="success" title="Your PDF is unlocked">
-                  Create a free account to download it — no credit card required.
-                </Callout>
-                <div style={{ display: 'flex', gap: 'var(--th-space-3)', flexWrap: 'wrap' }}>
-                  <Button variant="solid-terra" onClick={goToSignup}>Sign up to download</Button>
-                  <Button variant="ghost" onClick={goToSignin}>Already have an account?</Button>
-                </div>
-              </Stack>
-            ) : downloadLink ? (
-              <Stack gap={4} align="center" style={{ paddingBlock: 'var(--th-space-4)' }}>
-                <Callout variant="success" title="Your PDF is unlocked">
-                  The password protection has been removed successfully.
-                </Callout>
-                <div style={{ display: 'flex', gap: 'var(--th-space-3)', flexWrap: 'wrap' }}>
-                  <Button href={downloadLink} variant="solid-terra" icon={<DownloadIcon />}>
-                    Download unlocked PDF
-                  </Button>
-                  <Button variant="ghost" onClick={reset}>Unlock another PDF</Button>
-                </div>
-              </Stack>
-            ) : (
-              <>
-                {!file ? (
-                  <FileDropzone
-                    label="Upload PDF"
-                    hint="Drag and drop or click to browse — one PDF file"
-                    accept="application/pdf"
-                    onFiles={handleFiles}
-                  />
-                ) : (
-                  <Stack gap={3}>
-                    <Text size="sm" color="2" weight={500}>Selected file</Text>
-                    <div style={{
-                      display: 'flex',
-                      alignItems: 'center',
-                      justifyContent: 'space-between',
-                      padding: 'var(--th-space-3) var(--th-space-4)',
-                      borderRadius: 'var(--th-radius-md)',
-                      border: '1px solid var(--th-color-border)',
-                      background: 'var(--th-color-surface-2)',
-                    }}>
-                      <Text size="sm" color="1">{file.name}</Text>
-                      <Button type="button" variant="ghost" size="sm" onClick={() => setFile(null)} aria-label="Remove file"><XIcon /></Button>
-                    </div>
-                  </Stack>
-                )}
-
-                {file && (
-                  <>
-                    <Divider />
-                    <form onSubmit={handleSubmit}>
-                      <Stack gap={4}>
-                        <Input
-                          type="password"
-                          name="password"
-                          id="password"
-                          label="PDF password"
-                          hint="Enter the password that protects this file"
-                          value={password}
-                          onChange={e => setPassword(e.target.value)}
-                          autoComplete="current-password"
-                          required
-                        />
-                        {error && <ErrorCallout message={error} />}
-                        <Button
-                          type="submit"
-                          variant="solid-terra"
-                          disabled={isProcessing || !password}
-                          style={{ alignSelf: 'flex-start' }}
-                        >
-                          {buttonLabel}
-                        </Button>
-                      </Stack>
-                    </form>
-                  </>
-                )}
-              </>
-            )}
+            {renderContent()}
 
           </Stack>
         </Card>

--- a/apps/pdf-craft/src/components/views/EncryptPdf/EncryptPdf.test.tsx
+++ b/apps/pdf-craft/src/components/views/EncryptPdf/EncryptPdf.test.tsx
@@ -2,10 +2,18 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, screen, waitFor, fireEvent } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
+const mockSignInAnonymously = vi.fn();
+vi.mock("firebase/auth", () => ({
+  signInAnonymously: (...args: unknown[]) => mockSignInAnonymously(...args),
+}));
+
 vi.mock("../../../utils/lib/analytics", () => ({ logEvent: vi.fn() }));
 
 import EncryptPdf from "./EncryptPdf";
-import { checkCredits, encryptPdf } from "../../../test/mocks/astro-actions";
+import { checkCredits, encryptPdf, createAnonymousSession } from "../../../test/mocks/astro-actions";
+import { auth } from "../../../firebase/client";
+
+const mockAnonUser = { uid: "anon-uid", isAnonymous: true, getIdToken: vi.fn().mockResolvedValue("anon-token") };
 
 const pdfFile = new File(["pdf"], "doc.pdf", { type: "application/pdf" });
 
@@ -17,32 +25,37 @@ function selectFile(file = pdfFile) {
 
 beforeEach(() => {
   vi.clearAllMocks();
+  (auth as any).currentUser = { uid: "test-uid", isAnonymous: false };
   checkCredits.mockResolvedValue({ data: { success: true }, error: null });
   encryptPdf.mockResolvedValue({ data: { success: true, data: { fileUrl: "https://cdn.test/enc.pdf" } } });
+  createAnonymousSession.mockResolvedValue({ data: { success: true }, error: null });
+  mockSignInAnonymously.mockResolvedValue({ user: mockAnonUser });
+  vi.stubGlobal("sessionStorage", { getItem: vi.fn(() => null), setItem: vi.fn(), removeItem: vi.fn() });
+  vi.stubGlobal("location", { href: "" });
 });
 
 describe("EncryptPdf", () => {
   it("renders the file dropzone initially", () => {
-    render(<EncryptPdf creditCost={2} />);
+    render(<EncryptPdf creditCost={2} isAuthenticated />);
     expect(screen.getByTestId("file-input")).toBeInTheDocument();
   });
 
   it("shows the file name and password form after a file is selected", async () => {
-    render(<EncryptPdf creditCost={2} />);
+    render(<EncryptPdf creditCost={2} isAuthenticated />);
     selectFile();
     await waitFor(() => expect(screen.getByText("doc.pdf")).toBeInTheDocument());
     expect(screen.getByLabelText("Open password")).toBeInTheDocument();
   });
 
   it("hides the dropzone after a file is selected", async () => {
-    render(<EncryptPdf creditCost={2} />);
+    render(<EncryptPdf creditCost={2} isAuthenticated />);
     selectFile();
     await waitFor(() => expect(screen.queryByTestId("file-input")).not.toBeInTheDocument());
   });
 
   it("removes the file when the remove button is clicked", async () => {
     const user = userEvent.setup();
-    render(<EncryptPdf creditCost={2} />);
+    render(<EncryptPdf creditCost={2} isAuthenticated />);
     selectFile();
     await waitFor(() => screen.getByText("doc.pdf"));
     await user.click(screen.getByRole("button", { name: /Remove file/i }));
@@ -52,7 +65,7 @@ describe("EncryptPdf", () => {
   it("shows an insufficient credits error when checkCredits fails", async () => {
     checkCredits.mockResolvedValue({ data: { success: false } });
     const user = userEvent.setup();
-    render(<EncryptPdf creditCost={2} />);
+    render(<EncryptPdf creditCost={2} isAuthenticated />);
     selectFile();
     await waitFor(() => screen.getByLabelText("Open password"));
     await user.type(screen.getByLabelText("Open password"), "secret");
@@ -64,7 +77,7 @@ describe("EncryptPdf", () => {
 
   it("shows the download link after a successful encrypt", async () => {
     const user = userEvent.setup();
-    render(<EncryptPdf creditCost={2} />);
+    render(<EncryptPdf creditCost={2} isAuthenticated />);
     selectFile();
     await waitFor(() => screen.getByLabelText("Open password"));
     await user.type(screen.getByLabelText("Open password"), "secret");
@@ -80,7 +93,7 @@ describe("EncryptPdf", () => {
   it("shows an error callout when encryptPdf returns a failure", async () => {
     encryptPdf.mockResolvedValue({ data: { success: false, error: "Encryption failed." } });
     const user = userEvent.setup();
-    render(<EncryptPdf creditCost={2} />);
+    render(<EncryptPdf creditCost={2} isAuthenticated />);
     selectFile();
     await waitFor(() => screen.getByLabelText("Open password"));
     await user.type(screen.getByLabelText("Open password"), "secret");
@@ -92,7 +105,7 @@ describe("EncryptPdf", () => {
 
   it("resets to the dropzone when Protect another PDF is clicked", async () => {
     const user = userEvent.setup();
-    render(<EncryptPdf creditCost={2} />);
+    render(<EncryptPdf creditCost={2} isAuthenticated />);
     selectFile();
     await waitFor(() => screen.getByLabelText("Open password"));
     await user.type(screen.getByLabelText("Open password"), "secret");
@@ -100,5 +113,61 @@ describe("EncryptPdf", () => {
     await waitFor(() => screen.getByRole("link", { name: /Download protected PDF/i }));
     await user.click(screen.getByRole("button", { name: /Protect another PDF/i }));
     await waitFor(() => expect(screen.getByTestId("file-input")).toBeInTheDocument());
+  });
+
+  // ── Anonymous user flow ───────────────────────────────────────────────────
+
+  it("calls signInAnonymously when currentUser is null and skips checkCredits", async () => {
+    (auth as any).currentUser = null;
+    const user = userEvent.setup();
+    render(<EncryptPdf creditCost={2} isAuthenticated={false} />);
+    selectFile();
+    await waitFor(() => screen.getByLabelText("Open password"));
+    await user.type(screen.getByLabelText("Open password"), "secret");
+    await user.click(screen.getByRole("button", { name: /Protect PDF/i }));
+    await waitFor(() => expect(mockSignInAnonymously).toHaveBeenCalled());
+    expect(checkCredits).not.toHaveBeenCalled();
+  });
+
+  it("shows pending UI when encryptPdf returns a claimToken", async () => {
+    encryptPdf.mockResolvedValue({ data: { success: true, data: { claimToken: "tok-enc" } } });
+    const user = userEvent.setup();
+    render(<EncryptPdf creditCost={2} isAuthenticated={false} />);
+    selectFile();
+    await waitFor(() => screen.getByLabelText("Open password"));
+    await user.type(screen.getByLabelText("Open password"), "secret");
+    await user.click(screen.getByRole("button", { name: /Protect PDF/i }));
+    await waitFor(() =>
+      expect(screen.getByRole("button", { name: /Sign up to download/i })).toBeInTheDocument(),
+    );
+    expect(screen.getByRole("button", { name: /Already have an account/i })).toBeInTheDocument();
+  });
+
+  it("stores claimToken and navigates to /signup on 'Sign up to download'", async () => {
+    encryptPdf.mockResolvedValue({ data: { success: true, data: { claimToken: "tok-enc" } } });
+    const user = userEvent.setup();
+    render(<EncryptPdf creditCost={2} isAuthenticated={false} />);
+    selectFile();
+    await waitFor(() => screen.getByLabelText("Open password"));
+    await user.type(screen.getByLabelText("Open password"), "secret");
+    await user.click(screen.getByRole("button", { name: /Protect PDF/i }));
+    await waitFor(() => screen.getByRole("button", { name: /Sign up to download/i }));
+    await user.click(screen.getByRole("button", { name: /Sign up to download/i }));
+    expect(globalThis.sessionStorage.setItem).toHaveBeenCalledWith("pendingClaimToken", "tok-enc");
+    expect(globalThis.location.href).toBe("/signup");
+  });
+
+  it("stores claimToken and navigates to /signin on 'Already have an account?'", async () => {
+    encryptPdf.mockResolvedValue({ data: { success: true, data: { claimToken: "tok-enc" } } });
+    const user = userEvent.setup();
+    render(<EncryptPdf creditCost={2} isAuthenticated={false} />);
+    selectFile();
+    await waitFor(() => screen.getByLabelText("Open password"));
+    await user.type(screen.getByLabelText("Open password"), "secret");
+    await user.click(screen.getByRole("button", { name: /Protect PDF/i }));
+    await waitFor(() => screen.getByRole("button", { name: /Already have an account/i }));
+    await user.click(screen.getByRole("button", { name: /Already have an account/i }));
+    expect(globalThis.sessionStorage.setItem).toHaveBeenCalledWith("pendingClaimToken", "tok-enc");
+    expect(globalThis.location.href).toBe("/signin");
   });
 });

--- a/apps/pdf-craft/src/components/views/EncryptPdf/EncryptPdf.tsx
+++ b/apps/pdf-craft/src/components/views/EncryptPdf/EncryptPdf.tsx
@@ -18,7 +18,7 @@ const PRESETS: { value: PermissionPreset; label: string; description: string }[]
   { value: 'read-only',      label: 'Read Only',      description: 'View only — no printing, copying, or editing' },
 ]
 
-export default function EncryptPdf({ creditCost, isAuthenticated = false }: { creditCost: number; isAuthenticated?: boolean }) {
+export default function EncryptPdf({ creditCost, isAuthenticated = false }: { readonly creditCost: number; readonly isAuthenticated?: boolean }) {
   const [file, setFile]                   = useState<File | null>(null)
   const [userPassword, setUserPassword]   = useState('')
   const [ownerPassword, setOwnerPassword] = useState('')
@@ -38,6 +38,41 @@ export default function EncryptPdf({ creditCost, isAuthenticated = false }: { cr
     }
   }
 
+  const prepareSession = async (task: string, requestId: string): Promise<boolean> => {
+    if (!isAuthenticated) {
+      setButtonLabel('Processing...')
+      if (!auth.currentUser) {
+        try {
+          const credential = await signInAnonymously(auth)
+          const idToken = await credential.user.getIdToken()
+          const sessionRes = await actions.user.createAnonymousSession({ idToken })
+          if (!sessionRes.data?.success) {
+            setError('Failed to start session. Please try again.')
+            setButtonLabel('Protect PDF')
+            setIsProcessing(false)
+            return false
+          }
+        } catch (err) {
+          setError('Failed to start session. Please try again.')
+          setButtonLabel('Protect PDF')
+          setIsProcessing(false)
+          Sentry.captureException(err)
+          return false
+        }
+      }
+      return true
+    }
+    setButtonLabel('Checking credits...')
+    const creditsResponse = await actions.credits.checkCredits({ task, requestId, creditCost })
+    if (!creditsResponse.data?.success) {
+      setError(INSUFFICIENT_CREDITS_ERROR)
+      setButtonLabel('Protect PDF')
+      setIsProcessing(false)
+      return false
+    }
+    return true
+  }
+
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault()
     if (!file || !userPassword) return
@@ -47,40 +82,7 @@ export default function EncryptPdf({ creditCost, isAuthenticated = false }: { cr
     setError(null)
     setIsProcessing(true)
 
-    const currentUser = auth.currentUser
-    const isAnon = !isAuthenticated
-
-    if (isAnon) {
-      setButtonLabel('Processing...')
-      if (!currentUser) {
-        try {
-          const credential = await signInAnonymously(auth)
-          const idToken = await credential.user.getIdToken()
-          const sessionRes = await actions.user.createAnonymousSession({ idToken })
-          if (!sessionRes.data?.success) {
-            setError('Failed to start session. Please try again.')
-            setButtonLabel('Protect PDF')
-            setIsProcessing(false)
-            return
-          }
-        } catch (err) {
-          setError('Failed to start session. Please try again.')
-          setButtonLabel('Protect PDF')
-          setIsProcessing(false)
-          Sentry.captureException(err)
-          return
-        }
-      }
-    } else {
-      setButtonLabel('Checking credits...')
-      const creditsResponse = await actions.credits.checkCredits({ task, requestId, creditCost })
-      if (!creditsResponse.data?.success) {
-        setError(INSUFFICIENT_CREDITS_ERROR)
-        setButtonLabel('Protect PDF')
-        setIsProcessing(false)
-        return
-      }
-    }
+    if (!await prepareSession(task, requestId)) return
 
     logEvent('pdf_operation_started', { operation_type: task })
     setButtonLabel('Encrypting...')
@@ -126,12 +128,111 @@ export default function EncryptPdf({ creditCost, isAuthenticated = false }: { cr
 
   const goToSignup = () => {
     if (claimToken) sessionStorage.setItem('pendingClaimToken', claimToken)
-    window.location.href = '/signup'
+    globalThis.location.href = '/signup'
   }
 
   const goToSignin = () => {
     if (claimToken) sessionStorage.setItem('pendingClaimToken', claimToken)
-    window.location.href = '/signin'
+    globalThis.location.href = '/signin'
+  }
+
+  const renderContent = () => {
+    if (claimToken) return (
+      <Stack gap={4} align="center" style={{ paddingBlock: 'var(--th-space-4)' }}>
+        <Callout variant="success" title="Your PDF is protected">
+          Create a free account to download it — no credit card required.
+        </Callout>
+        <div style={{ display: 'flex', gap: 'var(--th-space-3)', flexWrap: 'wrap' }}>
+          <Button variant="solid-terra" onClick={goToSignup}>Sign up to download</Button>
+          <Button variant="ghost" onClick={goToSignin}>Already have an account?</Button>
+        </div>
+      </Stack>
+    )
+    if (downloadLink) return (
+      <Stack gap={4} align="center" style={{ paddingBlock: 'var(--th-space-4)' }}>
+        <Callout variant="success" title="Your PDF is protected">
+          The file has been encrypted with the password you provided.
+        </Callout>
+        <div style={{ display: 'flex', gap: 'var(--th-space-3)', flexWrap: 'wrap' }}>
+          <Button href={downloadLink} variant="solid-terra" icon={<DownloadIcon />}>
+            Download protected PDF
+          </Button>
+          <Button variant="ghost" onClick={reset}>Protect another PDF</Button>
+        </div>
+      </Stack>
+    )
+    return (
+      <>
+        {!file ? (
+          <FileDropzone
+            label="Upload PDF"
+            hint="Drag and drop or click to browse — one PDF file"
+            accept="application/pdf"
+            onFiles={handleFiles}
+          />
+        ) : (
+          <Stack gap={3}>
+            <Text size="sm" color="2" weight={500}>Selected file</Text>
+            <div style={{
+              display: 'flex', alignItems: 'center', justifyContent: 'space-between',
+              padding: 'var(--th-space-3) var(--th-space-4)',
+              borderRadius: 'var(--th-radius-md)',
+              border: '1px solid var(--th-color-border)',
+              background: 'var(--th-color-surface-2)',
+            }}>
+              <Text size="sm" color="1">{file.name}</Text>
+              <Button type="button" variant="ghost" size="sm" onClick={() => setFile(null)} aria-label="Remove file"><XIcon /></Button>
+            </div>
+          </Stack>
+        )}
+        {file && (
+          <>
+            <Divider />
+            <form onSubmit={handleSubmit}>
+              <Stack gap={6}>
+                <Stack gap={4}>
+                  <Text as="h2" size="base" color="1" weight={600}>Password</Text>
+                  <Input type="password" name="userPassword" id="userPassword" label="Open password"
+                    hint="Users need this password to open the PDF" value={userPassword}
+                    onChange={e => setUserPassword(e.target.value)} required />
+                  <Input type="password" name="ownerPassword" id="ownerPassword" label="Owner password (optional)"
+                    hint="Leave blank to use the same password as above" value={ownerPassword}
+                    onChange={e => setOwnerPassword(e.target.value)} />
+                </Stack>
+                <Stack gap={3}>
+                  <Text as="h2" size="base" color="1" weight={600}>Permissions</Text>
+                  <Stack gap={2}>
+                    {PRESETS.map((preset) => (
+                      <label key={preset.value} style={{
+                        display: 'flex', alignItems: 'center', gap: 'var(--th-space-3)',
+                        padding: 'var(--th-space-3) var(--th-space-4)',
+                        borderRadius: 'var(--th-radius-md)',
+                        border: `1px solid ${permissions === preset.value ? 'var(--th-color-accent)' : 'var(--th-color-border)'}`,
+                        background: permissions === preset.value ? 'var(--th-color-surface-2)' : 'var(--th-color-surface-1)',
+                        cursor: 'pointer',
+                        transition: 'border-color var(--th-duration-base) var(--th-ease-base)',
+                      }}>
+                        <Radio name="permissions" value={preset.value} checked={permissions === preset.value}
+                          onChange={() => setPermissions(preset.value)} label="" />
+                        <Stack gap={0}>
+                          <Text as="span" size="sm" color="1" weight={600}>{preset.label}</Text>
+                          <Text as="span" size="xs" color="2">{preset.description}</Text>
+                        </Stack>
+                      </label>
+                    ))}
+                  </Stack>
+                </Stack>
+                {error && <ErrorCallout message={error} />}
+                <Button type="submit" variant="solid-terra" disabled={isProcessing || !userPassword}
+                  style={{ alignSelf: 'flex-start' }}>
+                  {buttonLabel}
+                </Button>
+              </Stack>
+            </form>
+          </>
+        )}
+      </>
+    )
   }
 
   return (
@@ -148,134 +249,7 @@ export default function EncryptPdf({ creditCost, isAuthenticated = false }: { cr
 
         <Card variant="elevated">
           <Stack gap={5} style={{ padding: 'var(--th-space-6)' }}>
-
-            {claimToken ? (
-              <Stack gap={4} align="center" style={{ paddingBlock: 'var(--th-space-4)' }}>
-                <Callout variant="success" title="Your PDF is protected">
-                  Create a free account to download it — no credit card required.
-                </Callout>
-                <div style={{ display: 'flex', gap: 'var(--th-space-3)', flexWrap: 'wrap' }}>
-                  <Button variant="solid-terra" onClick={goToSignup}>Sign up to download</Button>
-                  <Button variant="ghost" onClick={goToSignin}>Already have an account?</Button>
-                </div>
-              </Stack>
-            ) : downloadLink ? (
-              <Stack gap={4} align="center" style={{ paddingBlock: 'var(--th-space-4)' }}>
-                <Callout variant="success" title="Your PDF is protected">
-                  The file has been encrypted with the password you provided.
-                </Callout>
-                <div style={{ display: 'flex', gap: 'var(--th-space-3)', flexWrap: 'wrap' }}>
-                  <Button href={downloadLink} variant="solid-terra" icon={<DownloadIcon />}>
-                    Download protected PDF
-                  </Button>
-                  <Button variant="ghost" onClick={reset}>Protect another PDF</Button>
-                </div>
-              </Stack>
-            ) : (
-              <>
-                {!file ? (
-                  <FileDropzone
-                    label="Upload PDF"
-                    hint="Drag and drop or click to browse — one PDF file"
-                    accept="application/pdf"
-                    onFiles={handleFiles}
-                  />
-                ) : (
-                  <Stack gap={3}>
-                    <Text size="sm" color="2" weight={500}>Selected file</Text>
-                    <div style={{
-                      display: 'flex',
-                      alignItems: 'center',
-                      justifyContent: 'space-between',
-                      padding: 'var(--th-space-3) var(--th-space-4)',
-                      borderRadius: 'var(--th-radius-md)',
-                      border: '1px solid var(--th-color-border)',
-                      background: 'var(--th-color-surface-2)',
-                    }}>
-                      <Text size="sm" color="1">{file.name}</Text>
-                      <Button type="button" variant="ghost" size="sm" onClick={() => setFile(null)} aria-label="Remove file"><XIcon /></Button>
-                    </div>
-                  </Stack>
-                )}
-
-                {file && (
-                  <>
-                    <Divider />
-                    <form onSubmit={handleSubmit}>
-                      <Stack gap={6}>
-
-                        <Stack gap={4}>
-                          <Text as="h2" size="base" color="1" weight={600}>Password</Text>
-                          <Input
-                            type="password"
-                            name="userPassword"
-                            id="userPassword"
-                            label="Open password"
-                            hint="Users need this password to open the PDF"
-                            value={userPassword}
-                            onChange={e => setUserPassword(e.target.value)}
-                            required
-                          />
-                          <Input
-                            type="password"
-                            name="ownerPassword"
-                            id="ownerPassword"
-                            label="Owner password (optional)"
-                            hint="Leave blank to use the same password as above"
-                            value={ownerPassword}
-                            onChange={e => setOwnerPassword(e.target.value)}
-                          />
-                        </Stack>
-
-                        <Stack gap={3}>
-                          <Text as="h2" size="base" color="1" weight={600}>Permissions</Text>
-                          <Stack gap={2}>
-                            {PRESETS.map((preset) => (
-                              <label
-                                key={preset.value}
-                                style={{
-                                  display: 'flex',
-                                  alignItems: 'center',
-                                  gap: 'var(--th-space-3)',
-                                  padding: 'var(--th-space-3) var(--th-space-4)',
-                                  borderRadius: 'var(--th-radius-md)',
-                                  border: `1px solid ${permissions === preset.value ? 'var(--th-color-accent)' : 'var(--th-color-border)'}`,
-                                  background: permissions === preset.value ? 'var(--th-color-surface-2)' : 'var(--th-color-surface-1)',
-                                  cursor: 'pointer',
-                                  transition: 'border-color var(--th-duration-base) var(--th-ease-base)',
-                                }}
-                              >
-                                <Radio
-                                  name="permissions"
-                                  value={preset.value}
-                                  checked={permissions === preset.value}
-                                  onChange={() => setPermissions(preset.value)}
-                                  label=""
-                                />
-                                <Stack gap={0}>
-                                  <Text as="span" size="sm" color="1" weight={600}>{preset.label}</Text>
-                                  <Text as="span" size="xs" color="2">{preset.description}</Text>
-                                </Stack>
-                              </label>
-                            ))}
-                          </Stack>
-                        </Stack>
-
-                        {error && <ErrorCallout message={error} />}
-                        <Button
-                          type="submit"
-                          variant="solid-terra"
-                          disabled={isProcessing || !userPassword}
-                          style={{ alignSelf: 'flex-start' }}
-                        >
-                          {buttonLabel}
-                        </Button>
-                      </Stack>
-                    </form>
-                  </>
-                )}
-              </>
-            )}
+            {renderContent()}
 
           </Stack>
         </Card>

--- a/apps/pdf-craft/src/components/views/EncryptPdf/EncryptPdf.tsx
+++ b/apps/pdf-craft/src/components/views/EncryptPdf/EncryptPdf.tsx
@@ -1,14 +1,12 @@
 'use client'
 import { useState } from 'react'
 import { actions } from 'astro:actions'
-import { signInAnonymously } from 'firebase/auth'
 import {
   Container, Stack, Text, Button, Input, FileDropzone, Callout, Card, Divider, Radio,
 } from '@fhdamd/threads'
-import * as Sentry from '@sentry/astro'
-import { auth } from '../../../firebase/client'
 import { logEvent } from '../../../utils/lib/analytics'
-import { XIcon, DownloadIcon, ErrorCallout, INSUFFICIENT_CREDITS_ERROR } from '../../shared'
+import { buildPrepareSession } from '../../../utils/lib/operationSession'
+import { XIcon, DownloadIcon, ErrorCallout } from '../../shared'
 
 type PermissionPreset = 'full-access' | 'view-and-print' | 'read-only'
 
@@ -38,40 +36,10 @@ export default function EncryptPdf({ creditCost, isAuthenticated = false }: { re
     }
   }
 
-  const prepareSession = async (task: string, requestId: string): Promise<boolean> => {
-    if (!isAuthenticated) {
-      setButtonLabel('Processing...')
-      if (!auth.currentUser) {
-        try {
-          const credential = await signInAnonymously(auth)
-          const idToken = await credential.user.getIdToken()
-          const sessionRes = await actions.user.createAnonymousSession({ idToken })
-          if (!sessionRes.data?.success) {
-            setError('Failed to start session. Please try again.')
-            setButtonLabel('Protect PDF')
-            setIsProcessing(false)
-            return false
-          }
-        } catch (err) {
-          setError('Failed to start session. Please try again.')
-          setButtonLabel('Protect PDF')
-          setIsProcessing(false)
-          Sentry.captureException(err)
-          return false
-        }
-      }
-      return true
-    }
-    setButtonLabel('Checking credits...')
-    const creditsResponse = await actions.credits.checkCredits({ task, requestId, creditCost })
-    if (!creditsResponse.data?.success) {
-      setError(INSUFFICIENT_CREDITS_ERROR)
-      setButtonLabel('Protect PDF')
-      setIsProcessing(false)
-      return false
-    }
-    return true
-  }
+  const prepareSession = buildPrepareSession({
+    isAuthenticated, creditCost, defaultLabel: 'Protect PDF',
+    setButtonLabel, setError: (e) => setError(e), setProcessing: setIsProcessing,
+  })
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault()

--- a/apps/pdf-craft/src/components/views/EncryptPdf/EncryptPdf.tsx
+++ b/apps/pdf-craft/src/components/views/EncryptPdf/EncryptPdf.tsx
@@ -1,10 +1,12 @@
 'use client'
 import { useState } from 'react'
 import { actions } from 'astro:actions'
+import { signInAnonymously } from 'firebase/auth'
 import {
   Container, Stack, Text, Button, Input, FileDropzone, Callout, Card, Divider, Radio,
 } from '@fhdamd/threads'
 import * as Sentry from '@sentry/astro'
+import { auth } from '../../../firebase/client'
 import { logEvent } from '../../../utils/lib/analytics'
 import { XIcon, DownloadIcon, ErrorCallout, INSUFFICIENT_CREDITS_ERROR } from '../../shared'
 
@@ -16,13 +18,14 @@ const PRESETS: { value: PermissionPreset; label: string; description: string }[]
   { value: 'read-only',      label: 'Read Only',      description: 'View only — no printing, copying, or editing' },
 ]
 
-export default function EncryptPdf({ creditCost }: { creditCost: number }) {
+export default function EncryptPdf({ creditCost, isAuthenticated = false }: { creditCost: number; isAuthenticated?: boolean }) {
   const [file, setFile]                   = useState<File | null>(null)
   const [userPassword, setUserPassword]   = useState('')
   const [ownerPassword, setOwnerPassword] = useState('')
   const [permissions, setPermissions]     = useState<PermissionPreset>('full-access')
   const [isProcessing, setIsProcessing]   = useState(false)
   const [downloadLink, setDownloadLink]   = useState<string | null>(null)
+  const [claimToken, setClaimToken]       = useState<string | null>(null)
   const [error, setError]                 = useState<string | null>(null)
   const [buttonLabel, setButtonLabel]     = useState('Protect PDF')
 
@@ -30,6 +33,7 @@ export default function EncryptPdf({ creditCost }: { creditCost: number }) {
     if (files.length > 0) {
       setFile(files[0])
       setDownloadLink(null)
+      setClaimToken(null)
       setError(null)
     }
   }
@@ -41,19 +45,46 @@ export default function EncryptPdf({ creditCost }: { creditCost: number }) {
     const requestId = crypto.randomUUID()
     const task = 'pdf-encrypt'
     setError(null)
-    setButtonLabel('Checking credits...')
     setIsProcessing(true)
 
-    const creditsResponse = await actions.credits.checkCredits({ task, requestId, creditCost })
-    if (!creditsResponse.data?.success) {
-      setError(INSUFFICIENT_CREDITS_ERROR)
-      setButtonLabel('Protect PDF')
-      setIsProcessing(false)
-      return
+    const currentUser = auth.currentUser
+    const isAnon = !isAuthenticated
+
+    if (isAnon) {
+      setButtonLabel('Processing...')
+      if (!currentUser) {
+        try {
+          const credential = await signInAnonymously(auth)
+          const idToken = await credential.user.getIdToken()
+          const sessionRes = await actions.user.createAnonymousSession({ idToken })
+          if (!sessionRes.data?.success) {
+            setError('Failed to start session. Please try again.')
+            setButtonLabel('Protect PDF')
+            setIsProcessing(false)
+            return
+          }
+        } catch (err) {
+          setError('Failed to start session. Please try again.')
+          setButtonLabel('Protect PDF')
+          setIsProcessing(false)
+          Sentry.captureException(err)
+          return
+        }
+      }
+    } else {
+      setButtonLabel('Checking credits...')
+      const creditsResponse = await actions.credits.checkCredits({ task, requestId, creditCost })
+      if (!creditsResponse.data?.success) {
+        setError(INSUFFICIENT_CREDITS_ERROR)
+        setButtonLabel('Protect PDF')
+        setIsProcessing(false)
+        return
+      }
     }
 
     logEvent('pdf_operation_started', { operation_type: task })
     setButtonLabel('Encrypting...')
+
     const formData = new FormData()
     formData.append('file', file)
     formData.append('userPassword', userPassword)
@@ -67,7 +98,12 @@ export default function EncryptPdf({ creditCost }: { creditCost: number }) {
       const response = await actions.operations.encryptPdf(formData)
       if (response.data?.success) {
         logEvent('pdf_operation_completed', { operation_type: task })
-        setDownloadLink(response.data.data?.fileUrl || null)
+        const token = response.data.data?.claimToken
+        if (token) {
+          setClaimToken(token)
+        } else {
+          setDownloadLink(response.data.data?.fileUrl || null)
+        }
       } else {
         logEvent('pdf_operation_failed', { operation_type: task })
         setError(response.data?.error || 'Failed to protect PDF.')
@@ -83,9 +119,19 @@ export default function EncryptPdf({ creditCost }: { creditCost: number }) {
   }
 
   const reset = () => {
-    setDownloadLink(null); setFile(null)
+    setDownloadLink(null); setClaimToken(null); setFile(null)
     setUserPassword(''); setOwnerPassword('')
     setError(null); setPermissions('full-access')
+  }
+
+  const goToSignup = () => {
+    if (claimToken) sessionStorage.setItem('pendingClaimToken', claimToken)
+    window.location.href = '/signup'
+  }
+
+  const goToSignin = () => {
+    if (claimToken) sessionStorage.setItem('pendingClaimToken', claimToken)
+    window.location.href = '/signin'
   }
 
   return (
@@ -103,7 +149,17 @@ export default function EncryptPdf({ creditCost }: { creditCost: number }) {
         <Card variant="elevated">
           <Stack gap={5} style={{ padding: 'var(--th-space-6)' }}>
 
-            {downloadLink ? (
+            {claimToken ? (
+              <Stack gap={4} align="center" style={{ paddingBlock: 'var(--th-space-4)' }}>
+                <Callout variant="success" title="Your PDF is protected">
+                  Create a free account to download it — no credit card required.
+                </Callout>
+                <div style={{ display: 'flex', gap: 'var(--th-space-3)', flexWrap: 'wrap' }}>
+                  <Button variant="solid-terra" onClick={goToSignup}>Sign up to download</Button>
+                  <Button variant="ghost" onClick={goToSignin}>Already have an account?</Button>
+                </div>
+              </Stack>
+            ) : downloadLink ? (
               <Stack gap={4} align="center" style={{ paddingBlock: 'var(--th-space-4)' }}>
                 <Callout variant="success" title="Your PDF is protected">
                   The file has been encrypted with the password you provided.

--- a/apps/pdf-craft/src/components/views/ImageToPdf/ImageToPdf.test.tsx
+++ b/apps/pdf-craft/src/components/views/ImageToPdf/ImageToPdf.test.tsx
@@ -2,10 +2,18 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, screen, waitFor, fireEvent } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
+const mockSignInAnonymously = vi.fn();
+vi.mock("firebase/auth", () => ({
+  signInAnonymously: (...args: unknown[]) => mockSignInAnonymously(...args),
+}));
+
 vi.mock("../../../utils/lib/analytics", () => ({ logEvent: vi.fn() }));
 
 import ImageToPdf from "./ImageToPdf";
-import { checkCredits, imageToPdf } from "../../../test/mocks/astro-actions";
+import { checkCredits, imageToPdf, createAnonymousSession } from "../../../test/mocks/astro-actions";
+import { auth } from "../../../firebase/client";
+
+const mockAnonUser = { uid: "anon-uid", isAnonymous: true, getIdToken: vi.fn().mockResolvedValue("anon-token") };
 
 function makeImage(name: string) {
   return new File(["img"], name, { type: "image/png" });
@@ -19,18 +27,23 @@ function addFiles(files: File[]) {
 
 beforeEach(() => {
   vi.clearAllMocks();
+  (auth as any).currentUser = { uid: "test-uid", isAnonymous: false };
   checkCredits.mockResolvedValue({ data: { success: true }, error: null });
   imageToPdf.mockResolvedValue({ data: { data: { fileUrl: "https://cdn.test/output.pdf" } }, error: null });
+  createAnonymousSession.mockResolvedValue({ data: { success: true }, error: null });
+  mockSignInAnonymously.mockResolvedValue({ user: mockAnonUser });
+  vi.stubGlobal("sessionStorage", { getItem: vi.fn(() => null), setItem: vi.fn(), removeItem: vi.fn() });
+  vi.stubGlobal("location", { href: "" });
 });
 
 describe("ImageToPdf", () => {
   it("renders the file dropzone initially", () => {
-    render(<ImageToPdf creditCost={2} />);
+    render(<ImageToPdf creditCost={2} isAuthenticated />);
     expect(screen.getByTestId("file-input")).toBeInTheDocument();
   });
 
   it("shows uploaded image names after adding files", async () => {
-    render(<ImageToPdf creditCost={2} />);
+    render(<ImageToPdf creditCost={2} isAuthenticated />);
     addFiles([makeImage("photo1.png"), makeImage("photo2.png")]);
     await waitFor(() => {
       expect(screen.getByText("photo1.png")).toBeInTheDocument();
@@ -39,7 +52,7 @@ describe("ImageToPdf", () => {
   });
 
   it("shows the max-files callout and hides the dropzone at 10 images", async () => {
-    render(<ImageToPdf creditCost={2} />);
+    render(<ImageToPdf creditCost={2} isAuthenticated />);
     addFiles(Array.from({ length: 10 }, (_, i) => makeImage(`img${i}.png`)));
     await waitFor(() =>
       expect(screen.getByRole("alert")).toHaveTextContent(/Maximum of 10 images reached/i),
@@ -49,7 +62,7 @@ describe("ImageToPdf", () => {
 
   it("removes an image when its remove button is clicked", async () => {
     const user = userEvent.setup();
-    render(<ImageToPdf creditCost={2} />);
+    render(<ImageToPdf creditCost={2} isAuthenticated />);
     addFiles([makeImage("photo1.png"), makeImage("photo2.png")]);
     await waitFor(() => screen.getByText("photo1.png"));
     await user.click(screen.getByRole("button", { name: /Remove photo1\.png/i }));
@@ -60,7 +73,7 @@ describe("ImageToPdf", () => {
   it("shows insufficient credits error", async () => {
     checkCredits.mockResolvedValue({ data: { success: false } });
     const user = userEvent.setup();
-    render(<ImageToPdf creditCost={2} />);
+    render(<ImageToPdf creditCost={2} isAuthenticated />);
     addFiles([makeImage("photo1.png")]);
     await waitFor(() => screen.getByText("photo1.png"));
     await user.click(screen.getByRole("button", { name: /Convert to PDF/i }));
@@ -71,7 +84,7 @@ describe("ImageToPdf", () => {
 
   it("shows download link after a successful conversion", async () => {
     const user = userEvent.setup();
-    render(<ImageToPdf creditCost={2} />);
+    render(<ImageToPdf creditCost={2} isAuthenticated />);
     addFiles([makeImage("photo1.png")]);
     await waitFor(() => screen.getByText("photo1.png"));
     await user.click(screen.getByRole("button", { name: /Convert to PDF/i }));
@@ -85,12 +98,91 @@ describe("ImageToPdf", () => {
 
   it("resets to dropzone when Convert more images is clicked", async () => {
     const user = userEvent.setup();
-    render(<ImageToPdf creditCost={2} />);
+    render(<ImageToPdf creditCost={2} isAuthenticated />);
     addFiles([makeImage("photo1.png")]);
     await waitFor(() => screen.getByText("photo1.png"));
     await user.click(screen.getByRole("button", { name: /Convert to PDF/i }));
     await waitFor(() => screen.getByRole("link", { name: /Download PDF/i }));
     await user.click(screen.getByRole("button", { name: /Convert more images/i }));
     await waitFor(() => expect(screen.getByTestId("file-input")).toBeInTheDocument());
+  });
+
+  // ── Anonymous user flow ───────────────────────────────────────────────────
+
+  it("calls signInAnonymously when currentUser is null and skips checkCredits", async () => {
+    (auth as any).currentUser = null;
+    const user = userEvent.setup();
+    render(<ImageToPdf creditCost={2} isAuthenticated={false} />);
+    addFiles([makeImage("photo1.png")]);
+    await waitFor(() => screen.getByText("photo1.png"));
+    await user.click(screen.getByRole("button", { name: /Convert to PDF/i }));
+    await waitFor(() => expect(mockSignInAnonymously).toHaveBeenCalled());
+    expect(checkCredits).not.toHaveBeenCalled();
+  });
+
+  it("shows pending UI when imageToPdf returns a claimToken", async () => {
+    imageToPdf.mockResolvedValue({ data: { data: { claimToken: "tok-img" } }, error: null });
+    const user = userEvent.setup();
+    render(<ImageToPdf creditCost={2} isAuthenticated={false} />);
+    addFiles([makeImage("photo1.png")]);
+    await waitFor(() => screen.getByText("photo1.png"));
+    await user.click(screen.getByRole("button", { name: /Convert to PDF/i }));
+    await waitFor(() =>
+      expect(screen.getByRole("button", { name: /Sign up to download/i })).toBeInTheDocument(),
+    );
+    expect(screen.getByRole("button", { name: /Already have an account/i })).toBeInTheDocument();
+  });
+
+  it("stores claimToken and navigates to /signup on 'Sign up to download'", async () => {
+    imageToPdf.mockResolvedValue({ data: { data: { claimToken: "tok-img" } }, error: null });
+    const user = userEvent.setup();
+    render(<ImageToPdf creditCost={2} isAuthenticated={false} />);
+    addFiles([makeImage("photo1.png")]);
+    await waitFor(() => screen.getByText("photo1.png"));
+    await user.click(screen.getByRole("button", { name: /Convert to PDF/i }));
+    await waitFor(() => screen.getByRole("button", { name: /Sign up to download/i }));
+    await user.click(screen.getByRole("button", { name: /Sign up to download/i }));
+    expect(globalThis.sessionStorage.setItem).toHaveBeenCalledWith("pendingClaimToken", "tok-img");
+    expect(globalThis.location.href).toBe("/signup");
+  });
+
+  it("stores claimToken and navigates to /signin on 'Already have an account?'", async () => {
+    imageToPdf.mockResolvedValue({ data: { data: { claimToken: "tok-img" } }, error: null });
+    const user = userEvent.setup();
+    render(<ImageToPdf creditCost={2} isAuthenticated={false} />);
+    addFiles([makeImage("photo1.png")]);
+    await waitFor(() => screen.getByText("photo1.png"));
+    await user.click(screen.getByRole("button", { name: /Convert to PDF/i }));
+    await waitFor(() => screen.getByRole("button", { name: /Already have an account/i }));
+    await user.click(screen.getByRole("button", { name: /Already have an account/i }));
+    expect(globalThis.sessionStorage.setItem).toHaveBeenCalledWith("pendingClaimToken", "tok-img");
+    expect(globalThis.location.href).toBe("/signin");
+  });
+
+  it("shows an error when createAnonymousSession returns failure", async () => {
+    (auth as any).currentUser = null;
+    createAnonymousSession.mockResolvedValue({ data: { success: false }, error: null });
+    const user = userEvent.setup();
+    render(<ImageToPdf creditCost={2} isAuthenticated={false} />);
+    addFiles([makeImage("photo1.png")]);
+    await waitFor(() => screen.getByText("photo1.png"));
+    await user.click(screen.getByRole("button", { name: /Convert to PDF/i }));
+    await waitFor(() =>
+      expect(screen.getByRole("alert")).toHaveTextContent(/Failed to start session/i),
+    );
+    expect(imageToPdf).not.toHaveBeenCalled();
+  });
+
+  it("shows an error when createAnonymousSession throws", async () => {
+    (auth as any).currentUser = null;
+    createAnonymousSession.mockRejectedValue(new Error("Network failure"));
+    const user = userEvent.setup();
+    render(<ImageToPdf creditCost={2} isAuthenticated={false} />);
+    addFiles([makeImage("photo1.png")]);
+    await waitFor(() => screen.getByText("photo1.png"));
+    await user.click(screen.getByRole("button", { name: /Convert to PDF/i }));
+    await waitFor(() =>
+      expect(screen.getByRole("alert")).toHaveTextContent(/Failed to start session/i),
+    );
   });
 });

--- a/apps/pdf-craft/src/components/views/ImageToPdf/ImageToPdf.tsx
+++ b/apps/pdf-craft/src/components/views/ImageToPdf/ImageToPdf.tsx
@@ -1,39 +1,69 @@
 'use client'
 import { useState } from "react"
 import { actions } from 'astro:actions'
+import { signInAnonymously } from 'firebase/auth'
 import {
   Container, Stack, Text, Button, FileDropzone, Callout, Card, Divider,
 } from '@fhdamd/threads'
 import * as Sentry from '@sentry/astro'
+import { auth } from '../../../firebase/client'
 import { logEvent } from '../../../utils/lib/analytics'
 import { DownloadIcon, DraggableFileList, ErrorCallout, INSUFFICIENT_CREDITS_ERROR, useDraggableFiles } from '../../shared'
 
 const MAX_IMAGES = 10
 
-export default function ImageToPdf({ creditCost }: { creditCost: number }) {
+export default function ImageToPdf({ creditCost, isAuthenticated = false }: { creditCost: number; isAuthenticated?: boolean }) {
   const { uploadedFiles, setUploadedFiles, error, setError, handleFiles, sensors, handleDragEnd, handleDelete } = useDraggableFiles(MAX_IMAGES)
-  const [isConverting, setIsConverting]   = useState(false)
-  const [downloadLink, setDownloadLink]   = useState<string | null>(null)
-  const [buttonLabel, setButtonLabel]     = useState('Convert to PDF')
+  const [isConverting, setIsConverting] = useState(false)
+  const [downloadLink, setDownloadLink] = useState<string | null>(null)
+  const [claimToken, setClaimToken]     = useState<string | null>(null)
+  const [buttonLabel, setButtonLabel]   = useState('Convert to PDF')
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault()
     const requestId = crypto.randomUUID()
     const task = 'image-to-pdf'
     setError(null)
-    setButtonLabel('Checking credits...')
     setIsConverting(true)
 
-    const response = await actions.credits.checkCredits({ task, requestId, creditCost })
-    if (!response.data?.success) {
-      setError(INSUFFICIENT_CREDITS_ERROR)
-      setButtonLabel('Convert to PDF')
-      setIsConverting(false)
-      return
+    const currentUser = auth.currentUser
+    const isAnon = !isAuthenticated
+
+    if (isAnon) {
+      setButtonLabel('Processing...')
+      if (!currentUser) {
+        try {
+          const credential = await signInAnonymously(auth)
+          const idToken = await credential.user.getIdToken()
+          const sessionRes = await actions.user.createAnonymousSession({ idToken })
+          if (!sessionRes.data?.success) {
+            setError('Failed to start session. Please try again.')
+            setButtonLabel('Convert to PDF')
+            setIsConverting(false)
+            return
+          }
+        } catch (err) {
+          setError('Failed to start session. Please try again.')
+          setButtonLabel('Convert to PDF')
+          setIsConverting(false)
+          Sentry.captureException(err)
+          return
+        }
+      }
+    } else {
+      setButtonLabel('Checking credits...')
+      const response = await actions.credits.checkCredits({ task, requestId, creditCost })
+      if (!response.data?.success) {
+        setError(INSUFFICIENT_CREDITS_ERROR)
+        setButtonLabel('Convert to PDF')
+        setIsConverting(false)
+        return
+      }
     }
 
     logEvent('pdf_operation_started', { operation_type: task, file_count: uploadedFiles.length })
     setButtonLabel('Converting images...')
+
     const formData = new FormData()
     uploadedFiles.forEach(file => formData.append('images', file))
     formData.append('requestId', requestId)
@@ -44,7 +74,12 @@ export default function ImageToPdf({ creditCost }: { creditCost: number }) {
       const convertResponse = await actions.operations.imageToPdf(formData)
       if (convertResponse.data) {
         logEvent('pdf_operation_completed', { operation_type: task, file_count: uploadedFiles.length })
-        setDownloadLink(convertResponse.data?.data?.fileUrl || null)
+        const token = convertResponse.data?.data?.claimToken
+        if (token) {
+          setClaimToken(token)
+        } else {
+          setDownloadLink(convertResponse.data?.data?.fileUrl || null)
+        }
       } else if (convertResponse.error) {
         logEvent('pdf_operation_failed', { operation_type: task })
         setError(
@@ -57,7 +92,6 @@ export default function ImageToPdf({ creditCost }: { creditCost: number }) {
     } catch (err) {
       logEvent('pdf_operation_failed', { operation_type: task })
       setError('An unexpected error occurred. Please try again.')
-      console.error('Error converting images to PDF:', err)
       Sentry.captureException(err)
     } finally {
       setButtonLabel('Convert to PDF')
@@ -65,8 +99,18 @@ export default function ImageToPdf({ creditCost }: { creditCost: number }) {
     }
   }
 
-  const reset = () => { setDownloadLink(null); setUploadedFiles([]); setError(null) }
+  const reset = () => { setDownloadLink(null); setClaimToken(null); setUploadedFiles([]); setError(null) }
   const atLimit = uploadedFiles.length >= MAX_IMAGES
+
+  const goToSignup = () => {
+    if (claimToken) sessionStorage.setItem('pendingClaimToken', claimToken)
+    window.location.href = '/signup'
+  }
+
+  const goToSignin = () => {
+    if (claimToken) sessionStorage.setItem('pendingClaimToken', claimToken)
+    window.location.href = '/signin'
+  }
 
   return (
     <Container>
@@ -83,7 +127,17 @@ export default function ImageToPdf({ creditCost }: { creditCost: number }) {
         <Card variant="elevated">
           <Stack gap={5} style={{ padding: 'var(--th-space-6)' }}>
 
-            {downloadLink ? (
+            {claimToken ? (
+              <Stack gap={4} align="center" style={{ paddingBlock: 'var(--th-space-4)' }}>
+                <Callout variant="success" title="Conversion complete">
+                  Create a free account to download your PDF — no credit card required.
+                </Callout>
+                <div style={{ display: 'flex', gap: 'var(--th-space-3)', flexWrap: 'wrap' }}>
+                  <Button variant="solid-terra" onClick={goToSignup}>Sign up to download</Button>
+                  <Button variant="ghost" onClick={goToSignin}>Already have an account?</Button>
+                </div>
+              </Stack>
+            ) : downloadLink ? (
               <Stack gap={4} align="center" style={{ paddingBlock: 'var(--th-space-4)' }}>
                 <Callout variant="success" title="Conversion complete">
                   Your images have been combined into a PDF file.

--- a/apps/pdf-craft/src/components/views/ImageToPdf/ImageToPdf.tsx
+++ b/apps/pdf-craft/src/components/views/ImageToPdf/ImageToPdf.tsx
@@ -12,26 +12,17 @@ import { DownloadIcon, DraggableFileList, ErrorCallout, INSUFFICIENT_CREDITS_ERR
 
 const MAX_IMAGES = 10
 
-export default function ImageToPdf({ creditCost, isAuthenticated = false }: { creditCost: number; isAuthenticated?: boolean }) {
+export default function ImageToPdf({ creditCost, isAuthenticated = false }: { readonly creditCost: number; readonly isAuthenticated?: boolean }) {
   const { uploadedFiles, setUploadedFiles, error, setError, handleFiles, sensors, handleDragEnd, handleDelete } = useDraggableFiles(MAX_IMAGES)
   const [isConverting, setIsConverting] = useState(false)
   const [downloadLink, setDownloadLink] = useState<string | null>(null)
   const [claimToken, setClaimToken]     = useState<string | null>(null)
   const [buttonLabel, setButtonLabel]   = useState('Convert to PDF')
 
-  const handleSubmit = async (e: React.FormEvent) => {
-    e.preventDefault()
-    const requestId = crypto.randomUUID()
-    const task = 'image-to-pdf'
-    setError(null)
-    setIsConverting(true)
-
-    const currentUser = auth.currentUser
-    const isAnon = !isAuthenticated
-
-    if (isAnon) {
+  const prepareSession = async (task: string, requestId: string): Promise<boolean> => {
+    if (!isAuthenticated) {
       setButtonLabel('Processing...')
-      if (!currentUser) {
+      if (!auth.currentUser) {
         try {
           const credential = await signInAnonymously(auth)
           const idToken = await credential.user.getIdToken()
@@ -40,26 +31,37 @@ export default function ImageToPdf({ creditCost, isAuthenticated = false }: { cr
             setError('Failed to start session. Please try again.')
             setButtonLabel('Convert to PDF')
             setIsConverting(false)
-            return
+            return false
           }
         } catch (err) {
           setError('Failed to start session. Please try again.')
           setButtonLabel('Convert to PDF')
           setIsConverting(false)
           Sentry.captureException(err)
-          return
+          return false
         }
       }
-    } else {
-      setButtonLabel('Checking credits...')
-      const response = await actions.credits.checkCredits({ task, requestId, creditCost })
-      if (!response.data?.success) {
-        setError(INSUFFICIENT_CREDITS_ERROR)
-        setButtonLabel('Convert to PDF')
-        setIsConverting(false)
-        return
-      }
+      return true
     }
+    setButtonLabel('Checking credits...')
+    const response = await actions.credits.checkCredits({ task, requestId, creditCost })
+    if (!response.data?.success) {
+      setError(INSUFFICIENT_CREDITS_ERROR)
+      setButtonLabel('Convert to PDF')
+      setIsConverting(false)
+      return false
+    }
+    return true
+  }
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault()
+    const requestId = crypto.randomUUID()
+    const task = 'image-to-pdf'
+    setError(null)
+    setIsConverting(true)
+
+    if (!await prepareSession(task, requestId)) return
 
     logEvent('pdf_operation_started', { operation_type: task, file_count: uploadedFiles.length })
     setButtonLabel('Converting images...')
@@ -104,12 +106,67 @@ export default function ImageToPdf({ creditCost, isAuthenticated = false }: { cr
 
   const goToSignup = () => {
     if (claimToken) sessionStorage.setItem('pendingClaimToken', claimToken)
-    window.location.href = '/signup'
+    globalThis.location.href = '/signup'
   }
 
   const goToSignin = () => {
     if (claimToken) sessionStorage.setItem('pendingClaimToken', claimToken)
-    window.location.href = '/signin'
+    globalThis.location.href = '/signin'
+  }
+
+  const renderContent = () => {
+    if (claimToken) return (
+      <Stack gap={4} align="center" style={{ paddingBlock: 'var(--th-space-4)' }}>
+        <Callout variant="success" title="Conversion complete">
+          Create a free account to download your PDF — no credit card required.
+        </Callout>
+        <div style={{ display: 'flex', gap: 'var(--th-space-3)', flexWrap: 'wrap' }}>
+          <Button variant="solid-terra" onClick={goToSignup}>Sign up to download</Button>
+          <Button variant="ghost" onClick={goToSignin}>Already have an account?</Button>
+        </div>
+      </Stack>
+    )
+    if (downloadLink) return (
+      <Stack gap={4} align="center" style={{ paddingBlock: 'var(--th-space-4)' }}>
+        <Callout variant="success" title="Conversion complete">
+          Your images have been combined into a PDF file.
+        </Callout>
+        <div style={{ display: 'flex', gap: 'var(--th-space-3)', flexWrap: 'wrap' }}>
+          <Button href={downloadLink} variant="solid-terra" icon={<DownloadIcon />}>Download PDF</Button>
+          <Button variant="ghost" onClick={reset}>Convert more images</Button>
+        </div>
+      </Stack>
+    )
+    return (
+      <>
+        {!atLimit ? (
+          <FileDropzone label="Upload images"
+            hint={`Drag and drop or click to browse — PNG/JPG only, up to ${MAX_IMAGES} images (${uploadedFiles.length}/${MAX_IMAGES} added)`}
+            accept="image/png,image/jpeg" multiple onFiles={handleFiles} />
+        ) : (
+          <Callout variant="info">
+            Maximum of {MAX_IMAGES} images reached. Remove an image to add another.
+          </Callout>
+        )}
+        {uploadedFiles.length > 0 && (
+          <>
+            <Divider />
+            <Stack gap={3}>
+              <Stack gap={1}>
+                <Text size="sm" color="1" weight={600}>Images to convert ({uploadedFiles.length})</Text>
+                <Text size="xs" color="2">Drag to reorder — images will appear as pages in this order</Text>
+              </Stack>
+              <DraggableFileList files={uploadedFiles} sensors={sensors} onDragEnd={handleDragEnd} onDelete={handleDelete} />
+            </Stack>
+            {error && <ErrorCallout message={error} />}
+            <form onSubmit={handleSubmit}>
+              <Button type="submit" variant="solid-terra" disabled={isConverting}>{buttonLabel}</Button>
+            </form>
+          </>
+        )}
+        {error && uploadedFiles.length === 0 && <ErrorCallout message={error} />}
+      </>
+    )
   }
 
   return (
@@ -126,69 +183,7 @@ export default function ImageToPdf({ creditCost, isAuthenticated = false }: { cr
 
         <Card variant="elevated">
           <Stack gap={5} style={{ padding: 'var(--th-space-6)' }}>
-
-            {claimToken ? (
-              <Stack gap={4} align="center" style={{ paddingBlock: 'var(--th-space-4)' }}>
-                <Callout variant="success" title="Conversion complete">
-                  Create a free account to download your PDF — no credit card required.
-                </Callout>
-                <div style={{ display: 'flex', gap: 'var(--th-space-3)', flexWrap: 'wrap' }}>
-                  <Button variant="solid-terra" onClick={goToSignup}>Sign up to download</Button>
-                  <Button variant="ghost" onClick={goToSignin}>Already have an account?</Button>
-                </div>
-              </Stack>
-            ) : downloadLink ? (
-              <Stack gap={4} align="center" style={{ paddingBlock: 'var(--th-space-4)' }}>
-                <Callout variant="success" title="Conversion complete">
-                  Your images have been combined into a PDF file.
-                </Callout>
-                <div style={{ display: 'flex', gap: 'var(--th-space-3)', flexWrap: 'wrap' }}>
-                  <Button href={downloadLink} variant="solid-terra" icon={<DownloadIcon />}>
-                    Download PDF
-                  </Button>
-                  <Button variant="ghost" onClick={reset}>Convert more images</Button>
-                </div>
-              </Stack>
-            ) : (
-              <>
-                {!atLimit ? (
-                  <FileDropzone
-                    label="Upload images"
-                    hint={`Drag and drop or click to browse — PNG/JPG only, up to ${MAX_IMAGES} images (${uploadedFiles.length}/${MAX_IMAGES} added)`}
-                    accept="image/png,image/jpeg"
-                    multiple
-                    onFiles={handleFiles}
-                  />
-                ) : (
-                  <Callout variant="info">
-                    Maximum of {MAX_IMAGES} images reached. Remove an image to add another.
-                  </Callout>
-                )}
-
-                {uploadedFiles.length > 0 && (
-                  <>
-                    <Divider />
-                    <Stack gap={3}>
-                      <Stack gap={1}>
-                        <Text size="sm" color="1" weight={600}>Images to convert ({uploadedFiles.length})</Text>
-                        <Text size="xs" color="2">Drag to reorder — images will appear as pages in this order</Text>
-                      </Stack>
-                      <DraggableFileList files={uploadedFiles} sensors={sensors} onDragEnd={handleDragEnd} onDelete={handleDelete} />
-                    </Stack>
-
-                    {error && <ErrorCallout message={error} />}
-
-                    <form onSubmit={handleSubmit}>
-                      <Button type="submit" variant="solid-terra" disabled={isConverting}>
-                        {buttonLabel}
-                      </Button>
-                    </form>
-                  </>
-                )}
-
-                {error && uploadedFiles.length === 0 && <ErrorCallout message={error} />}
-              </>
-            )}
+            {renderContent()}
 
           </Stack>
         </Card>

--- a/apps/pdf-craft/src/components/views/ImageToPdf/ImageToPdf.tsx
+++ b/apps/pdf-craft/src/components/views/ImageToPdf/ImageToPdf.tsx
@@ -1,14 +1,12 @@
 'use client'
 import { useState } from "react"
 import { actions } from 'astro:actions'
-import { signInAnonymously } from 'firebase/auth'
 import {
   Container, Stack, Text, Button, FileDropzone, Callout, Card, Divider,
 } from '@fhdamd/threads'
-import * as Sentry from '@sentry/astro'
-import { auth } from '../../../firebase/client'
 import { logEvent } from '../../../utils/lib/analytics'
-import { DownloadIcon, DraggableFileList, ErrorCallout, INSUFFICIENT_CREDITS_ERROR, useDraggableFiles } from '../../shared'
+import { buildPrepareSession } from '../../../utils/lib/operationSession'
+import { DownloadIcon, DraggableFileList, ErrorCallout, useDraggableFiles } from '../../shared'
 
 const MAX_IMAGES = 10
 
@@ -19,40 +17,10 @@ export default function ImageToPdf({ creditCost, isAuthenticated = false }: { re
   const [claimToken, setClaimToken]     = useState<string | null>(null)
   const [buttonLabel, setButtonLabel]   = useState('Convert to PDF')
 
-  const prepareSession = async (task: string, requestId: string): Promise<boolean> => {
-    if (!isAuthenticated) {
-      setButtonLabel('Processing...')
-      if (!auth.currentUser) {
-        try {
-          const credential = await signInAnonymously(auth)
-          const idToken = await credential.user.getIdToken()
-          const sessionRes = await actions.user.createAnonymousSession({ idToken })
-          if (!sessionRes.data?.success) {
-            setError('Failed to start session. Please try again.')
-            setButtonLabel('Convert to PDF')
-            setIsConverting(false)
-            return false
-          }
-        } catch (err) {
-          setError('Failed to start session. Please try again.')
-          setButtonLabel('Convert to PDF')
-          setIsConverting(false)
-          Sentry.captureException(err)
-          return false
-        }
-      }
-      return true
-    }
-    setButtonLabel('Checking credits...')
-    const response = await actions.credits.checkCredits({ task, requestId, creditCost })
-    if (!response.data?.success) {
-      setError(INSUFFICIENT_CREDITS_ERROR)
-      setButtonLabel('Convert to PDF')
-      setIsConverting(false)
-      return false
-    }
-    return true
-  }
+  const prepareSession = buildPrepareSession({
+    isAuthenticated, creditCost, defaultLabel: 'Convert to PDF',
+    setButtonLabel, setError: (e) => setError(e), setProcessing: setIsConverting,
+  })
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault()

--- a/apps/pdf-craft/src/components/views/SigninForm/SigninForm.test.tsx
+++ b/apps/pdf-craft/src/components/views/SigninForm/SigninForm.test.tsx
@@ -22,13 +22,18 @@ vi.mock("../../../utils/lib/analytics", () => ({
 }));
 
 import SigninForm from "./SigninForm";
-import { verifyUser } from "../../../test/mocks/astro-actions";
+import { verifyUser, migrateFile } from "../../../test/mocks/astro-actions";
+
+const mockSessionStorage = { getItem: vi.fn(() => null), removeItem: vi.fn(), setItem: vi.fn() };
 
 beforeEach(() => {
   vi.clearAllMocks();
   mockGetToken.mockResolvedValue("captcha-token");
   mockSignIn.mockResolvedValue({ user: { uid: "uid-1", getIdToken: mockGetIdToken } });
-  verifyUser.mockResolvedValue({ data: { redirected: false }, error: null });
+  verifyUser.mockResolvedValue({ data: { redirected: true, url: "/dashboard" }, error: null });
+  migrateFile.mockResolvedValue({ data: { success: true }, error: null });
+  mockSessionStorage.getItem.mockReturnValue(null);
+  vi.stubGlobal("sessionStorage", mockSessionStorage);
   vi.stubGlobal("location", { assign: vi.fn(), href: "" } as any);
 });
 
@@ -76,7 +81,6 @@ describe("SigninForm", () => {
   });
 
   it("navigates when verifyUser returns redirected=true", async () => {
-    verifyUser.mockResolvedValue({ data: { redirected: true, url: "/dashboard" } });
     const user = userEvent.setup();
     render(<SigninForm />);
     await user.type(screen.getByLabelText("Email address"), "user@test.com");
@@ -95,5 +99,49 @@ describe("SigninForm", () => {
     await waitFor(() =>
       expect(screen.getByRole("alert")).toHaveTextContent(/Failed to sign in/i),
     );
+  });
+
+  // ── Pending claim token migration ─────────────────────────────────────────
+
+  it("does not call migrateFile when sessionStorage has no pending token", async () => {
+    mockSessionStorage.getItem.mockReturnValue(null);
+    const user = userEvent.setup();
+    render(<SigninForm />);
+    await user.type(screen.getByLabelText("Email address"), "user@test.com");
+    await user.type(screen.getByLabelText("Password"), "secret");
+    await user.click(screen.getByRole("button", { name: /Sign in/i }));
+    await waitFor(() => expect(globalThis.location.assign).toHaveBeenCalled());
+    expect(migrateFile).not.toHaveBeenCalled();
+  });
+
+  it("calls migrateFile with the pending claim token before redirecting", async () => {
+    mockSessionStorage.getItem.mockReturnValue("claim-token-abc");
+    const user = userEvent.setup();
+    render(<SigninForm />);
+    await user.type(screen.getByLabelText("Email address"), "user@test.com");
+    await user.type(screen.getByLabelText("Password"), "secret");
+    await user.click(screen.getByRole("button", { name: /Sign in/i }));
+    await waitFor(() => expect(migrateFile).toHaveBeenCalledWith({ claimToken: "claim-token-abc" }));
+  });
+
+  it("removes the claim token from sessionStorage after calling migrateFile", async () => {
+    mockSessionStorage.getItem.mockReturnValue("claim-token-abc");
+    const user = userEvent.setup();
+    render(<SigninForm />);
+    await user.type(screen.getByLabelText("Email address"), "user@test.com");
+    await user.type(screen.getByLabelText("Password"), "secret");
+    await user.click(screen.getByRole("button", { name: /Sign in/i }));
+    await waitFor(() => expect(mockSessionStorage.removeItem).toHaveBeenCalledWith("pendingClaimToken"));
+  });
+
+  it("still redirects to dashboard even when migrateFile throws", async () => {
+    mockSessionStorage.getItem.mockReturnValue("claim-token-abc");
+    migrateFile.mockRejectedValue(new Error("Network error"));
+    const user = userEvent.setup();
+    render(<SigninForm />);
+    await user.type(screen.getByLabelText("Email address"), "user@test.com");
+    await user.type(screen.getByLabelText("Password"), "secret");
+    await user.click(screen.getByRole("button", { name: /Sign in/i }));
+    await waitFor(() => expect(globalThis.location.assign).toHaveBeenCalledWith("/dashboard"));
   });
 });

--- a/apps/pdf-craft/src/components/views/SigninForm/SigninForm.tsx
+++ b/apps/pdf-craft/src/components/views/SigninForm/SigninForm.tsx
@@ -51,7 +51,7 @@ export default function SigninForm() {
         }
       }
 
-      window.location.assign('/dashboard')
+      globalThis.location.assign('/dashboard')
     } catch (err) {
       setError('Failed to sign in. Please check your credentials.')
       Sentry.captureException(err)

--- a/apps/pdf-craft/src/components/views/SigninForm/SigninForm.tsx
+++ b/apps/pdf-craft/src/components/views/SigninForm/SigninForm.tsx
@@ -12,14 +12,18 @@ export default function SigninForm() {
   const [email, setEmail]       = useState('')
   const [password, setPassword] = useState('')
   const [error, setError]       = useState('')
+  const [isLoading, setIsLoading] = useState(false)
   const { getToken } = useRecaptcha('signin')
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault()
+    setIsLoading(true)
+    setError('')
 
     const captchaToken = await getToken()
     if (!captchaToken) {
       setError('Captcha verification failed. Please try again.')
+      setIsLoading(false)
       return
     }
 
@@ -27,15 +31,31 @@ export default function SigninForm() {
       const userCredential = await signInWithEmailAndPassword(auth, email, password)
       const idToken = await userCredential.user.getIdToken()
       const response = await actions.user.verifyUser({ idToken, captchaToken })
-      if (response.data?.redirected) {
-        logEvent('login', { method: 'email' })
-        setUserId(userCredential.user.uid)
-        window.location.assign(response.data?.url)
+      if (!response.data?.redirected) {
+        setError('Sign in failed. Please try again.')
+        setIsLoading(false)
+        return
       }
+
+      logEvent('login', { method: 'email' })
+      setUserId(userCredential.user.uid)
+
+      // If the user arrived here after an anonymous operation, migrate their file
+      const claimToken = sessionStorage.getItem('pendingClaimToken')
+      if (claimToken) {
+        sessionStorage.removeItem('pendingClaimToken')
+        try {
+          await actions.claims.migrateFile({ claimToken })
+        } catch {
+          // Non-fatal: file may have expired, proceed to dashboard anyway
+        }
+      }
+
+      window.location.assign('/dashboard')
     } catch (err) {
       setError('Failed to sign in. Please check your credentials.')
-      console.error('Error signing in:', err)
       Sentry.captureException(err)
+      setIsLoading(false)
     }
   }
 
@@ -76,8 +96,8 @@ export default function SigninForm() {
             </a>
           </div>
         </div>
-        <Button type="submit" variant="solid-terra" style={{ width: '100%' }}>
-          Sign in
+        <Button type="submit" variant="solid-terra" disabled={isLoading} style={{ width: '100%' }}>
+          {isLoading ? 'Signing in…' : 'Sign in'}
         </Button>
       </Stack>
     </form>

--- a/apps/pdf-craft/src/components/views/SignupForm/SignupForm.test.tsx
+++ b/apps/pdf-craft/src/components/views/SignupForm/SignupForm.test.tsx
@@ -3,6 +3,16 @@ import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
 const mockGetToken = vi.fn().mockResolvedValue("captcha-token");
+const mockCreateUserWithEmailAndPassword = vi.fn();
+const mockLinkWithCredential = vi.fn();
+const mockSignInWithEmailAndPassword = vi.fn();
+
+vi.mock("firebase/auth", () => ({
+  createUserWithEmailAndPassword: (...args: unknown[]) => mockCreateUserWithEmailAndPassword(...args),
+  linkWithCredential: (...args: unknown[]) => mockLinkWithCredential(...args),
+  EmailAuthProvider: { credential: vi.fn(() => ({ type: "email" })) },
+  signInWithEmailAndPassword: (...args: unknown[]) => mockSignInWithEmailAndPassword(...args),
+}));
 
 vi.mock("../../../utils", () => ({
   useRecaptcha: () => ({ getToken: mockGetToken }),
@@ -14,13 +24,24 @@ vi.mock("../../../utils/lib/analytics", () => ({
 }));
 
 import SignupForm from "./SignupForm";
-import { createUser } from "../../../test/mocks/astro-actions";
+import { finalizeLinkedUser, migrateFile } from "../../../test/mocks/astro-actions";
+import { auth } from "../../../firebase/client";
+
+const mockUser = { uid: "new-uid", isAnonymous: false, getIdToken: async () => "new-id-token" };
+const mockAnonUser = { uid: "anon-uid", isAnonymous: true, getIdToken: async () => "anon-id-token" };
 
 beforeEach(() => {
   vi.clearAllMocks();
   mockGetToken.mockResolvedValue("captcha-token");
-  createUser.mockResolvedValue({ data: { success: true }, error: null });
-  vi.stubGlobal("location", { href: "", assign: vi.fn() });
+  // Default: no anonymous session active
+  (auth as any).currentUser = { uid: "test-uid", isAnonymous: false };
+  mockCreateUserWithEmailAndPassword.mockResolvedValue({ user: mockUser });
+  mockLinkWithCredential.mockResolvedValue({ user: mockUser });
+  mockSignInWithEmailAndPassword.mockResolvedValue({ user: mockUser });
+  finalizeLinkedUser.mockResolvedValue({ data: { success: true }, error: null });
+  migrateFile.mockResolvedValue({ data: { success: true }, error: null });
+  vi.stubGlobal("location", { href: "" });
+  vi.stubGlobal("sessionStorage", { getItem: vi.fn(() => null), removeItem: vi.fn(), setItem: vi.fn() });
 });
 
 describe("SignupForm", () => {
@@ -43,10 +64,10 @@ describe("SignupForm", () => {
     await waitFor(() =>
       expect(screen.getByRole("alert")).toHaveTextContent(/Captcha verification failed/i),
     );
-    expect(createUser).not.toHaveBeenCalled();
+    expect(mockCreateUserWithEmailAndPassword).not.toHaveBeenCalled();
   });
 
-  it("calls actions.user.createUser with form values and captcha token", async () => {
+  it("calls finalizeLinkedUser after creating the account and redirects to /dashboard", async () => {
     const user = userEvent.setup();
     render(<SignupForm />);
     await user.type(screen.getByLabelText("Full name"), "Jane");
@@ -54,27 +75,26 @@ describe("SignupForm", () => {
     await user.type(screen.getByLabelText("Password"), "password123");
     await user.click(screen.getByRole("button", { name: /Create account/i }));
     await waitFor(() =>
-      expect(createUser).toHaveBeenCalledWith({
-        name: "Jane",
-        email: "jane@test.com",
-        password: "password123",
-        captchaToken: "captcha-token",
-      }),
+      expect(finalizeLinkedUser).toHaveBeenCalledWith({ idToken: "new-id-token", name: "Jane" }),
     );
+    await waitFor(() => expect(globalThis.location.href).toBe("/dashboard"));
   });
 
-  it("redirects to /signin on success", async () => {
+  it("shows a weak-password error when Firebase rejects the password", async () => {
+    mockCreateUserWithEmailAndPassword.mockRejectedValue({ code: "auth/weak-password" });
     const user = userEvent.setup();
     render(<SignupForm />);
     await user.type(screen.getByLabelText("Full name"), "Jane");
     await user.type(screen.getByLabelText("Email address"), "jane@test.com");
-    await user.type(screen.getByLabelText("Password"), "password123");
+    await user.type(screen.getByLabelText("Password"), "abc");
     await user.click(screen.getByRole("button", { name: /Create account/i }));
-    await waitFor(() => expect(globalThis.location.href).toBe("/signin"));
+    await waitFor(() =>
+      expect(screen.getByRole("alert")).toHaveTextContent(/Password must be at least 6 characters/i),
+    );
   });
 
-  it("shows an API error message when createUser returns success=false", async () => {
-    createUser.mockResolvedValue({ data: { success: false, error: "Email already in use." } });
+  it("shows an error when finalizeLinkedUser returns success=false", async () => {
+    finalizeLinkedUser.mockResolvedValue({ data: { success: false, error: "Failed to set up your account. Please try again." } });
     const user = userEvent.setup();
     render(<SignupForm />);
     await user.type(screen.getByLabelText("Full name"), "Jane");
@@ -82,12 +102,12 @@ describe("SignupForm", () => {
     await user.type(screen.getByLabelText("Password"), "password123");
     await user.click(screen.getByRole("button", { name: /Create account/i }));
     await waitFor(() =>
-      expect(screen.getByRole("alert")).toHaveTextContent("Email already in use."),
+      expect(screen.getByRole("alert")).toHaveTextContent(/Failed to set up your account/i),
     );
   });
 
-  it("shows the exception message when createUser throws", async () => {
-    createUser.mockRejectedValue({ message: "Network error" });
+  it("shows email-already-in-use error for duplicate accounts", async () => {
+    mockCreateUserWithEmailAndPassword.mockRejectedValue({ code: "auth/email-already-in-use" });
     const user = userEvent.setup();
     render(<SignupForm />);
     await user.type(screen.getByLabelText("Full name"), "Jane");
@@ -95,7 +115,51 @@ describe("SignupForm", () => {
     await user.type(screen.getByLabelText("Password"), "password123");
     await user.click(screen.getByRole("button", { name: /Create account/i }));
     await waitFor(() =>
-      expect(screen.getByRole("alert")).toHaveTextContent("Network error"),
+      expect(screen.getByRole("alert")).toHaveTextContent(/already exists.*sign in/i),
     );
+  });
+
+  // ── Anonymous user flows ──────────────────────────────────────────────────
+
+  it("calls linkWithCredential when currentUser is anonymous", async () => {
+    (auth as any).currentUser = { ...mockAnonUser };
+    mockLinkWithCredential.mockResolvedValue({ user: { ...mockUser, getIdToken: async () => "linked-token" } });
+    const user = userEvent.setup();
+    render(<SignupForm />);
+    await user.type(screen.getByLabelText("Full name"), "Jane");
+    await user.type(screen.getByLabelText("Email address"), "jane@test.com");
+    await user.type(screen.getByLabelText("Password"), "password123");
+    await user.click(screen.getByRole("button", { name: /Create account/i }));
+    await waitFor(() => expect(mockLinkWithCredential).toHaveBeenCalled());
+    expect(mockCreateUserWithEmailAndPassword).not.toHaveBeenCalled();
+  });
+
+  it("redirects to /buy-credits after linking an anonymous account", async () => {
+    (auth as any).currentUser = { ...mockAnonUser };
+    mockLinkWithCredential.mockResolvedValue({ user: { ...mockUser, getIdToken: async () => "linked-token" } });
+    const user = userEvent.setup();
+    render(<SignupForm />);
+    await user.type(screen.getByLabelText("Full name"), "Jane");
+    await user.type(screen.getByLabelText("Email address"), "jane@test.com");
+    await user.type(screen.getByLabelText("Password"), "password123");
+    await user.click(screen.getByRole("button", { name: /Create account/i }));
+    await waitFor(() => expect(globalThis.location.href).toBe("/buy-credits"));
+  });
+
+  it("falls back to signIn and calls migrateFile when link fails with email-already-in-use", async () => {
+    (auth as any).currentUser = { ...mockAnonUser };
+    mockLinkWithCredential.mockRejectedValue({ code: "auth/email-already-in-use" });
+    mockSignInWithEmailAndPassword.mockResolvedValue({ user: { ...mockUser, getIdToken: async () => "existing-token" } });
+    // Simulate sessionStorage has a pending token
+    (globalThis.sessionStorage.getItem as any).mockReturnValue("claim-token-abc");
+    const user = userEvent.setup();
+    render(<SignupForm />);
+    await user.type(screen.getByLabelText("Full name"), "Jane");
+    await user.type(screen.getByLabelText("Email address"), "existing@test.com");
+    await user.type(screen.getByLabelText("Password"), "password123");
+    await user.click(screen.getByRole("button", { name: /Create account/i }));
+    await waitFor(() => expect(mockSignInWithEmailAndPassword).toHaveBeenCalled());
+    await waitFor(() => expect(migrateFile).toHaveBeenCalledWith({ claimToken: "claim-token-abc" }));
+    await waitFor(() => expect(globalThis.location.href).toBe("/dashboard"));
   });
 });

--- a/apps/pdf-craft/src/components/views/SignupForm/SignupForm.tsx
+++ b/apps/pdf-craft/src/components/views/SignupForm/SignupForm.tsx
@@ -21,6 +21,25 @@ export default function SignupForm() {
   const [isLoading, setIsLoading] = useState(false)
   const { getToken } = useRecaptcha('signup')
 
+  // Resolves the Firebase ID token for the appropriate account creation path.
+  // Returns isNewUser=false when falling back to sign-in for an existing account.
+  const resolveIdToken = async (): Promise<{ idToken: string; isNewUser: boolean }> => {
+    const currentUser = auth.currentUser
+    if (currentUser?.isAnonymous) {
+      const credential = EmailAuthProvider.credential(email, password)
+      try {
+        const linked = await linkWithCredential(currentUser, credential)
+        return { idToken: await linked.user.getIdToken(), isNewUser: true }
+      } catch (linkErr: any) {
+        if (linkErr.code !== 'auth/email-already-in-use') throw linkErr
+        const signed = await signInWithEmailAndPassword(auth, email, password)
+        return { idToken: await signed.user.getIdToken(), isNewUser: false }
+      }
+    }
+    const created = await createUserWithEmailAndPassword(auth, email, password)
+    return { idToken: await created.user.getIdToken(), isNewUser: true }
+  }
+
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault()
     setIsLoading(true)
@@ -33,36 +52,12 @@ export default function SignupForm() {
       return
     }
 
-    const credential = EmailAuthProvider.credential(email, password)
-    const currentUser = auth.currentUser
-    const isAnonymousSession = currentUser?.isAnonymous ?? false
+    const isAnonymousSession = auth.currentUser?.isAnonymous ?? false
     const claimToken = sessionStorage.getItem('pendingClaimToken')
 
     try {
-      let idToken: string
-      let isNewUser = true
+      const { idToken, isNewUser } = await resolveIdToken()
 
-      if (currentUser?.isAnonymous) {
-        try {
-          const linked = await linkWithCredential(currentUser, credential)
-          idToken = await linked.user.getIdToken()
-          // Same UID preserved — file is already under their account
-        } catch (linkErr: any) {
-          if (linkErr.code === 'auth/email-already-in-use') {
-            // Existing account — sign in and migrate their file
-            isNewUser = false
-            const signed = await signInWithEmailAndPassword(auth, email, password)
-            idToken = await signed.user.getIdToken()
-          } else {
-            throw linkErr
-          }
-        }
-      } else {
-        const created = await createUserWithEmailAndPassword(auth, email, password)
-        idToken = await created.user.getIdToken()
-      }
-
-      // Create session cookie + initialise profile if needed
       const finalizeRes = await actions.user.finalizeLinkedUser({ idToken, name })
       if (!finalizeRes.data?.success) {
         setError(finalizeRes.data?.error || 'Failed to set up your account. Please try again.')
@@ -73,20 +68,12 @@ export default function SignupForm() {
       logEvent('sign_up', { method: 'email' })
       if (auth.currentUser) setUserId(auth.currentUser.uid)
 
+      sessionStorage.removeItem('pendingClaimToken')
       if (!isNewUser && claimToken) {
-        // Existing account path: migrate the anonymous file to their real account
-        sessionStorage.removeItem('pendingClaimToken')
-        try {
-          await actions.claims.migrateFile({ claimToken })
-        } catch {
-          // Non-fatal: file may have expired, user still proceeds to dashboard
-        }
-        window.location.href = '/dashboard'
+        await actions.claims.migrateFile({ claimToken }).catch(() => {})
+        globalThis.location.href = '/dashboard'
       } else {
-        // New account: clear the token (file is already under their UID via link)
-        // Send them to buy credits so they can download the pending file
-        sessionStorage.removeItem('pendingClaimToken')
-        window.location.href = isAnonymousSession ? '/buy-credits' : '/dashboard'
+        globalThis.location.href = isAnonymousSession ? '/buy-credits' : '/dashboard'
       }
     } catch (err: any) {
       if (err.code === 'auth/email-already-in-use') {

--- a/apps/pdf-craft/src/components/views/SignupForm/SignupForm.tsx
+++ b/apps/pdf-craft/src/components/views/SignupForm/SignupForm.tsx
@@ -1,8 +1,15 @@
 'use client'
 import { useState } from 'react'
 import { actions } from 'astro:actions'
+import {
+  createUserWithEmailAndPassword,
+  linkWithCredential,
+  EmailAuthProvider,
+  signInWithEmailAndPassword,
+} from 'firebase/auth'
 import { Input, Button, Stack, Callout } from '@fhdamd/threads'
 import * as Sentry from '@sentry/astro'
+import { auth } from '../../../firebase/client'
 import { useRecaptcha } from '../../../utils'
 import { logEvent, setUserId } from '../../../utils/lib/analytics'
 
@@ -11,37 +18,86 @@ export default function SignupForm() {
   const [email, setEmail]       = useState('')
   const [password, setPassword] = useState('')
   const [error, setError]       = useState('')
+  const [isLoading, setIsLoading] = useState(false)
   const { getToken } = useRecaptcha('signup')
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault()
+    setIsLoading(true)
+    setError('')
 
     const captchaToken = await getToken()
     if (!captchaToken) {
       setError('Captcha verification failed. Please try again.')
+      setIsLoading(false)
       return
     }
 
-    try {
-      const response = await actions.user.createUser({
-        name,
-        email,
-        password,
-        captchaToken,
-      })
+    const credential = EmailAuthProvider.credential(email, password)
+    const currentUser = auth.currentUser
+    const isAnonymousSession = currentUser?.isAnonymous ?? false
+    const claimToken = sessionStorage.getItem('pendingClaimToken')
 
-      if (response.data?.success) {
-        logEvent('sign_up', { method: 'email' })
-        if (response.data.payload?.userId) {
-          setUserId(response.data.payload.userId)
+    try {
+      let idToken: string
+      let isNewUser = true
+
+      if (currentUser?.isAnonymous) {
+        try {
+          const linked = await linkWithCredential(currentUser, credential)
+          idToken = await linked.user.getIdToken()
+          // Same UID preserved — file is already under their account
+        } catch (linkErr: any) {
+          if (linkErr.code === 'auth/email-already-in-use') {
+            // Existing account — sign in and migrate their file
+            isNewUser = false
+            const signed = await signInWithEmailAndPassword(auth, email, password)
+            idToken = await signed.user.getIdToken()
+          } else {
+            throw linkErr
+          }
         }
-        window.location.href = '/signin'
       } else {
-        setError(response.data?.error || 'An unknown error occurred.')
+        const created = await createUserWithEmailAndPassword(auth, email, password)
+        idToken = await created.user.getIdToken()
+      }
+
+      // Create session cookie + initialise profile if needed
+      const finalizeRes = await actions.user.finalizeLinkedUser({ idToken, name })
+      if (!finalizeRes.data?.success) {
+        setError(finalizeRes.data?.error || 'Failed to set up your account. Please try again.')
+        setIsLoading(false)
+        return
+      }
+
+      logEvent('sign_up', { method: 'email' })
+      if (auth.currentUser) setUserId(auth.currentUser.uid)
+
+      if (!isNewUser && claimToken) {
+        // Existing account path: migrate the anonymous file to their real account
+        sessionStorage.removeItem('pendingClaimToken')
+        try {
+          await actions.claims.migrateFile({ claimToken })
+        } catch {
+          // Non-fatal: file may have expired, user still proceeds to dashboard
+        }
+        window.location.href = '/dashboard'
+      } else {
+        // New account: clear the token (file is already under their UID via link)
+        // Send them to buy credits so they can download the pending file
+        sessionStorage.removeItem('pendingClaimToken')
+        window.location.href = isAnonymousSession ? '/buy-credits' : '/dashboard'
       }
     } catch (err: any) {
-      setError(err.message)
-      Sentry.captureException(err)
+      if (err.code === 'auth/email-already-in-use') {
+        setError('An account with this email already exists. Sign in instead.')
+      } else if (err.code === 'auth/weak-password') {
+        setError('Password must be at least 6 characters.')
+      } else {
+        setError(err.message || 'An unexpected error occurred.')
+        Sentry.captureException(err)
+      }
+      setIsLoading(false)
     }
   }
 
@@ -80,8 +136,8 @@ export default function SignupForm() {
           hint="At least 8 characters recommended"
           required
         />
-        <Button type="submit" variant="solid-terra" style={{ width: '100%' }}>
-          Create account
+        <Button type="submit" variant="solid-terra" disabled={isLoading} style={{ width: '100%' }}>
+          {isLoading ? 'Creating account…' : 'Create account'}
         </Button>
       </Stack>
     </form>

--- a/apps/pdf-craft/src/firebase/server.ts
+++ b/apps/pdf-craft/src/firebase/server.ts
@@ -60,3 +60,16 @@ export async function getFirebaseFirestore() {
   }
   return _db;
 }
+
+// Returns true when the __session cookie belongs to a real (non-anonymous) account.
+// Used by operation pages to tell their client components whether to skip the anon flow.
+export async function resolveIsAuthenticated(sessionCookieValue: string | undefined): Promise<boolean> {
+  if (!sessionCookieValue) return false;
+  try {
+    const auth = await getFirebaseAuth();
+    const decoded = await auth.verifySessionCookie(sessionCookieValue, true);
+    return decoded.firebase.sign_in_provider !== 'anonymous';
+  } catch {
+    return false;
+  }
+}

--- a/apps/pdf-craft/src/pages/buy-credits.astro
+++ b/apps/pdf-craft/src/pages/buy-credits.astro
@@ -18,6 +18,14 @@ import "../styles/pricing.css";
     <div class="pricing-grid">
       <Pricing client:load />
     </div>
+    <div style="text-align:center;margin-top:var(--th-space-6)">
+      <a
+        href="/dashboard"
+        style="font-size:var(--th-text-sm);color:var(--th-color-text-3);text-decoration:underline;text-underline-offset:3px"
+      >
+        Maybe later — go to dashboard
+      </a>
+    </div>
   </div>
 </Layout>
 

--- a/apps/pdf-craft/src/pages/decryptpdf.astro
+++ b/apps/pdf-craft/src/pages/decryptpdf.astro
@@ -2,18 +2,58 @@
 import Layout from "../layouts/Layout.astro";
 import { DecryptPdf } from "../components";
 import { fetchCms } from "../utils/lib/cms";
-import type { Operation } from "../utils";
-
-if (!Astro.cookies.has('__session')) {
-  return Astro.redirect('/signin')
-}
+import { resolveIsAuthenticated } from "../firebase/server";
+import { Container, Section, Accordion } from "@fhdamd/threads";
+import type { Operation, Faq } from "../utils";
 
 type OperationsResponse = { data: { allOperations: Operation[] } }
-const opsRes = await fetchCms<OperationsResponse>('operations')
+type FaqsResponse = { data: { allFaqs: Faq[] } }
+
+const [opsRes, faqsRes] = await Promise.all([
+  fetchCms<OperationsResponse>('operations'),
+  fetchCms<FaqsResponse>('faqs', { area: 'decrypt' }),
+])
+
 const op = opsRes.data.allOperations.find(o => o.iconKey === 'decrypt')
 const creditCost = op?.creditCost ?? 4
+const faqItems = faqsRes.data.allFaqs.map(({ title, content }) => ({ question: title, answer: content }))
+const isAuthenticated = await resolveIsAuthenticated(Astro.cookies.get('__session')?.value)
 ---
 
-<Layout title="Unlock PDF — Riqa" noindex={true}>
-  <DecryptPdf creditCost={creditCost} client:load />
+<Layout
+  title="Unlock PDF — Riqa"
+  description="Remove password protection from any PDF. Fast, secure, and private — your file is deleted within 24 hours."
+>
+  <Fragment slot="head">
+    {faqItems.length > 0 && (
+      <script
+        is:inline
+        type="application/ld+json"
+        set:html={JSON.stringify({
+          "@context": "https://schema.org",
+          "@type": "FAQPage",
+          mainEntity: faqItems.map(({ question, answer }) => ({
+            "@type": "Question",
+            name: question,
+            acceptedAnswer: { "@type": "Answer", text: answer },
+          })),
+        })}
+      />
+    )}
+  </Fragment>
+
+  <DecryptPdf creditCost={creditCost} isAuthenticated={isAuthenticated} client:load />
+
+  {faqItems.length > 0 && (
+    <Container>
+      <Section size="md">
+        <h2 style="font-size:var(--th-text-xl);font-weight:650;margin-bottom:var(--th-space-6)">
+          Frequently asked questions
+        </h2>
+        <div style="max-width:680px">
+          <Accordion client:load items={faqItems} />
+        </div>
+      </Section>
+    </Container>
+  )}
 </Layout>

--- a/apps/pdf-craft/src/pages/encryptpdf.astro
+++ b/apps/pdf-craft/src/pages/encryptpdf.astro
@@ -2,18 +2,58 @@
 import Layout from "../layouts/Layout.astro";
 import { EncryptPdf } from "../components";
 import { fetchCms } from "../utils/lib/cms";
-import type { Operation } from "../utils";
-
-if (!Astro.cookies.has('__session')) {
-  return Astro.redirect('/signin')
-}
+import { resolveIsAuthenticated } from "../firebase/server";
+import { Container, Section, Accordion } from "@fhdamd/threads";
+import type { Operation, Faq } from "../utils";
 
 type OperationsResponse = { data: { allOperations: Operation[] } }
-const opsRes = await fetchCms<OperationsResponse>('operations')
+type FaqsResponse = { data: { allFaqs: Faq[] } }
+
+const [opsRes, faqsRes] = await Promise.all([
+  fetchCms<OperationsResponse>('operations'),
+  fetchCms<FaqsResponse>('faqs', { area: 'encrypt' }),
+])
+
 const op = opsRes.data.allOperations.find(o => o.iconKey === 'encrypt')
 const creditCost = op?.creditCost ?? 4
+const faqItems = faqsRes.data.allFaqs.map(({ title, content }) => ({ question: title, answer: content }))
+const isAuthenticated = await resolveIsAuthenticated(Astro.cookies.get('__session')?.value)
 ---
 
-<Layout title="Protect PDF — Riqa" noindex={true}>
-  <EncryptPdf creditCost={creditCost} client:load />
+<Layout
+  title="Protect PDF — Riqa"
+  description="Add 256-bit AES password protection to any PDF. Set permissions and secure your documents in seconds."
+>
+  <Fragment slot="head">
+    {faqItems.length > 0 && (
+      <script
+        is:inline
+        type="application/ld+json"
+        set:html={JSON.stringify({
+          "@context": "https://schema.org",
+          "@type": "FAQPage",
+          mainEntity: faqItems.map(({ question, answer }) => ({
+            "@type": "Question",
+            name: question,
+            acceptedAnswer: { "@type": "Answer", text: answer },
+          })),
+        })}
+      />
+    )}
+  </Fragment>
+
+  <EncryptPdf creditCost={creditCost} isAuthenticated={isAuthenticated} client:load />
+
+  {faqItems.length > 0 && (
+    <Container>
+      <Section size="md">
+        <h2 style="font-size:var(--th-text-xl);font-weight:650;margin-bottom:var(--th-space-6)">
+          Frequently asked questions
+        </h2>
+        <div style="max-width:680px">
+          <Accordion client:load items={faqItems} />
+        </div>
+      </Section>
+    </Container>
+  )}
 </Layout>

--- a/apps/pdf-craft/src/pages/imagetopdf.astro
+++ b/apps/pdf-craft/src/pages/imagetopdf.astro
@@ -2,18 +2,58 @@
 import Layout from "../layouts/Layout.astro";
 import { ImageToPdf } from "../components";
 import { fetchCms } from "../utils/lib/cms";
-import type { Operation } from "../utils";
-
-if (!Astro.cookies.has("__session")) {
-  return Astro.redirect("/signin");
-}
+import { resolveIsAuthenticated } from "../firebase/server";
+import { Container, Section, Accordion } from "@fhdamd/threads";
+import type { Operation, Faq } from "../utils";
 
 type OperationsResponse = { data: { allOperations: Operation[] } }
-const opsRes = await fetchCms<OperationsResponse>('operations')
+type FaqsResponse = { data: { allFaqs: Faq[] } }
+
+const [opsRes, faqsRes] = await Promise.all([
+  fetchCms<OperationsResponse>('operations'),
+  fetchCms<FaqsResponse>('faqs', { area: 'imagetopdf' }),
+])
+
 const op = opsRes.data.allOperations.find(o => o.iconKey === 'convert')
 const creditCost = op?.creditCost ?? 2
+const faqItems = faqsRes.data.allFaqs.map(({ title, content }) => ({ question: title, answer: content }))
+const isAuthenticated = await resolveIsAuthenticated(Astro.cookies.get('__session')?.value)
 ---
 
-<Layout title="Image to PDF — Riqa" noindex={true}>
-  <ImageToPdf creditCost={creditCost} client:load />
+<Layout
+  title="Image to PDF — Riqa"
+  description="Convert JPG and PNG images into a PDF. Combine up to 10 images into one document — pay per use, no subscription."
+>
+  <Fragment slot="head">
+    {faqItems.length > 0 && (
+      <script
+        is:inline
+        type="application/ld+json"
+        set:html={JSON.stringify({
+          "@context": "https://schema.org",
+          "@type": "FAQPage",
+          mainEntity: faqItems.map(({ question, answer }) => ({
+            "@type": "Question",
+            name: question,
+            acceptedAnswer: { "@type": "Answer", text: answer },
+          })),
+        })}
+      />
+    )}
+  </Fragment>
+
+  <ImageToPdf creditCost={creditCost} isAuthenticated={isAuthenticated} client:load />
+
+  {faqItems.length > 0 && (
+    <Container>
+      <Section size="md">
+        <h2 style="font-size:var(--th-text-xl);font-weight:650;margin-bottom:var(--th-space-6)">
+          Frequently asked questions
+        </h2>
+        <div style="max-width:680px">
+          <Accordion client:load items={faqItems} />
+        </div>
+      </Section>
+    </Container>
+  )}
 </Layout>

--- a/apps/pdf-craft/src/pages/mergepdf.astro
+++ b/apps/pdf-craft/src/pages/mergepdf.astro
@@ -2,18 +2,58 @@
 import Layout from "../layouts/Layout.astro";
 import { MultiPdfUploader } from "../components";
 import { fetchCms } from "../utils/lib/cms";
-import type { Operation } from "../utils";
-
-if (!Astro.cookies.has('__session')) {
-  return Astro.redirect('/signin')
-}
+import { resolveIsAuthenticated } from "../firebase/server";
+import { Container, Section, Accordion } from "@fhdamd/threads";
+import type { Operation, Faq } from "../utils";
 
 type OperationsResponse = { data: { allOperations: Operation[] } }
-const opsRes = await fetchCms<OperationsResponse>('operations')
+type FaqsResponse = { data: { allFaqs: Faq[] } }
+
+const [opsRes, faqsRes] = await Promise.all([
+  fetchCms<OperationsResponse>('operations'),
+  fetchCms<FaqsResponse>('faqs', { area: 'merge' }),
+])
+
 const op = opsRes.data.allOperations.find(o => o.iconKey === 'merge')
 const creditCost = op?.creditCost ?? 2
+const faqItems = faqsRes.data.allFaqs.map(({ title, content }) => ({ question: title, answer: content }))
+const isAuthenticated = await resolveIsAuthenticated(Astro.cookies.get('__session')?.value)
 ---
 
-<Layout title="Merge PDFs — Riqa" noindex={true}>
-  <MultiPdfUploader creditCost={creditCost} client:load />
+<Layout
+  title="Merge PDFs — Riqa"
+  description="Combine up to 5 PDF files into one. Drag to reorder, merge in seconds. Pay per use — no subscription required."
+>
+  <Fragment slot="head">
+    {faqItems.length > 0 && (
+      <script
+        is:inline
+        type="application/ld+json"
+        set:html={JSON.stringify({
+          "@context": "https://schema.org",
+          "@type": "FAQPage",
+          mainEntity: faqItems.map(({ question, answer }) => ({
+            "@type": "Question",
+            name: question,
+            acceptedAnswer: { "@type": "Answer", text: answer },
+          })),
+        })}
+      />
+    )}
+  </Fragment>
+
+  <MultiPdfUploader creditCost={creditCost} isAuthenticated={isAuthenticated} client:load />
+
+  {faqItems.length > 0 && (
+    <Container>
+      <Section size="md">
+        <h2 style="font-size:var(--th-text-xl);font-weight:650;margin-bottom:var(--th-space-6)">
+          Frequently asked questions
+        </h2>
+        <div style="max-width:680px">
+          <Accordion client:load items={faqItems} />
+        </div>
+      </Section>
+    </Container>
+  )}
 </Layout>

--- a/apps/pdf-craft/src/pages/signin.astro
+++ b/apps/pdf-craft/src/pages/signin.astro
@@ -12,7 +12,7 @@ if (Astro.cookies.has("__session")) {
   if (sessionCookie) {
     try {
       const decodedCookie = await auth.verifySessionCookie(sessionCookie, true);
-      if (decodedCookie) {
+      if (decodedCookie && decodedCookie.firebase.sign_in_provider !== 'anonymous') {
         return Astro.redirect("/dashboard");
       }
     } catch (error: any) {

--- a/apps/pdf-craft/src/test/mocks/astro-actions.ts
+++ b/apps/pdf-craft/src/test/mocks/astro-actions.ts
@@ -11,12 +11,17 @@ export const createUser = vi.fn().mockResolvedValue({ data: { success: true }, e
 export const signOutUser = vi.fn().mockResolvedValue({ data: { success: true }, error: null });
 export const sendPasswordReset = vi.fn().mockResolvedValue({ data: { success: true }, error: null });
 export const sendMessage = vi.fn().mockResolvedValue({ data: { success: true }, error: null });
+export const createAnonymousSession = vi.fn().mockResolvedValue({ data: { success: true }, error: null });
+export const finalizeLinkedUser = vi.fn().mockResolvedValue({ data: { success: true }, error: null });
+export const migrateFile = vi.fn().mockResolvedValue({ data: { success: true }, error: null });
+export const claimFile = vi.fn().mockResolvedValue({ data: { success: true, payload: { downloadUrl: "https://cdn.test/claimed.pdf" } }, error: null });
 
 export const actions = {
   credits: { checkCredits },
   operations: { mergePdfs, encryptPdf, decryptPdf, imageToPdf },
-  user: { verifyUser, createUser, signOutUser, sendPasswordReset },
+  user: { verifyUser, createUser, signOutUser, sendPasswordReset, createAnonymousSession, finalizeLinkedUser },
   contact: { sendMessage },
+  claims: { migrateFile, claimFile },
 };
 
 export const defineAction = vi.fn((config: unknown) => config);

--- a/apps/pdf-craft/src/test/mocks/firebase-client.ts
+++ b/apps/pdf-craft/src/test/mocks/firebase-client.ts
@@ -1,3 +1,5 @@
-export const auth = { currentUser: null as any };
+export const auth = {
+  currentUser: { uid: 'test-uid', isAnonymous: false, getIdToken: async () => 'test-id-token' } as any,
+};
 export const db = {} as any;
 export const analytics = null;

--- a/apps/pdf-craft/src/utils/lib/claimToken.test.ts
+++ b/apps/pdf-craft/src/utils/lib/claimToken.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { generateClaimToken, verifyClaimToken } from "./claimToken";
+
+describe("claimToken", () => {
+  describe("generateClaimToken", () => {
+    it("returns a non-empty string", () => {
+      const token = generateClaimToken("file-123", "anon-uid-456");
+      expect(typeof token).toBe("string");
+      expect(token.length).toBeGreaterThan(0);
+    });
+
+    it("contains two dot-separated parts (encoded payload + HMAC)", () => {
+      const token = generateClaimToken("file-123", "anon-uid-456");
+      const parts = token.split(".");
+      expect(parts).toHaveLength(2);
+    });
+
+    it("produces different tokens for different fileIds", () => {
+      const t1 = generateClaimToken("file-aaa", "anon-uid");
+      const t2 = generateClaimToken("file-bbb", "anon-uid");
+      expect(t1).not.toBe(t2);
+    });
+
+    it("produces different tokens for different anonUids", () => {
+      const t1 = generateClaimToken("file-123", "anon-uid-aaa");
+      const t2 = generateClaimToken("file-123", "anon-uid-bbb");
+      expect(t1).not.toBe(t2);
+    });
+  });
+
+  describe("verifyClaimToken", () => {
+    it("returns the correct payload for a freshly generated token", () => {
+      const token = generateClaimToken("file-abc", "anon-xyz");
+      const payload = verifyClaimToken(token);
+      expect(payload).not.toBeNull();
+      expect(payload!.fileId).toBe("file-abc");
+      expect(payload!.anonUid).toBe("anon-xyz");
+      expect(payload!.expiresAt).toBeGreaterThan(Date.now());
+    });
+
+    it("returns null for an empty string", () => {
+      expect(verifyClaimToken("")).toBeNull();
+    });
+
+    it("returns null for a token with no dot separator", () => {
+      expect(verifyClaimToken("nodotsinhere")).toBeNull();
+    });
+
+    it("returns null when the HMAC has been tampered with", () => {
+      const token = generateClaimToken("file-abc", "anon-xyz");
+      const tampered = token.slice(0, -4) + "0000";
+      expect(verifyClaimToken(tampered)).toBeNull();
+    });
+
+    it("returns null when the payload has been tampered with", () => {
+      const token = generateClaimToken("file-abc", "anon-xyz");
+      const [, hmac] = token.split(".");
+      const fakePayload = Buffer.from(JSON.stringify({ fileId: "evil", anonUid: "evil", expiresAt: Date.now() + 9999 })).toString("base64url");
+      expect(verifyClaimToken(`${fakePayload}.${hmac}`)).toBeNull();
+    });
+
+    it("returns null for an expired token", () => {
+      const token = generateClaimToken("file-abc", "anon-xyz");
+      // Advance time by 31 minutes (TTL is 30 min)
+      const realDateNow = Date.now;
+      vi.spyOn(Date, "now").mockReturnValue(realDateNow() + 31 * 60 * 1000);
+      expect(verifyClaimToken(token)).toBeNull();
+      vi.restoreAllMocks();
+    });
+
+    it("returns null for malformed base64url payload", () => {
+      expect(verifyClaimToken("!!!invalid-base64.abc123")).toBeNull();
+    });
+  });
+});

--- a/apps/pdf-craft/src/utils/lib/claimToken.ts
+++ b/apps/pdf-craft/src/utils/lib/claimToken.ts
@@ -1,0 +1,47 @@
+import { createHmac, timingSafeEqual, randomBytes } from 'crypto';
+
+const SECRET = import.meta.env.CLAIM_SECRET;
+const TTL_MS = 30 * 60 * 1000; // 30 minutes
+
+export interface ClaimPayload {
+  fileId: string;
+  anonUid: string;
+  expiresAt: number;
+}
+
+export function generateClaimToken(fileId: string, anonUid: string): string {
+  const expiresAt = Date.now() + TTL_MS;
+  const payload = `${fileId}:${anonUid}:${expiresAt}`;
+  const hmac = createHmac('sha256', SECRET).update(payload).digest('hex');
+  const encoded = Buffer.from(JSON.stringify({ fileId, anonUid, expiresAt })).toString('base64url');
+  return `${encoded}.${hmac}`;
+}
+
+export function verifyClaimToken(token: string): ClaimPayload | null {
+  try {
+    const dotIndex = token.lastIndexOf('.');
+    if (dotIndex === -1) return null;
+
+    const encoded = token.slice(0, dotIndex);
+    const providedHmac = token.slice(dotIndex + 1);
+
+    const parsed: ClaimPayload = JSON.parse(Buffer.from(encoded, 'base64url').toString());
+    const { fileId, anonUid, expiresAt } = parsed;
+
+    const expectedHmac = createHmac('sha256', SECRET)
+      .update(`${fileId}:${anonUid}:${expiresAt}`)
+      .digest('hex');
+
+    const same = timingSafeEqual(
+      Buffer.from(providedHmac, 'hex'),
+      Buffer.from(expectedHmac, 'hex'),
+    );
+
+    if (!same) return null;
+    if (Date.now() > expiresAt) return null;
+
+    return { fileId, anonUid, expiresAt };
+  } catch {
+    return null;
+  }
+}

--- a/apps/pdf-craft/src/utils/lib/claimToken.ts
+++ b/apps/pdf-craft/src/utils/lib/claimToken.ts
@@ -1,4 +1,4 @@
-import { createHmac, timingSafeEqual, randomBytes } from 'crypto';
+import { createHmac, timingSafeEqual } from 'node:crypto';
 
 const SECRET = import.meta.env.CLAIM_SECRET;
 const TTL_MS = 30 * 60 * 1000; // 30 minutes

--- a/apps/pdf-craft/src/utils/lib/operationSession.ts
+++ b/apps/pdf-craft/src/utils/lib/operationSession.ts
@@ -1,0 +1,61 @@
+'use client'
+import { signInAnonymously } from 'firebase/auth'
+import { actions } from 'astro:actions'
+import * as Sentry from '@sentry/astro'
+import { auth } from '../../firebase/client'
+import { INSUFFICIENT_CREDITS_ERROR } from '../../components/shared'
+
+export interface PrepareSessionConfig {
+  readonly isAuthenticated: boolean
+  readonly creditCost: number
+  readonly defaultLabel: string
+  readonly setButtonLabel: (label: string) => void
+  readonly setError: (error: string) => void
+  readonly setProcessing: (processing: boolean) => void
+}
+
+/**
+ * Returns an async `prepareSession(task, requestId)` function that either:
+ * - Creates an anonymous Firebase session (when isAuthenticated is false), or
+ * - Runs the credit check (when the user is already authenticated).
+ * Returns false and handles all error UI if either step fails.
+ */
+export function buildPrepareSession(config: PrepareSessionConfig) {
+  return async (task: string, requestId: string): Promise<boolean> => {
+    const { isAuthenticated, creditCost, defaultLabel, setButtonLabel, setError, setProcessing } = config
+
+    if (!isAuthenticated) {
+      setButtonLabel('Processing...')
+      if (!auth.currentUser) {
+        try {
+          const credential = await signInAnonymously(auth)
+          const idToken = await credential.user.getIdToken()
+          const sessionRes = await actions.user.createAnonymousSession({ idToken })
+          if (!sessionRes.data?.success) {
+            setError('Failed to start session. Please try again.')
+            setButtonLabel(defaultLabel)
+            setProcessing(false)
+            return false
+          }
+        } catch (err) {
+          setError('Failed to start session. Please try again.')
+          setButtonLabel(defaultLabel)
+          setProcessing(false)
+          Sentry.captureException(err)
+          return false
+        }
+      }
+      return true
+    }
+
+    setButtonLabel('Checking credits...')
+    const response = await actions.credits.checkCredits({ task, requestId, creditCost })
+    if (!response.data?.success) {
+      setError(INSUFFICIENT_CREDITS_ERROR)
+      setButtonLabel(defaultLabel)
+      setProcessing(false)
+      return false
+    }
+    return true
+  }
+}

--- a/apps/pdf-craft/vitest.config.ts
+++ b/apps/pdf-craft/vitest.config.ts
@@ -33,6 +33,7 @@ export default defineConfig({
   define: {
     "import.meta.env.PUBLIC_RECAPTCHA_SITE_KEY": JSON.stringify("test-site-key"),
     "import.meta.env.PUBLIC_BASE_FUNCTIONS_URL": JSON.stringify("https://functions.test"),
+    "import.meta.env.CLAIM_SECRET": JSON.stringify("test-claim-secret-32-bytes-padded!"),
   },
   resolve: {
     alias: [


### PR DESCRIPTION
Closes #214

## Summary

- **Operation pages are now public** — server-side auth redirect and `noindex` removed from `/mergepdf`, `/encryptpdf`, `/decryptpdf`, `/imagetopdf`; each page fetches and renders its own FAQ section with `FAQPage` JSON-LD from DatoCMS
- **Anonymous-user-to-signup flow** — visitors can process a file without signing in; the result is held server-side until they create an account and buy credits to download
- **`isAuthenticated` server prop** — derived from the `__session` cookie via `resolveIsAuthenticated()` on each operation page; passed to the React component so auth logic is driven by the real session, not the client-side Firebase SDK (fixes e2e compatibility with Playwright's auth setup)
- **Claim token security** — HMAC-SHA256 with a 30-min TTL; never exposed in URLs or localStorage; credit deduction inside a Firestore transaction, signed URL generated after commit

## Flow

```
Anonymous visit → fill form → submit
  → signInAnonymously() + createAnonymousSession
  → operation runs → file stored (status: pending) → claimToken returned
  → "Sign up to download" / "Already have an account?" shown

Sign up (new user):
  linkWithCredential → finalizeLinkedUser → /buy-credits
  → buy credits → dashboard → "Download — N credits" button → claimFile

Sign in (existing user):
  verifyUser → migrateFile (copies file to real UID) → dashboard
  → "Download — N credits" → claimFile
```

## Test plan

- [ ] Unauthenticated visitor can reach `/encryptpdf`, `/mergepdf` etc. and see the tool + FAQs (no redirect)
- [ ] Visitor submits an operation anonymously → sees "Your PDF is ready — sign up to download it"
- [ ] "Sign up to download" navigates to `/signup` with token in sessionStorage
- [ ] "Already have an account?" navigates to `/signin` with token in sessionStorage
- [ ] New sign-up via link → redirected to `/buy-credits`; file visible in dashboard after buying credits; "Download — N credits" button deducts and serves file
- [ ] Existing-account sign-in after anonymous op → file migrated to account; dashboard shows pending file
- [ ] Signed-in user (with credits) processes operation → existing flow unchanged (download link appears immediately)
- [ ] Google Rich Results Test on `/encryptpdf` (and others) shows `FAQPage` structured data
- [ ] `pnpm test` → 220/220 passing
- [ ] `pnpm test:e2e --project=unauthenticated` → 4/4 passing locally
- [ ] Full e2e suite green on staging (set `CLAIM_SECRET` in App Hosting env before staging deploy)

## Pre-deploy checklist

- [ ] Add `CLAIM_SECRET` (`c5e74e949b7f3235d3b545a5d8edc9608e3890beb10666615572f0e6ce1ae6c4`) to Firebase App Hosting environment variables for `pdf-craft-stg` and `pdf-craft-prd`

🤖 Generated with [Claude Code](https://claude.com/claude-code)