### PR TITLE
feat(pdf-craft): fire GA4 purchase_complete on payment success

### DIFF
--- a/apps/pdf-craft/src/components/views/PaymentSuccess/PaymentSuccess.test.tsx
+++ b/apps/pdf-craft/src/components/views/PaymentSuccess/PaymentSuccess.test.tsx
@@ -1,8 +1,24 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, screen } from "@testing-library/react";
 import PaymentSuccess from "./PaymentSuccess";
 
-describe("PaymentSuccess", () => {
+vi.mock("../../../utils/lib/analytics", () => ({ logEvent: vi.fn() }));
+
+const PENDING_KEY = "pending_purchase";
+
+const mockPurchase = {
+  value: 9.99,
+  credits: 50,
+  productName: "50 Credits",
+  items: [{ item_id: "credits_50", item_name: "50 Credits", price: 9.99, quantity: 1 }],
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  sessionStorage.clear();
+});
+
+describe("PaymentSuccess — static content", () => {
   it("renders the payment successful heading", () => {
     render(<PaymentSuccess />);
     expect(screen.getByRole("heading", { name: /Payment successful/i })).toBeInTheDocument();
@@ -18,15 +34,61 @@ describe("PaymentSuccess", () => {
     expect(screen.getByRole("link", { name: /Buy more credits/i })).toHaveAttribute("href", "/buy-credits");
   });
 
-  it("lists the three supported tools", () => {
+  it("lists all six supported operations", () => {
     render(<PaymentSuccess />);
-    expect(screen.getByText("Merge PDFs")).toBeInTheDocument();
-    expect(screen.getByText("Image to PDF")).toBeInTheDocument();
-    expect(screen.getByText("Encrypt & decrypt PDFs")).toBeInTheDocument();
+    ["Merge PDFs", "Image to PDF", "Encrypt & decrypt PDFs", "Split PDFs", "Compress PDFs", "Sign PDFs"].forEach(tool =>
+      expect(screen.getByText(tool)).toBeInTheDocument(),
+    );
   });
 
   it("tells the user credits are ready to use", () => {
     render(<PaymentSuccess />);
     expect(screen.getByText(/credits have been added/i)).toBeInTheDocument();
+  });
+});
+
+describe("PaymentSuccess — GA4 purchase_complete event", () => {
+  it("fires purchase_complete with the stored payload on first render", async () => {
+    const { logEvent } = await import("../../../utils/lib/analytics");
+    sessionStorage.setItem(PENDING_KEY, JSON.stringify(mockPurchase));
+    render(<PaymentSuccess />);
+    expect(logEvent).toHaveBeenCalledWith("purchase_complete", {
+      currency: "USD",
+      value: 9.99,
+      items: mockPurchase.items,
+      credits_purchased: 50,
+      product_name: "50 Credits",
+    });
+  });
+
+  it("clears the sessionStorage key immediately after firing", async () => {
+    const { logEvent } = await import("../../../utils/lib/analytics");
+    sessionStorage.setItem(PENDING_KEY, JSON.stringify(mockPurchase));
+    render(<PaymentSuccess />);
+    expect(sessionStorage.getItem(PENDING_KEY)).toBeNull();
+    expect(logEvent).toHaveBeenCalledOnce();
+  });
+
+  it("does not fire when there is no pending purchase in sessionStorage", async () => {
+    const { logEvent } = await import("../../../utils/lib/analytics");
+    render(<PaymentSuccess />);
+    expect(logEvent).not.toHaveBeenCalledWith("purchase_complete", expect.anything());
+  });
+
+  it("does not fire again on a second render (simulates page refresh)", async () => {
+    const { logEvent } = await import("../../../utils/lib/analytics");
+    sessionStorage.setItem(PENDING_KEY, JSON.stringify(mockPurchase));
+    const { unmount } = render(<PaymentSuccess />);
+    unmount();
+    // sessionStorage was cleared by the first render
+    render(<PaymentSuccess />);
+    expect(logEvent).toHaveBeenCalledOnce(); // only from the first render
+  });
+
+  it("handles malformed sessionStorage payload gracefully without throwing", async () => {
+    const { logEvent } = await import("../../../utils/lib/analytics");
+    sessionStorage.setItem(PENDING_KEY, "not-valid-json{{{");
+    expect(() => render(<PaymentSuccess />)).not.toThrow();
+    expect(logEvent).not.toHaveBeenCalledWith("purchase_complete", expect.anything());
   });
 });

--- a/apps/pdf-craft/src/components/views/PaymentSuccess/PaymentSuccess.tsx
+++ b/apps/pdf-craft/src/components/views/PaymentSuccess/PaymentSuccess.tsx
@@ -1,4 +1,36 @@
+import { useEffect } from 'react'
 import { Container, Stack, Text, Button, Card, CardTitle, CardBody } from '@fhdamd/threads'
+import { logEvent } from '../../../utils/lib/analytics'
+
+const PENDING_KEY = 'pending_purchase'
+
+interface PendingPurchase {
+  value: number
+  credits: number
+  productName: string
+  items: { item_id: string; item_name: string; price: number; quantity: number }[]
+}
+
+function usePurchaseCompleteEvent() {
+  useEffect(() => {
+    const raw = sessionStorage.getItem(PENDING_KEY)
+    if (!raw) return
+    // Clear immediately — prevents the event firing again on a page refresh
+    sessionStorage.removeItem(PENDING_KEY)
+    try {
+      const purchase: PendingPurchase = JSON.parse(raw)
+      logEvent('purchase_complete', {
+        currency: 'USD',
+        value: purchase.value,
+        items: purchase.items,
+        credits_purchased: purchase.credits,
+        product_name: purchase.productName,
+      })
+    } catch {
+      // Malformed payload — swallow silently, nothing to report
+    }
+  }, [])
+}
 
 const iconStyle: React.CSSProperties = {
   width: 64,
@@ -13,6 +45,8 @@ const iconStyle: React.CSSProperties = {
 }
 
 export default function PaymentSuccess() {
+  usePurchaseCompleteEvent()
+
   return (
     <Container style={{ paddingBlock: 'var(--th-space-16)' }}>
       <Stack gap={8} align="center" style={{ maxWidth: 480, marginInline: 'auto', textAlign: 'center' }}>
@@ -36,7 +70,7 @@ export default function PaymentSuccess() {
           <CardTitle>Your credits work across</CardTitle>
           <CardBody>
             <Stack as="ul" gap={2} style={{ listStyle: 'none', padding: 0, margin: 0 }}>
-              {['Merge PDFs', 'Image to PDF', 'Encrypt & decrypt PDFs'].map(tool => (
+              {['Merge PDFs', 'Image to PDF', 'Encrypt & decrypt PDFs', 'Split PDFs', 'Compress PDFs', 'Sign PDFs'].map(tool => (
                 <li key={tool} style={{ display: 'flex', alignItems: 'center', gap: 'var(--th-space-3)' }}>
                   <span style={{ width: 6, height: 6, borderRadius: '50%', background: 'var(--th-color-accent)', flexShrink: 0, display: 'inline-block' }} aria-hidden="true" />
                   <Text as="span" size="base" color="1">{tool}</Text>


### PR DESCRIPTION
Closes #213
Closes #195

## Summary

`Pricing.tsx` already stashes `{ value, credits, productName, items }` in `sessionStorage` under `pending_purchase` before redirecting to Stripe Checkout. `PaymentSuccess.tsx` now reads that key on mount and fires `logEvent('purchase_complete', ...)` exactly once, then immediately clears the key.

**Double-fire protection**: the key is removed before the event fires — if the user refreshes the success page, `sessionStorage.getItem` returns null and nothing happens.

**No server-side changes**: the event is fired client-side via the existing Firebase Analytics wrapper, consistent with how `begin_checkout` is already tracked in `Pricing.tsx`.

Also updated the "Your credits work across" list to include Split PDFs, Compress PDFs, and Sign PDFs alongside the original three.

## Test plan

- [ ] Complete a real Stripe test-mode purchase → confirm `purchase_complete` fires once in browser network tab / GA4 DebugView with correct `value`, `items`, `credits_purchased`, `product_name`
- [ ] Refresh the success page → confirm `purchase_complete` does NOT fire again
- [ ] `pnpm test` → 345/345

🤖 Generated with [Claude Code](https://claude.com/claude-code)