### PR TITLE
fix(pdf-craft): SignatureModal font previews empty on open + canvas squishing

### DIFF
--- a/apps/pdf-craft/src/components/views/SignPdf/SignPdf.test.tsx
+++ b/apps/pdf-craft/src/components/views/SignPdf/SignPdf.test.tsx
@@ -1,0 +1,177 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, waitFor, fireEvent } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+vi.mock("../../../utils/lib/pdfRender", () => ({
+  getPdfPageCount: vi.fn().mockResolvedValue(3),
+  getPdfPageDimensions: vi.fn().mockResolvedValue([
+    { width: 595, height: 842 },
+    { width: 595, height: 842 },
+    { width: 595, height: 842 },
+  ]),
+  renderPdfPageToCanvas: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("../../../utils/lib/analytics", () => ({ logEvent: vi.fn() }));
+
+// Mock SignatureModal so we can control when it fires onConfirm
+vi.mock("./SignatureModal", () => ({
+  default: ({ isOpen, onClose, onConfirm }: any) => {
+    if (!isOpen) return null;
+    return (
+      <div data-testid="signature-modal">
+        <button onClick={onClose}>Close modal</button>
+        <button onClick={() => onConfirm({ dataUrl: "data:image/png;base64,sig", source: "typed", signerName: "Fahad" })}>
+          Confirm signature
+        </button>
+      </div>
+    );
+  },
+}));
+
+// Mock SignaturePlacement similarly
+vi.mock("./SignaturePlacement", () => ({
+  default: ({ onConfirm, onBack }: any) => (
+    <div data-testid="signature-placement">
+      <button onClick={onBack}>Back</button>
+      <button onClick={() => onConfirm([{ page: 1, x: 100, y: 200, width: 160, height: 60 }])}>
+        Place Signature
+      </button>
+    </div>
+  ),
+}));
+
+import SignPdf from "./SignPdf";
+import { signPdf, checkCredits } from "../../../test/mocks/astro-actions";
+import { auth } from "../../../firebase/client";
+
+const pdfFile = new File(["pdf"], "doc.pdf", { type: "application/pdf" });
+
+function selectFile() {
+  const input = screen.getByTestId("file-input");
+  Object.defineProperty(input, "files", { value: [pdfFile], configurable: true });
+  fireEvent.change(input);
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  (auth as any).currentUser = { uid: "user-1", isAnonymous: false };
+  checkCredits.mockResolvedValue({ data: { success: true }, error: null });
+  signPdf.mockResolvedValue({ data: { success: true, data: { fileUrl: "https://cdn.test/signed.pdf" } }, error: null });
+  vi.stubGlobal("sessionStorage", { getItem: vi.fn(() => null), setItem: vi.fn(), removeItem: vi.fn() });
+  vi.stubGlobal("location", { href: "" });
+});
+
+describe("SignPdf orchestrator", () => {
+  it("renders the file dropzone initially", () => {
+    render(<SignPdf creditCost={3} isAuthenticated />);
+    expect(screen.getByTestId("file-input")).toBeInTheDocument();
+  });
+
+  it("shows the SignatureModal after a file is selected", async () => {
+    render(<SignPdf creditCost={3} isAuthenticated />);
+    selectFile();
+    await waitFor(() => expect(screen.getByTestId("signature-modal")).toBeInTheDocument());
+  });
+
+  it("returns to upload step when modal is closed", async () => {
+    const user = userEvent.setup();
+    render(<SignPdf creditCost={3} isAuthenticated />);
+    selectFile();
+    await waitFor(() => screen.getByTestId("signature-modal"));
+    await user.click(screen.getByRole("button", { name: /Close modal/i }));
+    await waitFor(() => expect(screen.getByTestId("file-input")).toBeInTheDocument());
+  });
+
+  it("shows SignaturePlacement after signature is confirmed in modal", async () => {
+    const user = userEvent.setup();
+    render(<SignPdf creditCost={3} isAuthenticated />);
+    selectFile();
+    await waitFor(() => screen.getByTestId("signature-modal"));
+    await user.click(screen.getByRole("button", { name: /Confirm signature/i }));
+    await waitFor(() => expect(screen.getByTestId("signature-placement")).toBeInTheDocument());
+  });
+
+  it("goes back to modal when Back is clicked in placement", async () => {
+    const user = userEvent.setup();
+    render(<SignPdf creditCost={3} isAuthenticated />);
+    selectFile();
+    await waitFor(() => screen.getByTestId("signature-modal"));
+    await user.click(screen.getByRole("button", { name: /Confirm signature/i }));
+    await waitFor(() => screen.getByTestId("signature-placement"));
+    await user.click(screen.getByRole("button", { name: /Back/i }));
+    await waitFor(() => expect(screen.getByTestId("signature-modal")).toBeInTheDocument());
+  });
+
+  it("shows download link after successful sign", async () => {
+    const user = userEvent.setup();
+    render(<SignPdf creditCost={3} isAuthenticated />);
+    selectFile();
+    await waitFor(() => screen.getByTestId("signature-modal"));
+    await user.click(screen.getByRole("button", { name: /Confirm signature/i }));
+    await waitFor(() => screen.getByTestId("signature-placement"));
+    await user.click(screen.getByRole("button", { name: /Place Signature/i }));
+    await waitFor(() =>
+      expect(screen.getByRole("link", { name: /Download signed PDF/i })).toHaveAttribute(
+        "href", "https://cdn.test/signed.pdf",
+      ),
+    );
+  });
+
+  it("shows pending UI when signPdf returns a claimToken", async () => {
+    signPdf.mockResolvedValue({ data: { success: true, data: { claimToken: "tok-sign" } }, error: null });
+    const user = userEvent.setup();
+    render(<SignPdf creditCost={3} />);
+    selectFile();
+    await waitFor(() => screen.getByTestId("signature-modal"));
+    await user.click(screen.getByRole("button", { name: /Confirm signature/i }));
+    await waitFor(() => screen.getByTestId("signature-placement"));
+    await user.click(screen.getByRole("button", { name: /Place Signature/i }));
+    await waitFor(() =>
+      expect(screen.getByRole("button", { name: /Sign up to download/i })).toBeInTheDocument(),
+    );
+    expect(screen.getByRole("button", { name: /Already have an account/i })).toBeInTheDocument();
+  });
+
+  it("shows error when signPdf returns failure", async () => {
+    signPdf.mockResolvedValue({ data: { success: false, error: "This PDF is password-protected." } });
+    const user = userEvent.setup();
+    render(<SignPdf creditCost={3} isAuthenticated />);
+    selectFile();
+    await waitFor(() => screen.getByTestId("signature-modal"));
+    await user.click(screen.getByRole("button", { name: /Confirm signature/i }));
+    await waitFor(() => screen.getByTestId("signature-placement"));
+    await user.click(screen.getByRole("button", { name: /Place Signature/i }));
+    await waitFor(() =>
+      expect(screen.getByRole("alert")).toHaveTextContent(/password-protected/i),
+    );
+  });
+
+  it("shows insufficient credits error when checkCredits fails", async () => {
+    checkCredits.mockResolvedValue({ data: { success: false } });
+    const user = userEvent.setup();
+    render(<SignPdf creditCost={3} isAuthenticated />);
+    selectFile();
+    await waitFor(() => screen.getByTestId("signature-modal"));
+    await user.click(screen.getByRole("button", { name: /Confirm signature/i }));
+    await waitFor(() => screen.getByTestId("signature-placement"));
+    await user.click(screen.getByRole("button", { name: /Place Signature/i }));
+    await waitFor(() =>
+      expect(screen.getByRole("alert")).toHaveTextContent(/Insufficient credits/i),
+    );
+    expect(signPdf).not.toHaveBeenCalled();
+  });
+
+  it("'Sign another PDF' resets to upload step", async () => {
+    const user = userEvent.setup();
+    render(<SignPdf creditCost={3} isAuthenticated />);
+    selectFile();
+    await waitFor(() => screen.getByTestId("signature-modal"));
+    await user.click(screen.getByRole("button", { name: /Confirm signature/i }));
+    await waitFor(() => screen.getByTestId("signature-placement"));
+    await user.click(screen.getByRole("button", { name: /Place Signature/i }));
+    await waitFor(() => screen.getByRole("link", { name: /Download signed PDF/i }));
+    await user.click(screen.getByRole("button", { name: /Sign another PDF/i }));
+    await waitFor(() => expect(screen.getByTestId("file-input")).toBeInTheDocument());
+  });
+});

--- a/apps/pdf-craft/src/components/views/SignPdf/SignPdf.tsx
+++ b/apps/pdf-craft/src/components/views/SignPdf/SignPdf.tsx
@@ -1,0 +1,206 @@
+'use client'
+import { useState, useCallback } from 'react'
+import { actions } from 'astro:actions'
+import { Container, Stack, Text, Button, FileDropzone, Callout, Card } from '@fhdamd/threads'
+import * as Sentry from '@sentry/astro'
+import { logEvent } from '../../../utils/lib/analytics'
+import { buildPrepareSession } from '../../../utils/lib/operationSession'
+import { getPdfPageCount, getPdfPageDimensions } from '../../../utils/lib/pdfRender'
+import { DownloadIcon, ErrorCallout } from '../../shared'
+import SignatureModal, { type SignatureOutput } from './SignatureModal'
+import SignaturePlacement, { type Placement } from './SignaturePlacement'
+
+type Step = 'upload' | 'modal' | 'placement' | 'result'
+
+export default function SignPdf({
+  creditCost, isAuthenticated = false,
+}: { readonly creditCost: number; readonly isAuthenticated?: boolean }) {
+  const [step, setStep]                   = useState<Step>('upload')
+  const [file, setFile]                   = useState<File | null>(null)
+  const [pageDimensions, setPageDimensions] = useState<Array<{ width: number; height: number }>>([])
+  const [signature, setSignature]         = useState<SignatureOutput | null>(null)
+  const [downloadLink, setDownloadLink]   = useState<string | null>(null)
+  const [claimToken, setClaimToken]       = useState<string | null>(null)
+  const [error, setError]                 = useState<string | null>(null)
+  const [isProcessing, setIsProcessing]   = useState(false)
+  const [buttonLabel, setButtonLabel]     = useState('Sign PDF')
+
+  const prepareSession = buildPrepareSession({
+    isAuthenticated, creditCost, defaultLabel: 'Sign PDF',
+    setButtonLabel, setError: (e) => setError(e), setProcessing: setIsProcessing,
+  })
+
+  const handleFiles = useCallback(async (files: File[]) => {
+    if (!files.length) return
+    const f = files[0]
+    setFile(f); setError(null)
+    try {
+      const [, dims] = await Promise.all([
+        getPdfPageCount(f),   // validates the file is readable
+        getPdfPageDimensions(f),
+      ])
+      setPageDimensions(dims)
+      setStep('modal')
+    } catch (err) {
+      console.error('[SignPdf] failed to read PDF:', err)
+      setError('Could not read the PDF. Make sure it is a valid, unencrypted file.')
+    }
+  }, [])
+
+  const handleModalConfirm = (output: SignatureOutput) => {
+    setSignature(output)
+    setStep('placement')
+  }
+
+  const handleModalClose = () => {
+    setFile(null); setPageDimensions([])
+    setStep('upload')
+  }
+
+  const handlePlacementBack = () => setStep('modal')
+
+  const handlePlacementConfirm = useCallback(async (placements: Placement[]) => {
+    if (!file || !signature) return
+
+    const requestId = crypto.randomUUID()
+    const task = 'pdf-sign'
+    setError(null); setIsProcessing(true)
+    if (!await prepareSession(task, requestId)) return
+
+    logEvent('pdf_operation_started', { operation_type: task, placement_count: placements.length })
+    setButtonLabel('Signing...')
+
+    const formData = new FormData()
+    formData.append('file', file)
+    formData.append('signatureImage', signature.dataUrl)
+    formData.append('placements', JSON.stringify(placements))
+    formData.append('signerName', signature.signerName)
+    formData.append('signatureMethod', signature.source)
+    formData.append('requestId', requestId)
+    formData.append('task', task)
+    formData.append('creditCost', String(creditCost))
+
+    try {
+      const response = await actions.operations.signPdf(formData)
+      if (response.data?.success) {
+        logEvent('pdf_operation_completed', { operation_type: task })
+        const token = response.data.data?.claimToken
+        if (token) { setClaimToken(token) } else { setDownloadLink(response.data.data?.fileUrl || null) }
+        setStep('result')
+      } else {
+        logEvent('pdf_operation_failed', { operation_type: task })
+        setError(response.data?.error || 'Failed to sign PDF.')
+      }
+    } catch (err) {
+      logEvent('pdf_operation_failed', { operation_type: task })
+      setError('An unexpected error occurred. Please try again.')
+      Sentry.captureException(err)
+    } finally {
+      setButtonLabel('Sign PDF')
+      setIsProcessing(false)
+    }
+  }, [file, signature, prepareSession, creditCost])
+
+  const resetAll = () => {
+    setFile(null); setPageDimensions([]); setSignature(null)
+    setDownloadLink(null); setClaimToken(null); setError(null)
+    setStep('upload')
+  }
+
+  const goToSignup = () => { if (claimToken) sessionStorage.setItem('pendingClaimToken', claimToken); globalThis.location.href = '/signup' }
+  const goToSignin = () => { if (claimToken) sessionStorage.setItem('pendingClaimToken', claimToken); globalThis.location.href = '/signin' }
+
+  return (
+    <Container>
+      <Stack gap={6} style={{ paddingBlock: 'var(--th-space-8)' }}>
+        <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', flexWrap: 'wrap', gap: 'var(--th-space-3)' }}>
+          <Stack gap={1}>
+            <Text as="h1" size="2xl" color="1" weight={650} width={90}>Sign PDF</Text>
+            <Text size="sm" color="2">Add your electronic signature and embed an audit record.</Text>
+          </Stack>
+          <Button href="/dashboard" variant="ghost" size="sm">Back to dashboard</Button>
+        </div>
+
+        {/* Upload step */}
+        {step === 'upload' && (
+          <Card variant="elevated">
+            <Stack gap={5} style={{ padding: 'var(--th-space-6)' }}>
+              <FileDropzone
+                label="Upload PDF"
+                hint="Drag and drop or click to browse — one PDF file"
+                accept="application/pdf"
+                onFiles={handleFiles}
+              />
+              {error && <ErrorCallout message={error} />}
+            </Stack>
+          </Card>
+        )}
+
+        {/* Placement step — full-height card */}
+        {(step === 'modal' || step === 'placement') && file && (
+          <Card variant="elevated" style={{ overflow: 'hidden', minHeight: '600px', display: 'flex', flexDirection: 'column' }}>
+            {error && (
+              <div style={{ padding: 'var(--th-space-4)' }}>
+                <ErrorCallout message={error} />
+              </div>
+            )}
+            {step === 'placement' && signature && (
+              <SignaturePlacement
+                file={file}
+                signature={signature}
+                pageDimensions={pageDimensions}
+                onConfirm={handlePlacementConfirm}
+                onBack={handlePlacementBack}
+              />
+            )}
+            {isProcessing && (
+              <div style={{ padding: 'var(--th-space-6)', textAlign: 'center' }}>
+                <Text size="sm" color="2">{buttonLabel}</Text>
+              </div>
+            )}
+          </Card>
+        )}
+
+        {/* Result step */}
+        {step === 'result' && (
+          <Card variant="elevated">
+            <Stack gap={4} align="center" style={{ padding: 'var(--th-space-6)', paddingBlock: 'var(--th-space-8)' }}>
+              {claimToken ? (
+                <>
+                  <Callout variant="success" title="Your PDF has been signed">
+                    Create a free account to download it — no credit card required.
+                  </Callout>
+                  <div style={{ display: 'flex', gap: 'var(--th-space-3)', flexWrap: 'wrap' }}>
+                    <Button variant="solid-terra" onClick={goToSignup}>Sign up to download</Button>
+                    <Button variant="ghost" onClick={goToSignin}>Already have an account?</Button>
+                  </div>
+                </>
+              ) : (
+                <>
+                  <Callout variant="success" title="Your PDF has been signed">
+                    Your signature and audit record have been embedded.
+                  </Callout>
+                  <div style={{ display: 'flex', gap: 'var(--th-space-3)', flexWrap: 'wrap' }}>
+                    <Button href={downloadLink!} variant="solid-terra" icon={<DownloadIcon />}>
+                      Download signed PDF
+                    </Button>
+                    <Button variant="ghost" onClick={resetAll}>Sign another PDF</Button>
+                  </div>
+                </>
+              )}
+            </Stack>
+          </Card>
+        )}
+      </Stack>
+
+      {/* Signature creation modal — rendered above everything */}
+      {file && (
+        <SignatureModal
+          isOpen={step === 'modal'}
+          onClose={handleModalClose}
+          onConfirm={handleModalConfirm}
+        />
+      )}
+    </Container>
+  )
+}

--- a/apps/pdf-craft/src/components/views/SignPdf/SignatureModal.tsx
+++ b/apps/pdf-craft/src/components/views/SignPdf/SignatureModal.tsx
@@ -133,13 +133,16 @@ export default function SignatureModal({ isOpen, onClose, onConfirm }: Signature
     }
   }, [isOpen])
 
-  // Re-render all font previews when name or ink changes
+  // Re-render all font previews when name, ink, or open state changes.
+  // isOpen must be in the dependency array: when the modal first opens the canvas
+  // refs are freshly mounted and won't render unless this effect re-fires.
   useEffect(() => {
+    if (!isOpen) return
     FONT_STYLES.forEach(fs => {
       const canvas = previewCanvasRefs.current[fs.id]
       if (canvas) renderSignatureToCanvas(canvas, signerName || 'Your Name', fs, inkColor)
     })
-  }, [signerName, inkColor])
+  }, [signerName, inkColor, isOpen])
 
   // ── Draw tab handlers ──────────────────────────────────────────────────────
 
@@ -342,7 +345,7 @@ export default function SignatureModal({ isOpen, onClose, onConfirm }: Signature
                     >
                       <canvas
                         ref={el => { previewCanvasRefs.current[fs.id] = el }}
-                        style={{ display: 'block', maxWidth: '100%', pointerEvents: 'none' }}
+                        style={{ display: 'block', width: '100%', aspectRatio: `${CANVAS_W}/${CANVAS_H}`, pointerEvents: 'none' }}
                         width={CANVAS_W}
                         height={CANVAS_H}
                       />

--- a/apps/pdf-craft/src/components/views/SignPdf/SignaturePlacement.test.tsx
+++ b/apps/pdf-craft/src/components/views/SignPdf/SignaturePlacement.test.tsx
@@ -1,0 +1,234 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, waitFor, fireEvent } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import SignaturePlacement from "./SignaturePlacement";
+
+vi.mock("../../../utils/lib/pdfRender", () => ({
+  renderPdfPageToCanvas: vi.fn().mockResolvedValue(undefined),
+}));
+
+// jsdom doesn't implement setPointerCapture — stub it
+HTMLElement.prototype.setPointerCapture = vi.fn();
+
+const mockOnConfirm = vi.fn();
+const mockOnBack = vi.fn();
+
+const PAGE_DIMS = [
+  { width: 595, height: 842 },
+  { width: 595, height: 842 },
+  { width: 595, height: 842 },
+];
+
+const SIG: { dataUrl: string; source: 'typed'; signerName: string } = {
+  dataUrl: "data:image/png;base64,fakepng",
+  source: "typed",
+  signerName: "Fahad Ahmed",
+};
+
+const pdfFile = new File(["pdf"], "doc.pdf", { type: "application/pdf" });
+
+const defaultProps = {
+  file: pdfFile,
+  signature: SIG,
+  pageDimensions: PAGE_DIMS,
+  onConfirm: mockOnConfirm,
+  onBack: mockOnBack,
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+// ── Rendering ─────────────────────────────────────────────────────────────────
+
+describe("SignaturePlacement — rendering", () => {
+  it("renders the header and footer", () => {
+    render(<SignaturePlacement {...defaultProps} />);
+    expect(screen.getByText("Place your signature")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /Back/i })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /Place Signature/i })).toBeInTheDocument();
+  });
+
+  it("shows the page count in the footer", () => {
+    render(<SignaturePlacement {...defaultProps} />);
+    expect(screen.getByText(/Page 1 of 3/i)).toBeInTheDocument();
+  });
+
+  it("renders a thumbnail button for each page", () => {
+    render(<SignaturePlacement {...defaultProps} />);
+    expect(screen.getByRole("button", { name: /Page 1/i })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /Page 2/i })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /Page 3/i })).toBeInTheDocument();
+  });
+
+  it("renders the signature image in the overlay", () => {
+    render(<SignaturePlacement {...defaultProps} />);
+    const img = screen.getByRole("img", { name: /Signature/i });
+    expect(img).toHaveAttribute("src", SIG.dataUrl);
+  });
+
+  it("shows the 'Also stamp initials on other pages' checkbox unchecked by default", () => {
+    render(<SignaturePlacement {...defaultProps} />);
+    expect(screen.getByRole("checkbox", { name: /Also stamp initials/i })).not.toBeChecked();
+  });
+
+  it("shows a zoom range input", () => {
+    render(<SignaturePlacement {...defaultProps} />);
+    expect(screen.getByRole("slider", { name: /Zoom/i })).toBeInTheDocument();
+  });
+});
+
+// ── Navigation ────────────────────────────────────────────────────────────────
+
+describe("SignaturePlacement — navigation", () => {
+  it("calls onBack when the Back button is clicked", async () => {
+    const user = userEvent.setup();
+    render(<SignaturePlacement {...defaultProps} />);
+    await user.click(screen.getByRole("button", { name: /Back/i }));
+    expect(mockOnBack).toHaveBeenCalledOnce();
+  });
+
+  it("switching to page 2 via thumbnail updates the page counter", async () => {
+    const user = userEvent.setup();
+    render(<SignaturePlacement {...defaultProps} />);
+    await user.click(screen.getByRole("button", { name: /Page 2/i }));
+    await waitFor(() => expect(screen.getByText(/Page 2 of 3/i)).toBeInTheDocument());
+  });
+
+  it("switching pages re-renders the main canvas", async () => {
+    const { renderPdfPageToCanvas } = await import("../../../utils/lib/pdfRender");
+    const user = userEvent.setup();
+    render(<SignaturePlacement {...defaultProps} />);
+    await user.click(screen.getByRole("button", { name: /Page 3/i }));
+    await waitFor(() =>
+      expect(renderPdfPageToCanvas).toHaveBeenCalledWith(pdfFile, 3, expect.any(HTMLCanvasElement), expect.any(Number)),
+    );
+  });
+});
+
+// ── Placement confirm ─────────────────────────────────────────────────────────
+
+describe("SignaturePlacement — confirm", () => {
+  it("calls onConfirm with a single placement when Place Signature is clicked", async () => {
+    const user = userEvent.setup();
+    render(<SignaturePlacement {...defaultProps} />);
+    await user.click(screen.getByRole("button", { name: /Place Signature/i }));
+    expect(mockOnConfirm).toHaveBeenCalledOnce();
+    const [placements] = mockOnConfirm.mock.calls[0];
+    expect(placements).toHaveLength(1);
+    expect(placements[0].page).toBe(1);
+    expect(typeof placements[0].x).toBe("number");
+    expect(typeof placements[0].y).toBe("number");
+    expect(typeof placements[0].width).toBe("number");
+    expect(typeof placements[0].height).toBe("number");
+  });
+
+  it("calls onConfirm with placements for all pages when 'stamp all' is checked", async () => {
+    const user = userEvent.setup();
+    render(<SignaturePlacement {...defaultProps} />);
+    await user.click(screen.getByRole("checkbox", { name: /Also stamp initials/i }));
+    await user.click(screen.getByRole("button", { name: /Place Signature/i }));
+    const [placements] = mockOnConfirm.mock.calls[0];
+    expect(placements).toHaveLength(3); // one per page
+    expect(placements[0].page).toBe(1);
+    expect(placements[1].page).toBe(2);
+    expect(placements[2].page).toBe(3);
+  });
+
+  it("places signature on the correct page when on page 2", async () => {
+    const user = userEvent.setup();
+    render(<SignaturePlacement {...defaultProps} />);
+    await user.click(screen.getByRole("button", { name: /Page 2/i }));
+    await waitFor(() => screen.getByText(/Page 2 of 3/i));
+    await user.click(screen.getByRole("button", { name: /Place Signature/i }));
+    const [placements] = mockOnConfirm.mock.calls[0];
+    expect(placements[0].page).toBe(2);
+  });
+});
+
+// ── Drag interactions ─────────────────────────────────────────────────────────
+
+describe("SignaturePlacement — drag", () => {
+  it("dragging the signature overlay calls setSigRect (no crash)", () => {
+    render(<SignaturePlacement {...defaultProps} />);
+    const overlay = screen.getByRole("img", { name: /Signature/i }).parentElement!;
+    fireEvent.pointerDown(overlay, { clientX: 100, clientY: 100, pointerId: 1 });
+    fireEvent.pointerMove(overlay, { clientX: 120, clientY: 130, pointerId: 1 });
+    fireEvent.pointerUp(overlay, { pointerId: 1 });
+    // Component stays stable
+    expect(screen.getByRole("button", { name: /Place Signature/i })).toBeInTheDocument();
+  });
+
+  it("pointer move without prior pointer down does nothing (early return)", () => {
+    render(<SignaturePlacement {...defaultProps} />);
+    const overlay = screen.getByRole("img", { name: /Signature/i }).parentElement!;
+    // No pointerDown first
+    fireEvent.pointerMove(overlay, { clientX: 120, clientY: 130 });
+    expect(screen.getByText(/Page 1 of 3/i)).toBeInTheDocument();
+  });
+
+  it("drag is constrained to canvas bounds (clamps to 0 minimum)", async () => {
+    const user = userEvent.setup();
+    render(<SignaturePlacement {...defaultProps} />);
+    const overlay = screen.getByRole("img", { name: /Signature/i }).parentElement!;
+    fireEvent.pointerDown(overlay, { clientX: 100, clientY: 100, pointerId: 1 });
+    // Move far negative — should clamp to 0
+    fireEvent.pointerMove(overlay, { clientX: -9999, clientY: -9999, pointerId: 1 });
+    fireEvent.pointerUp(overlay);
+    // After confirm the x and y should be ≥ 0 in PDF points
+    await user.click(screen.getByRole("button", { name: /Place Signature/i }));
+    const [[placements]] = mockOnConfirm.mock.calls;
+    expect(placements[0].x).toBeGreaterThanOrEqual(0);
+    expect(placements[0].y).toBeGreaterThanOrEqual(0);
+  });
+});
+
+// ── Resize interactions ───────────────────────────────────────────────────────
+
+describe("SignaturePlacement — resize", () => {
+  it("dragging the resize handle updates the signature size without crashing", () => {
+    render(<SignaturePlacement {...defaultProps} />);
+    const handle = screen.getByRole("button", { name: /Resize signature/i });
+    fireEvent.pointerDown(handle, { clientX: 200, clientY: 300, pointerId: 1 });
+    fireEvent.pointerMove(handle, { clientX: 250, clientY: 350, pointerId: 1 });
+    fireEvent.pointerUp(handle);
+    expect(screen.getByRole("button", { name: /Place Signature/i })).toBeInTheDocument();
+  });
+
+  it("resize pointer move without prior down does nothing (early return)", () => {
+    render(<SignaturePlacement {...defaultProps} />);
+    const handle = screen.getByRole("button", { name: /Resize signature/i });
+    fireEvent.pointerMove(handle, { clientX: 250, clientY: 350 });
+    expect(screen.getByText(/Page 1 of 3/i)).toBeInTheDocument();
+  });
+
+  it("resize is constrained to minimum size", async () => {
+    const user = userEvent.setup();
+    render(<SignaturePlacement {...defaultProps} />);
+    const handle = screen.getByRole("button", { name: /Resize signature/i });
+    fireEvent.pointerDown(handle, { clientX: 200, clientY: 300, pointerId: 1 });
+    // Drag far negative — width/height should clamp to MIN_SIG_W/H
+    fireEvent.pointerMove(handle, { clientX: -9999, clientY: -9999, pointerId: 1 });
+    fireEvent.pointerUp(handle);
+    await user.click(screen.getByRole("button", { name: /Place Signature/i }));
+    const [[placements]] = mockOnConfirm.mock.calls;
+    expect(placements[0].width).toBeGreaterThan(0);
+    expect(placements[0].height).toBeGreaterThan(0);
+  });
+});
+
+// ── Zoom ──────────────────────────────────────────────────────────────────────
+
+describe("SignaturePlacement — zoom", () => {
+  it("changing the zoom slider triggers a canvas re-render", async () => {
+    const { renderPdfPageToCanvas } = await import("../../../utils/lib/pdfRender");
+    render(<SignaturePlacement {...defaultProps} />);
+    const slider = screen.getByRole("slider", { name: /Zoom/i });
+    fireEvent.change(slider, { target: { value: "0.8" } });
+    await waitFor(() =>
+      expect(renderPdfPageToCanvas).toHaveBeenCalledWith(
+        pdfFile, 1, expect.any(HTMLCanvasElement), 0.8,
+      ),
+    );
+  });
+});

--- a/apps/pdf-craft/src/components/views/SignPdf/SignaturePlacement.tsx
+++ b/apps/pdf-craft/src/components/views/SignPdf/SignaturePlacement.tsx
@@ -1,0 +1,278 @@
+'use client'
+import { useState, useRef, useEffect, useCallback } from 'react'
+import { Text, Button } from '@fhdamd/threads'
+import { renderPdfPageToCanvas } from '../../../utils/lib/pdfRender'
+import { pixelsToPdfPoints } from './pixelsToPdfPoints'
+import type { SignatureOutput } from './SignatureModal'
+
+export interface Placement {
+  readonly page: number
+  readonly x: number
+  readonly y: number
+  readonly width: number
+  readonly height: number
+}
+
+interface PageDimension { readonly width: number; readonly height: number }
+
+interface SignaturePlacementProps {
+  readonly file: File
+  readonly signature: SignatureOutput
+  readonly pageDimensions: PageDimension[]
+  readonly onConfirm: (placements: Placement[]) => void
+  readonly onBack: () => void
+}
+
+// ── Page thumbnail (lazy via IntersectionObserver) ────────────────────────────
+
+function PageThumb({ file, pageNumber, scale, isActive, onClick }: {
+  readonly file: File
+  readonly pageNumber: number
+  readonly scale: number
+  readonly isActive: boolean
+  readonly onClick: () => void
+}) {
+  const ref = useRef<HTMLCanvasElement>(null)
+  const [rendered, setRendered] = useState(false)
+
+  useEffect(() => { setRendered(false) }, [scale])
+
+  useEffect(() => {
+    const canvas = ref.current
+    if (!canvas) return
+    const observer = new IntersectionObserver(([entry]) => {
+      if (entry.isIntersecting && !rendered) {
+        setRendered(true)
+        renderPdfPageToCanvas(file, pageNumber, canvas, scale).catch(() => {})
+      }
+    }, { threshold: 0.1 })
+    observer.observe(canvas)
+    return () => observer.disconnect()
+  }, [file, pageNumber, scale, rendered])
+
+  return (
+    <button
+      onClick={onClick}
+      aria-label={`Page ${pageNumber}`}
+      style={{
+        border: 'none', background: 'transparent', cursor: 'pointer',
+        padding: '4px', borderRadius: 'var(--th-radius-sm)',
+        display: 'flex', flexDirection: 'column', alignItems: 'center', gap: '4px',
+        boxShadow: isActive ? '0 0 0 2px var(--th-color-accent)' : 'none',
+        transition: 'box-shadow var(--th-duration-base) var(--th-ease-base)',
+      }}
+    >
+      <canvas ref={ref} style={{ display: 'block', border: '1px solid var(--th-color-border)', borderRadius: '2px', backgroundColor: '#fff' }} />
+      <Text as="span" size="xs" color="3">{pageNumber}</Text>
+    </button>
+  )
+}
+
+// ── Main component ────────────────────────────────────────────────────────────
+
+const DEFAULT_SIG_W_PT = 160
+const DEFAULT_SIG_H_PT = 60
+const THUMB_SCALE = 0.18
+const MIN_SIG_W = 40
+const MIN_SIG_H = 20
+
+export default function SignaturePlacement({
+  file, signature, pageDimensions, onConfirm, onBack,
+}: SignaturePlacementProps) {
+  const [currentPage, setCurrentPage] = useState(1)
+  const [zoom, setZoom] = useState(0.6)
+  const [stampAll, setStampAll] = useState(false)
+
+  // Signature rect in canvas-pixel space (top-left origin)
+  const pageDim = pageDimensions[currentPage - 1] ?? { width: 595, height: 842 }
+  const [sigRect, setSigRect] = useState({
+    x: (pageDim.width * zoom - DEFAULT_SIG_W_PT * zoom) / 2,
+    y: (pageDim.height * zoom) - DEFAULT_SIG_H_PT * zoom - 60,
+    w: DEFAULT_SIG_W_PT * zoom,
+    h: DEFAULT_SIG_H_PT * zoom,
+  })
+
+  // Reset placement when page or zoom changes
+  useEffect(() => {
+    const dim = pageDimensions[currentPage - 1] ?? { width: 595, height: 842 }
+    setSigRect({
+      x: (dim.width * zoom - DEFAULT_SIG_W_PT * zoom) / 2,
+      y: dim.height * zoom - DEFAULT_SIG_H_PT * zoom - 60,
+      w: DEFAULT_SIG_W_PT * zoom,
+      h: DEFAULT_SIG_H_PT * zoom,
+    })
+  }, [currentPage, zoom, pageDimensions])
+
+  const mainCanvasRef = useRef<HTMLCanvasElement>(null)
+  const [mainRendered, setMainRendered] = useState(false)
+
+  // Re-render main canvas when page or zoom changes
+  useEffect(() => { setMainRendered(false) }, [currentPage, zoom])
+  useEffect(() => {
+    const canvas = mainCanvasRef.current
+    if (canvas && !mainRendered) {
+      setMainRendered(true)
+      renderPdfPageToCanvas(file, currentPage, canvas, zoom).catch(() => {})
+    }
+  }, [file, currentPage, zoom, mainRendered])
+
+  // ── Drag handling ──────────────────────────────────────────────────────────
+
+  const dragStartRef = useRef<{ mx: number; my: number; rx: number; ry: number } | null>(null)
+
+  const onSigPointerDown = (e: React.PointerEvent) => {
+    e.stopPropagation()
+    dragStartRef.current = { mx: e.clientX, my: e.clientY, rx: sigRect.x, ry: sigRect.y }
+    ;(e.currentTarget as HTMLElement).setPointerCapture(e.pointerId)
+  }
+
+  const onSigPointerMove = (e: React.PointerEvent) => {
+    if (!dragStartRef.current) return
+    const dim = pageDimensions[currentPage - 1] ?? { width: 595, height: 842 }
+    const maxX = dim.width * zoom - sigRect.w
+    const maxY = dim.height * zoom - sigRect.h
+    const nx = Math.max(0, Math.min(maxX, dragStartRef.current.rx + e.clientX - dragStartRef.current.mx))
+    const ny = Math.max(0, Math.min(maxY, dragStartRef.current.ry + e.clientY - dragStartRef.current.my))
+    setSigRect(prev => ({ ...prev, x: nx, y: ny }))
+  }
+
+  const onSigPointerUp = () => { dragStartRef.current = null }
+
+  // ── Resize handling ────────────────────────────────────────────────────────
+
+  const resizeStartRef = useRef<{ mx: number; my: number; rw: number; rh: number } | null>(null)
+
+  const onResizePointerDown = (e: React.PointerEvent) => {
+    e.stopPropagation()
+    resizeStartRef.current = { mx: e.clientX, my: e.clientY, rw: sigRect.w, rh: sigRect.h }
+    ;(e.currentTarget as HTMLElement).setPointerCapture(e.pointerId)
+  }
+
+  const onResizePointerMove = (e: React.PointerEvent) => {
+    if (!resizeStartRef.current) return
+    const dim = pageDimensions[currentPage - 1] ?? { width: 595, height: 842 }
+    const nw = Math.max(MIN_SIG_W, Math.min(dim.width * zoom - sigRect.x, resizeStartRef.current.rw + e.clientX - resizeStartRef.current.mx))
+    const nh = Math.max(MIN_SIG_H, Math.min(dim.height * zoom - sigRect.y, resizeStartRef.current.rh + e.clientY - resizeStartRef.current.my))
+    setSigRect(prev => ({ ...prev, w: nw, h: nh }))
+  }
+
+  const onResizePointerUp = () => { resizeStartRef.current = null }
+
+  // ── Confirm ────────────────────────────────────────────────────────────────
+
+  const handleConfirm = useCallback(() => {
+    const dim = pageDimensions[currentPage - 1] ?? { width: 595, height: 842 }
+    const pdfCoords = pixelsToPdfPoints(sigRect.x, sigRect.y, sigRect.w, sigRect.h, zoom, dim.height)
+    const placement: Placement = { page: currentPage, ...pdfCoords }
+
+    if (stampAll) {
+      const placements: Placement[] = pageDimensions.map((d, i) => {
+        const wPt = pdfCoords.width
+        const hPt = pdfCoords.height
+        const xFrac = pdfCoords.x / dim.width
+        const yFrac = pdfCoords.y / dim.height
+        return { page: i + 1, x: xFrac * d.width, y: yFrac * d.height, width: wPt, height: hPt }
+      })
+      onConfirm(placements)
+    } else {
+      onConfirm([placement])
+    }
+  }, [currentPage, pageDimensions, sigRect, zoom, stampAll, onConfirm])
+
+  const dim = pageDimensions[currentPage - 1] ?? { width: 595, height: 842 }
+  const canvasW = Math.round(dim.width * zoom)
+  const canvasH = Math.round(dim.height * zoom)
+
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', height: '100%' }}>
+      {/* Header */}
+      <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', padding: 'var(--th-space-4) var(--th-space-5)', borderBottom: '1px solid var(--th-color-border)', flexWrap: 'wrap', gap: 'var(--th-space-3)' }}>
+        <Text as="h2" size="lg" color="1" weight={650}>Place your signature</Text>
+        <div style={{ display: 'flex', alignItems: 'center', gap: 'var(--th-space-4)', flexWrap: 'wrap' }}>
+          <label style={{ display: 'flex', alignItems: 'center', gap: 'var(--th-space-2)', cursor: 'pointer', fontSize: 'var(--th-text-sm)', color: 'var(--th-color-text-2)' }}>
+            <input type="checkbox" checked={stampAll} onChange={e => setStampAll(e.target.checked)} style={{ accentColor: 'var(--th-color-accent)' }} />
+            <span>Also stamp initials on other pages</span>
+          </label>
+          <div style={{ display: 'flex', alignItems: 'center', gap: 'var(--th-space-2)' }}>
+            <Text as="span" size="xs" color="3">Zoom</Text>
+            <input type="range" min={0.3} max={1.2} step={0.05} value={zoom} onChange={e => setZoom(Number(e.target.value))} aria-label="Zoom" style={{ width: '80px', accentColor: 'var(--th-color-accent)' }} />
+          </div>
+        </div>
+      </div>
+
+      {/* Body */}
+      <div style={{ display: 'flex', flex: 1, overflow: 'hidden' }}>
+        {/* Page thumbnail rail */}
+        <div style={{ width: '100px', flexShrink: 0, borderRight: '1px solid var(--th-color-border)', overflowY: 'auto', padding: 'var(--th-space-3)', display: 'flex', flexDirection: 'column', gap: 'var(--th-space-2)', backgroundColor: 'var(--th-color-surface-2)' }}>
+          {pageDimensions.map((_, i) => (
+            <PageThumb
+              key={i + 1}
+              file={file}
+              pageNumber={i + 1}
+              scale={THUMB_SCALE}
+              isActive={currentPage === i + 1}
+              onClick={() => setCurrentPage(i + 1)}
+            />
+          ))}
+        </div>
+
+        {/* Main canvas area */}
+        <div style={{ flex: 1, overflow: 'auto', display: 'flex', alignItems: 'flex-start', justifyContent: 'center', padding: 'var(--th-space-6)', backgroundColor: 'var(--th-color-surface-1)' }}>
+          {/* Page + signature overlay container */}
+          <div style={{ position: 'relative', display: 'inline-block', boxShadow: '0 4px 20px rgba(0,0,0,0.15)' }}>
+            <canvas
+              ref={mainCanvasRef}
+              width={canvasW}
+              height={canvasH}
+              style={{ display: 'block', backgroundColor: '#fff' }}
+            />
+            {/* Draggable signature overlay */}
+            <div
+              onPointerDown={onSigPointerDown}
+              onPointerMove={onSigPointerMove}
+              onPointerUp={onSigPointerUp}
+              style={{
+                position: 'absolute',
+                left: sigRect.x, top: sigRect.y,
+                width: sigRect.w, height: sigRect.h,
+                cursor: 'move', userSelect: 'none', touchAction: 'none',
+                border: '1.5px dashed var(--th-color-accent)',
+                borderRadius: '2px',
+              }}
+            >
+              <img
+                src={signature.dataUrl}
+                alt="Signature"
+                style={{ width: '100%', height: '100%', objectFit: 'contain', pointerEvents: 'none', display: 'block' }}
+                draggable={false}
+              />
+              {/* Resize handle — bottom-right corner */}
+              <div
+                onPointerDown={onResizePointerDown}
+                onPointerMove={onResizePointerMove}
+                onPointerUp={onResizePointerUp}
+                aria-label="Resize signature"
+                style={{
+                  position: 'absolute', bottom: -5, right: -5,
+                  width: '12px', height: '12px',
+                  backgroundColor: 'var(--th-color-accent)',
+                  borderRadius: '2px', cursor: 'nwse-resize',
+                  touchAction: 'none',
+                }}
+              />
+            </div>
+          </div>
+        </div>
+      </div>
+
+      {/* Footer */}
+      <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', padding: 'var(--th-space-4) var(--th-space-5)', borderTop: '1px solid var(--th-color-border)', backgroundColor: 'var(--th-color-surface-2)' }}>
+        <Text as="span" size="sm" color="3">Page {currentPage} of {pageDimensions.length}</Text>
+        <div style={{ display: 'flex', gap: 'var(--th-space-3)' }}>
+          <Button variant="ghost" onClick={onBack}>Back</Button>
+          <Button variant="solid-terra" onClick={handleConfirm}>Place Signature</Button>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/apps/pdf-craft/src/components/views/SignPdf/SignaturePlacement.tsx
+++ b/apps/pdf-craft/src/components/views/SignPdf/SignaturePlacement.tsx
@@ -247,7 +247,7 @@ export default function SignaturePlacement({
                 draggable={false}
               />
               {/* Resize handle — bottom-right corner */}
-              <div
+              <button
                 onPointerDown={onResizePointerDown}
                 onPointerMove={onResizePointerMove}
                 onPointerUp={onResizePointerUp}
@@ -257,7 +257,7 @@ export default function SignaturePlacement({
                   width: '12px', height: '12px',
                   backgroundColor: 'var(--th-color-accent)',
                   borderRadius: '2px', cursor: 'nwse-resize',
-                  touchAction: 'none',
+                  touchAction: 'none', border: 'none', padding: 0,
                 }}
               />
             </div>

--- a/apps/pdf-craft/src/components/views/SignPdf/index.ts
+++ b/apps/pdf-craft/src/components/views/SignPdf/index.ts
@@ -1,0 +1,6 @@
+export { default as SignPdf } from './SignPdf';
+export { default as SignatureModal } from './SignatureModal';
+export type { SignatureOutput } from './SignatureModal';
+export { default as SignaturePlacement } from './SignaturePlacement';
+export type { Placement } from './SignaturePlacement';
+export { pixelsToPdfPoints } from './pixelsToPdfPoints';

--- a/apps/pdf-craft/src/components/views/SignPdf/pixelsToPdfPoints.test.ts
+++ b/apps/pdf-craft/src/components/views/SignPdf/pixelsToPdfPoints.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect } from "vitest";
+import { pixelsToPdfPoints } from "./pixelsToPdfPoints";
+
+// A4 page: 595 × 842 pt. Canvas rendered at scale=0.5 → 297.5 × 421 px.
+
+const PAGE_H = 842;
+const SCALE = 0.5;
+
+describe("pixelsToPdfPoints", () => {
+  it("converts x coordinate correctly (no flip needed for x)", () => {
+    const result = pixelsToPdfPoints(50, 100, 80, 30, SCALE, PAGE_H);
+    // x: 50px / 0.5 = 100pt
+    expect(result.x).toBeCloseTo(100);
+  });
+
+  it("converts width and height from pixels to PDF points", () => {
+    const result = pixelsToPdfPoints(0, 0, 100, 40, SCALE, PAGE_H);
+    expect(result.width).toBeCloseTo(200);   // 100px / 0.5 = 200pt
+    expect(result.height).toBeCloseTo(80);   // 40px / 0.5 = 80pt
+  });
+
+  it("flips y-axis from top-left to bottom-left origin", () => {
+    // Signature at top of canvas: canvasY=0, canvasH=60px → heightPt=120
+    // pdfY = pageH - 0 - 120 = 722pt (near top in PDF coords)
+    const result = pixelsToPdfPoints(0, 0, 100, 60, SCALE, PAGE_H);
+    expect(result.y).toBeCloseTo(PAGE_H - 0 - 60 / SCALE);
+  });
+
+  it("positions a signature at the bottom of the page correctly", () => {
+    // Bottom of a 421px canvas: canvasY = 421 - 30 = 391px
+    const canvasH = PAGE_H * SCALE; // 421
+    const sigHPx = 30;
+    const canvasY = canvasH - sigHPx;
+    const result = pixelsToPdfPoints(0, canvasY, 0, sigHPx, SCALE, PAGE_H);
+    // pdfY = 842 - 391/0.5 - 30/0.5 = 842 - 782 - 60 = 0
+    expect(result.y).toBeCloseTo(0);
+  });
+
+  it("returns zero x when input x is zero", () => {
+    const result = pixelsToPdfPoints(0, 50, 40, 20, SCALE, PAGE_H);
+    expect(result.x).toBe(0);
+  });
+
+  it("works at scale=1 (pixel === PDF point)", () => {
+    const result = pixelsToPdfPoints(10, 20, 30, 40, 1, PAGE_H);
+    expect(result.x).toBeCloseTo(10);
+    expect(result.y).toBeCloseTo(PAGE_H - 20 - 40);
+    expect(result.width).toBeCloseTo(30);
+    expect(result.height).toBeCloseTo(40);
+  });
+
+  it("works at scale=2 (canvas pixels are 2× the PDF points)", () => {
+    const result = pixelsToPdfPoints(100, 200, 80, 40, 2, PAGE_H);
+    expect(result.x).toBeCloseTo(50);     // 100/2
+    expect(result.width).toBeCloseTo(40); // 80/2
+    expect(result.height).toBeCloseTo(20); // 40/2
+    expect(result.y).toBeCloseTo(PAGE_H - 100 - 20); // 842 - 100 - 20 = 722
+  });
+
+  it("handles non-standard page heights (landscape / custom)", () => {
+    const landscapeH = 595; // A4 landscape
+    const result = pixelsToPdfPoints(0, 0, 0, 50, 1, landscapeH);
+    expect(result.y).toBeCloseTo(landscapeH - 50);
+  });
+});

--- a/apps/pdf-craft/src/components/views/SignPdf/pixelsToPdfPoints.ts
+++ b/apps/pdf-craft/src/components/views/SignPdf/pixelsToPdfPoints.ts
@@ -1,0 +1,37 @@
+/**
+ * Converts a signature placement rectangle from canvas-pixel space
+ * (top-left origin, as used by the browser) to PDF point space
+ * (bottom-left origin, as used by pdf-lib).
+ *
+ * @param x             Left edge of the signature in canvas pixels.
+ * @param y             Top edge of the signature in canvas pixels.
+ * @param width         Signature width in canvas pixels.
+ * @param height        Signature height in canvas pixels.
+ * @param scale         Canvas scale factor (canvasPixels = pdfPoints × scale).
+ * @param pageHeightPt  PDF page height in points (from pdf.js getViewport({scale:1})).
+ *
+ * @returns Placement in PDF points with bottom-left origin, ready for pdf-lib's
+ *          page.drawImage({ x, y, width, height }).
+ */
+export function pixelsToPdfPoints(
+  x: number,
+  y: number,
+  width: number,
+  height: number,
+  scale: number,
+  pageHeightPt: number,
+): { x: number; y: number; width: number; height: number } {
+  const xPt = x / scale
+  const yPt = y / scale
+  const wPt = width / scale
+  const hPt = height / scale
+  return {
+    x: xPt,
+    // PDF y=0 is the bottom edge; flip from top-left origin.
+    // pdf-lib positions images by their bottom-left corner, so subtract
+    // both the top offset and the image height.
+    y: pageHeightPt - yPt - hPt,
+    width: wPt,
+    height: hPt,
+  }
+}

--- a/apps/pdf-craft/src/components/views/index.ts
+++ b/apps/pdf-craft/src/components/views/index.ts
@@ -10,5 +10,6 @@ export { default as ForgotPasswordForm } from "./ForgotPasswordForm";
 export { default as ResetPasswordForm } from "./ResetPasswordForm";
 export { SplitPdf } from "./SplitPdf";
 export { CompressPdf } from "./CompressPdf";
+export { SignPdf } from "./SignPdf";
 
 export * from "./SignupForm";

--- a/apps/pdf-craft/src/pages/signpdf.astro
+++ b/apps/pdf-craft/src/pages/signpdf.astro
@@ -1,0 +1,59 @@
+---
+import Layout from "../layouts/Layout.astro";
+import { SignPdf } from "../components";
+import { fetchCms } from "../utils/lib/cms";
+import { resolveIsAuthenticated } from "../firebase/server";
+import { Container, Section, Accordion } from "@fhdamd/threads";
+import type { Operation, Faq } from "../utils";
+
+type OperationsResponse = { data: { allOperations: Operation[] } }
+type FaqsResponse = { data: { allFaqs: Faq[] } }
+
+const [opsRes, faqsRes] = await Promise.all([
+  fetchCms<OperationsResponse>('operations'),
+  fetchCms<FaqsResponse>('faqs', { area: 'sign' }),
+])
+
+const op = opsRes.data.allOperations.find(o => o.iconKey === 'sign')
+const creditCost = op?.creditCost ?? 3
+const faqItems = faqsRes.data.allFaqs.map(({ title, content }) => ({ question: title, answer: content }))
+const isAuthenticated = await resolveIsAuthenticated(Astro.cookies.get('__session')?.value)
+---
+
+<Layout
+  title="Sign PDF — Riqa"
+  description="Add your electronic signature to a PDF. Three signature styles, a visible audit record, and embedded metadata. Pay per use."
+>
+  <Fragment slot="head">
+    {faqItems.length > 0 && (
+      <script
+        is:inline
+        type="application/ld+json"
+        set:html={JSON.stringify({
+          "@context": "https://schema.org",
+          "@type": "FAQPage",
+          mainEntity: faqItems.map(({ question, answer }) => ({
+            "@type": "Question",
+            name: question,
+            acceptedAnswer: { "@type": "Answer", text: answer },
+          })),
+        })}
+      />
+    )}
+  </Fragment>
+
+  <SignPdf creditCost={creditCost} isAuthenticated={isAuthenticated} client:load />
+
+  {faqItems.length > 0 && (
+    <Container>
+      <Section size="md">
+        <h2 style="font-size:var(--th-text-xl);font-weight:650;margin-bottom:var(--th-space-6)">
+          Frequently asked questions
+        </h2>
+        <div style="max-width:680px">
+          <Accordion client:load items={faqItems} />
+        </div>
+      </Section>
+    </Container>
+  )}
+</Layout>

--- a/apps/pdf-craft/src/test/mocks/astro-actions.ts
+++ b/apps/pdf-craft/src/test/mocks/astro-actions.ts
@@ -9,6 +9,7 @@ export const imageToPdf = vi.fn().mockResolvedValue({ data: { data: { fileUrl: "
 export const splitPdf = vi.fn().mockResolvedValue({ data: { success: true, data: { fileUrl: "https://cdn.test/split.pdf" } }, error: null });
 export const compressPdf = vi.fn().mockResolvedValue({ data: { success: true, data: { fileUrl: "https://cdn.test/compressed.pdf", alreadyOptimised: false } }, error: null });
 export const signPdf = vi.fn().mockResolvedValue({ data: { success: true, data: { fileUrl: "https://cdn.test/signed.pdf" } }, error: null });
+
 export const verifyUser = vi.fn().mockResolvedValue({ data: { redirected: false }, error: null });
 export const createUser = vi.fn().mockResolvedValue({ data: { success: true }, error: null });
 export const signOutUser = vi.fn().mockResolvedValue({ data: { success: true }, error: null });

--- a/apps/pdf-craft/src/utils/lib/pdfRender.test.ts
+++ b/apps/pdf-craft/src/utils/lib/pdfRender.test.ts
@@ -19,7 +19,7 @@ vi.mock("pdfjs-dist", () => ({
   getDocument: (...args: unknown[]) => mockGetDocument(...args),
 }));
 
-import { getPdfPageCount, renderPdfPageToCanvas } from "./pdfRender";
+import { getPdfPageCount, getPdfPageDimensions, renderPdfPageToCanvas } from "./pdfRender";
 
 beforeEach(() => {
   vi.clearAllMocks();
@@ -82,5 +82,34 @@ describe("renderPdfPageToCanvas", () => {
     await renderPdfPageToCanvas(file, 1, canvas, 1);
     expect(mockPage.cleanup).toHaveBeenCalled();
     expect(mockDoc.cleanup).toHaveBeenCalled();
+  });
+});
+
+describe("getPdfPageDimensions", () => {
+  it("returns width and height for each page at scale=1", async () => {
+    const file = new File(["pdf"], "test.pdf", { type: "application/pdf" });
+    const dims = await getPdfPageDimensions(file);
+    expect(dims).toHaveLength(5); // mockDoc.numPages = 5
+    expect(dims[0]).toEqual({ width: 100, height: 150 }); // from mockPage.getViewport
+  });
+
+  it("calls getPage for each page (1-indexed)", async () => {
+    const file = new File(["pdf"], "test.pdf", { type: "application/pdf" });
+    await getPdfPageDimensions(file);
+    expect(mockDoc.getPage).toHaveBeenCalledWith(1);
+    expect(mockDoc.getPage).toHaveBeenCalledWith(5);
+  });
+
+  it("calls cleanup on each page and the document", async () => {
+    const file = new File(["pdf"], "test.pdf", { type: "application/pdf" });
+    await getPdfPageDimensions(file);
+    expect(mockPage.cleanup).toHaveBeenCalledTimes(5);
+    expect(mockDoc.cleanup).toHaveBeenCalled();
+  });
+
+  it("uses scale=1 for the viewport (returns PDF point dimensions)", async () => {
+    const file = new File(["pdf"], "test.pdf", { type: "application/pdf" });
+    await getPdfPageDimensions(file);
+    expect(mockPage.getViewport).toHaveBeenCalledWith({ scale: 1 });
   });
 });

--- a/apps/pdf-craft/src/utils/lib/pdfRender.ts
+++ b/apps/pdf-craft/src/utils/lib/pdfRender.ts
@@ -27,6 +27,28 @@ export async function getPdfPageCount(file: File): Promise<number> {
 }
 
 /**
+ * Returns the width and height (in PDF points) for every page in a file.
+ * Pages within a single document may have different sizes, so per-page
+ * dimensions are required for accurate signature placement.
+ */
+export async function getPdfPageDimensions(
+  file: File,
+): Promise<Array<{ width: number; height: number }>> {
+  const pdfjs = await getPdfjsLib()
+  const bytes = await file.arrayBuffer()
+  const doc = await pdfjs.getDocument({ data: bytes }).promise
+  const dims: Array<{ width: number; height: number }> = []
+  for (let i = 1; i <= doc.numPages; i++) {
+    const page = await doc.getPage(i)
+    const { width, height } = page.getViewport({ scale: 1 })
+    dims.push({ width, height })
+    page.cleanup()
+  }
+  await doc.cleanup()
+  return dims
+}
+
+/**
  * Renders a single page of a PDF file onto an existing <canvas> element.
  *
  * @param file       The PDF File object to render from.


### PR DESCRIPTION
## Problem

Two UX issues found after #244 merged:

1. **Empty font boxes on open** — the font preview canvases were blank when the modal first appeared. The `useEffect` that renders the canvases depended only on `[signerName, inkColor]`. When the modal opens, the canvases are freshly mounted but neither dependency has changed, so the effect never re-fired and canvases stayed empty.

2. **Squished previews when typing** — `maxWidth: '100%'` constrained the canvas display width but left the height fixed at the canvas element's height attribute, compressing the content horizontally as the grid cell narrowed.

## Fix

- Added `isOpen` to the canvas re-render effect dependencies (with an early `if (!isOpen) return` guard) so font previews render immediately when the modal becomes visible
- Replaced `maxWidth: '100%'` with `width: '100%' + aspectRatio: '380/120'` so both dimensions scale proportionally

## Test plan
- [ ] Open Sign PDF → upload a file → modal opens → font grid immediately shows "Your Name" previews in all 9 fonts without any interaction
- [ ] Type a name → previews update and remain correctly proportioned (not squished)
- [ ] `pnpm test` → 340/340

🤖 Generated with [Claude Code](https://claude.com/claude-code)