### PR TITLE
feat(pdf-craft): signPdf action + embedSignature backend logic

### DIFF
--- a/apps/pdf-craft/functions/src/email/templates/pdfOperation.ts
+++ b/apps/pdf-craft/functions/src/email/templates/pdfOperation.ts
@@ -2,7 +2,7 @@ import { baseEmail, emailButton, emailLabel } from "./base";
 
 const FONT = `'Bricolage Grotesque', -apple-system, BlinkMacSystemFont, 'Segoe UI', system-ui, sans-serif`;
 
-type OperationType = "pdf-merge" | "image-to-pdf" | "pdf-encrypt" | "pdf-decrypt" | "pdf-split" | "pdf-compress";
+type OperationType = "pdf-merge" | "image-to-pdf" | "pdf-encrypt" | "pdf-decrypt" | "pdf-split" | "pdf-compress" | "pdf-sign";
 
 interface OperationConfig {
   icon: string;
@@ -74,6 +74,16 @@ const OPERATION_CONFIG: Record<OperationType, OperationConfig> = {
       `<strong style="color: #2E2C28;">${fileName}</strong> has been compressed and is ready to download.`,
     ctaLabel: "Download compressed PDF",
     note: "Your compressed PDF will be available for 24 hours.",
+  },
+  "pdf-sign": {
+    icon: "✍️",
+    iconBg: "#EDE9FE",
+    subject: "Your Signed PDF is Ready!",
+    heading: "Your PDF has been signed",
+    description: (fileName) =>
+      `Your signature has been embedded in <strong style="color: #2E2C28;">${fileName}</strong> along with an audit record.`,
+    ctaLabel: "Download signed PDF",
+    note: "Your signed PDF will be available for 24 hours.",
   },
 };
 

--- a/apps/pdf-craft/functions/src/events/handlers/index.ts
+++ b/apps/pdf-craft/functions/src/events/handlers/index.ts
@@ -5,6 +5,7 @@ import { handleEncryptPdf } from "./encrypt";
 import { handleDecryptPdf } from "./decrypt";
 import { handleSplitPdf } from "./split";
 import { handleCompressPdf } from "./compress";
+import { handleSignPdf } from "./sign";
 import { handleUserCreated } from "./userCreated";
 import { handleCreditsPurchased } from "./creditsPurchased";
 
@@ -15,6 +16,7 @@ export const eventHandlers: Record<string, AppEventHandler> = {
   "pdf-decrypt": handleDecryptPdf,
   "pdf-split": handleSplitPdf,
   "pdf-compress": handleCompressPdf,
+  "pdf-sign": handleSignPdf,
   "user-created": handleUserCreated,
   "credits-purchased": handleCreditsPurchased,
 };

--- a/apps/pdf-craft/functions/src/events/handlers/sign.ts
+++ b/apps/pdf-craft/functions/src/events/handlers/sign.ts
@@ -1,0 +1,6 @@
+import type { TypedEventHandler } from "./types";
+import type { PdfOperationPayload } from "../types";
+import { sendOperationEmail } from "./sendOperationEmail";
+
+export const handleSignPdf: TypedEventHandler<PdfOperationPayload> = (payload) =>
+  sendOperationEmail(payload);

--- a/apps/pdf-craft/functions/src/events/types.ts
+++ b/apps/pdf-craft/functions/src/events/types.ts
@@ -1,5 +1,5 @@
 export interface PdfOperationPayload {
-  eventType: "pdf-merge" | "image-to-pdf" | "pdf-encrypt" | "pdf-decrypt" | "pdf-split" | "pdf-compress";
+  eventType: "pdf-merge" | "image-to-pdf" | "pdf-encrypt" | "pdf-decrypt" | "pdf-split" | "pdf-compress" | "pdf-sign";
   userId: string;
   userEmail: string;
   fileId: string;

--- a/apps/pdf-craft/src/actions/operations.ts
+++ b/apps/pdf-craft/src/actions/operations.ts
@@ -1,6 +1,6 @@
 import { defineAction } from "astro:actions";
 import { z } from "astro:schema";
-import { PDFDocument } from "pdf-lib";
+import { PDFDocument, PDFDict, PDFName, PDFHexString, StandardFonts, rgb } from "pdf-lib";
 import { FieldValue } from "firebase-admin/firestore";
 import admin from "firebase-admin";
 import { v4 as uuidv4 } from "uuid";
@@ -568,6 +568,132 @@ export const operations = {
       } catch (error) {
         log.exception(error as Error, { requestId, feature: task });
         return { success: false, error: "Failed to compress PDF" };
+      }
+    },
+  }),
+
+  signPdf: defineAction({
+    accept: "form",
+    input: z.object({
+      file: z.instanceof(File),
+      signatureImage: z.string(), // base64 data URL: "data:image/png;base64,..."
+      placements: z.string(),     // JSON: {page,x,y,width,height}[] — PDF point-space (bottom-left origin)
+      signerName: z.string().min(1),
+      signatureMethod: z.enum(["typed", "drawn", "uploaded"]).default("typed"),
+      requestId: z.string(),
+      task: z.string(),
+      creditCost: z.coerce.number().int().positive(),
+    }),
+    handler: async (input, context) => {
+      const { file, signatureImage, placements: placementsJson, signerName, signatureMethod, requestId, task, creditCost } = input;
+      log.event("📄 app-operation", { requestId, feature: task, status: "start" });
+      try {
+        const ctx = await resolveAuth(context, requestId, task);
+        if (!ctx) return { success: false, error: "Unauthorized" };
+        const { userId, isAnonymous } = ctx;
+
+        // Parse placements
+        let placements: { page: number; x: number; y: number; width: number; height: number }[];
+        try {
+          placements = JSON.parse(placementsJson);
+        } catch {
+          return { success: false, error: "Invalid placements format." };
+        }
+        if (!Array.isArray(placements) || placements.length === 0) {
+          return { success: false, error: "At least one placement is required." };
+        }
+
+        // Load PDF — detect encrypted
+        const fileBytes = await file.arrayBuffer();
+        let pdfDoc: PDFDocument;
+        try {
+          pdfDoc = await PDFDocument.load(fileBytes);
+        } catch (err: any) {
+          const msg = (err?.message ?? "") as string;
+          if (msg.includes("encrypted") || msg.includes("password")) {
+            return { success: false, error: "This PDF is password-protected. Please decrypt it first using the Unlock PDF tool." };
+          }
+          throw err;
+        }
+
+        // Embed signature PNG once — re-used for every placement
+        const base64 = signatureImage.replace(/^data:image\/png;base64,/, "");
+        const pngBytes = Buffer.from(base64, "base64");
+        const pngImage = await pdfDoc.embedPng(pngBytes);
+
+        // Standard font for audit lines — no font embedding needed
+        const helvetica = await pdfDoc.embedFont(StandardFonts.Helvetica);
+
+        // Timestamp must come from the server — never trust a client-supplied value
+        const signedAt = new Date();
+        const isoTimestamp = signedAt.toISOString();
+        const auditText = `Signed electronically by ${signerName} · ${signedAt.toUTCString()}`;
+
+        // Apply each placement
+        for (const p of placements) {
+          const pageIndex = p.page - 1; // convert 1-indexed to 0-indexed
+          if (pageIndex < 0 || pageIndex >= pdfDoc.getPageCount()) {
+            return { success: false, error: `Page ${p.page} does not exist in this document.` };
+          }
+          const page = pdfDoc.getPage(pageIndex);
+          const { width: pw, height: ph } = page.getSize();
+
+          // Bounds-check against actual page dimensions
+          if (p.x < 0 || p.y < 0 || p.x + p.width > pw || p.y + p.height > ph) {
+            return { success: false, error: `Placement on page ${p.page} is outside the page boundaries.` };
+          }
+
+          page.drawImage(pngImage, { x: p.x, y: p.y, width: p.width, height: p.height });
+
+          // Audit line drawn just below the signature, falling back to above if near bottom edge
+          const auditFontSize = 6.5;
+          const auditY = p.y > 20 ? p.y - 12 : p.y + p.height + 4;
+          page.drawText(auditText, {
+            x: p.x,
+            y: auditY,
+            size: auditFontSize,
+            font: helvetica,
+            color: rgb(0.45, 0.44, 0.42),
+            maxWidth: pw - p.x - 10,
+          });
+        }
+
+        // Metadata — setModificationDate must be called first to ensure Info dict exists
+        pdfDoc.setModificationDate(signedAt);
+        pdfDoc.setSubject(`Electronically signed by ${signerName} on ${isoTimestamp}`);
+        const infoDict = pdfDoc.context.lookup(pdfDoc.context.trailerInfo.Info!, PDFDict);
+        infoDict.set(PDFName.of("PDFCraftSignedBy"), PDFHexString.fromText(signerName));
+        infoDict.set(PDFName.of("PDFCraftSignedAtUTC"), PDFHexString.fromText(isoTimestamp));
+        infoDict.set(PDFName.of("PDFCraftSignatureMethod"), PDFHexString.fromText(signatureMethod));
+
+        const signedBytes = await pdfDoc.save();
+        const fileId = firestore.collection("users").doc(userId).collection("files").doc().id;
+        const signedFileName = `signed-${Date.now()}.pdf`;
+        const storagePath = `users/${userId}/${signedFileName}`;
+        const downloadToken = uuidv4();
+
+        await bucket.file(storagePath).save(Buffer.from(signedBytes), {
+          metadata: { contentType: "application/pdf", metadata: { firebaseStorageDownloadTokens: downloadToken } },
+        });
+
+        const fileUrl = `https://firebasestorage.googleapis.com/v0/b/${bucket.name}/o/${encodeURIComponent(storagePath)}?alt=media&token=${downloadToken}`;
+        const expiresAt = new Date(Date.now() + 24 * 60 * 60 * 1000);
+
+        await firestore.collection("users").doc(userId).collection("files").doc(fileId).set({
+          fileId, fileName: signedFileName, storagePath, fileUrl, operation: "sign",
+          status: isAnonymous ? "pending" : "ready", creditCost,
+          createdAt: FieldValue.serverTimestamp(), updatedAt: FieldValue.serverTimestamp(),
+          expiresAt, deleted: false, deletedAt: null, deletionReason: null,
+        });
+        log.debug("app-operation: file metadata saved", { requestId, feature: task, userId, fileId });
+
+        if (isAnonymous) return anonPending(fileId, userId, requestId, task);
+
+        await finaliseOperation({ userId, email: ctx.email, fileId, fileName: signedFileName, fileUrl, eventType: "pdf-sign", creditCost, requestId, task });
+        return { success: true, message: "PDF signed successfully", data: { fileUrl } };
+      } catch (error) {
+        log.exception(error as Error, { requestId, feature: task });
+        return { success: false, error: "Failed to sign PDF" };
       }
     },
   }),

--- a/apps/pdf-craft/src/actions/operations.ts
+++ b/apps/pdf-craft/src/actions/operations.ts
@@ -189,6 +189,38 @@ async function buildSplitOutput(
   };
 }
 
+// ── signPdf helpers ───────────────────────────────────────────────────────────
+
+type SignPlacement = { page: number; x: number; y: number; width: number; height: number };
+
+/** Draws the signature + audit line at each placement. Returns an error string or null. */
+function applySignaturePlacements(
+  pdfDoc: PDFDocument,
+  placements: SignPlacement[],
+  pngImage: Awaited<ReturnType<PDFDocument["embedPng"]>>,
+  helvetica: Awaited<ReturnType<PDFDocument["embedFont"]>>,
+  auditText: string,
+): string | null {
+  for (const p of placements) {
+    const pageIndex = p.page - 1;
+    if (pageIndex < 0 || pageIndex >= pdfDoc.getPageCount()) {
+      return `Page ${p.page} does not exist in this document.`;
+    }
+    const page = pdfDoc.getPage(pageIndex);
+    const { width: pw, height: ph } = page.getSize();
+    if (p.x < 0 || p.y < 0 || p.x + p.width > pw || p.y + p.height > ph) {
+      return `Placement on page ${p.page} is outside the page boundaries.`;
+    }
+    page.drawImage(pngImage, { x: p.x, y: p.y, width: p.width, height: p.height });
+    const auditY = p.y > 20 ? p.y - 12 : p.y + p.height + 4;
+    page.drawText(auditText, {
+      x: p.x, y: auditY, size: 6.5, font: helvetica,
+      color: rgb(0.45, 0.44, 0.42), maxWidth: pw - p.x - 10,
+    });
+  }
+  return null;
+}
+
 export const operations = {
   mergePdfs: defineAction({
     accept: "form",
@@ -629,34 +661,8 @@ export const operations = {
         const isoTimestamp = signedAt.toISOString();
         const auditText = `Signed electronically by ${signerName} · ${signedAt.toUTCString()}`;
 
-        // Apply each placement
-        for (const p of placements) {
-          const pageIndex = p.page - 1; // convert 1-indexed to 0-indexed
-          if (pageIndex < 0 || pageIndex >= pdfDoc.getPageCount()) {
-            return { success: false, error: `Page ${p.page} does not exist in this document.` };
-          }
-          const page = pdfDoc.getPage(pageIndex);
-          const { width: pw, height: ph } = page.getSize();
-
-          // Bounds-check against actual page dimensions
-          if (p.x < 0 || p.y < 0 || p.x + p.width > pw || p.y + p.height > ph) {
-            return { success: false, error: `Placement on page ${p.page} is outside the page boundaries.` };
-          }
-
-          page.drawImage(pngImage, { x: p.x, y: p.y, width: p.width, height: p.height });
-
-          // Audit line drawn just below the signature, falling back to above if near bottom edge
-          const auditFontSize = 6.5;
-          const auditY = p.y > 20 ? p.y - 12 : p.y + p.height + 4;
-          page.drawText(auditText, {
-            x: p.x,
-            y: auditY,
-            size: auditFontSize,
-            font: helvetica,
-            color: rgb(0.45, 0.44, 0.42),
-            maxWidth: pw - p.x - 10,
-          });
-        }
+        const placementError = applySignaturePlacements(pdfDoc, placements, pngImage, helvetica, auditText);
+        if (placementError) return { success: false, error: placementError };
 
         // Metadata — setModificationDate must be called first to ensure Info dict exists
         pdfDoc.setModificationDate(signedAt);

--- a/apps/pdf-craft/src/components/slices/UserFileList/UserFileList.tsx
+++ b/apps/pdf-craft/src/components/slices/UserFileList/UserFileList.tsx
@@ -10,6 +10,7 @@ const OP_META: Record<string, { label: string; variant: BadgeVariant }> = {
   'decrypt':      { label: 'Unlock',       variant: 'neutral' },
   'split':        { label: 'Split',        variant: 'terra'   },
   'compress':     { label: 'Compress',     variant: 'info'    },
+  'sign':         { label: 'Sign',         variant: 'neutral' },
 }
 
 function OperationBadge({ op }: { op: string }) {

--- a/apps/pdf-craft/src/test/mocks/astro-actions.ts
+++ b/apps/pdf-craft/src/test/mocks/astro-actions.ts
@@ -8,6 +8,7 @@ export const decryptPdf = vi.fn().mockResolvedValue({ data: { success: true, dat
 export const imageToPdf = vi.fn().mockResolvedValue({ data: { data: { fileUrl: "https://cdn.test/output.pdf" } }, error: null });
 export const splitPdf = vi.fn().mockResolvedValue({ data: { success: true, data: { fileUrl: "https://cdn.test/split.pdf" } }, error: null });
 export const compressPdf = vi.fn().mockResolvedValue({ data: { success: true, data: { fileUrl: "https://cdn.test/compressed.pdf", alreadyOptimised: false } }, error: null });
+export const signPdf = vi.fn().mockResolvedValue({ data: { success: true, data: { fileUrl: "https://cdn.test/signed.pdf" } }, error: null });
 export const verifyUser = vi.fn().mockResolvedValue({ data: { redirected: false }, error: null });
 export const createUser = vi.fn().mockResolvedValue({ data: { success: true }, error: null });
 export const signOutUser = vi.fn().mockResolvedValue({ data: { success: true }, error: null });
@@ -20,7 +21,7 @@ export const claimFile = vi.fn().mockResolvedValue({ data: { success: true, payl
 
 export const actions = {
   credits: { checkCredits },
-  operations: { mergePdfs, encryptPdf, decryptPdf, imageToPdf, splitPdf, compressPdf },
+  operations: { mergePdfs, encryptPdf, decryptPdf, imageToPdf, splitPdf, compressPdf, signPdf },
   user: { verifyUser, createUser, signOutUser, sendPasswordReset, createAnonymousSession, finalizeLinkedUser },
   contact: { sendMessage },
   claims: { migrateFile, claimFile },


### PR DESCRIPTION
Closes #220

## Summary

Backend implementation for Sign PDF — no UI yet (that's #221/#222).

### signPdf action
- Accepts `file`, `signatureImage` (base64 PNG data URL), `placements` (JSON `{page,x,y,width,height}[]` in PDF point-space, bottom-left origin), `signerName`, `signatureMethod`
- Encrypted-PDF guard
- Embeds the PNG once, draws it at every placement with a server-rendered audit line below (`"Signed electronically by {name} · {UTCTimestamp}"`, Helvetica 6.5pt)
- Metadata via `context.lookup(trailerInfo.Info, PDFDict)` — sets `PDFCraftSignedBy`, `PDFCraftSignedAtUTC`, `PDFCraftSignatureMethod` plus `pdfDoc.setSubject()` for the standard visible field
- **Server-only timestamp** — `new Date()` never comes from the client

### Functions
- `pdf-sign` event type, `sign.ts` handler, email template config (✍️ lavender)

## Test plan
- [ ] `pnpm test` → 272/272
- [ ] Manual: upload a PDF → sign via #221/#222 UI → download → open in PDF viewer → check Document Properties shows signed metadata and audit line is visible on the page
- [ ] Encrypted PDF input → "decrypt first" error returned

🤖 Generated with [Claude Code](https://claude.com/claude-code)