### PR TITLE
feat(pdf-craft): Resources section — listing + single post pages

### DIFF
--- a/apps/pdf-craft/functions/src/cms/datocms.ts
+++ b/apps/pdf-craft/functions/src/cms/datocms.ts
@@ -26,6 +26,9 @@ export async function fetchCMSData(
     );
   }
 
-  const data = await response.json();
-  return data;
+  const payload = await response.json();
+  if (payload.errors?.length) {
+    throw new Error(`DatoCMS GraphQL error: ${JSON.stringify(payload.errors)}`);
+  }
+  return payload;
 }

--- a/apps/pdf-craft/functions/src/cms/queries.ts
+++ b/apps/pdf-craft/functions/src/cms/queries.ts
@@ -7,7 +7,7 @@ const SECTION_HEADER_FIELDS = `key eyebrow title intro`;
 const STEP_FIELDS = `id number title body`;
 
 const LEGAL_PAGE_FIELDS = `title slug eyebrow metaDescription _updatedAt content`;
-const RESOURCE_FIELDS = `id title slug excerpt content coverImage { url } relatedOperationIds _createdAt _updatedAt`;
+const RESOURCE_FIELDS = `id title slug excerpt content coverImage { url } relatedOperationsId _createdAt _updatedAt`;
 
 export const CMS_QUERIES = {
   legalPage: `
@@ -42,12 +42,12 @@ export const CMS_QUERIES = {
   `,
   resources: `
     query ResourcesQuery {
-      allResources(orderBy: _createdAt_DESC) { ${RESOURCE_FIELDS} }
+      allArticles(orderBy: _createdAt_DESC) { ${RESOURCE_FIELDS} }
     }
   `,
   resource: `
     query ResourceQuery($slug: String!) {
-      resource(filter: { slug: { eq: $slug } }) { ${RESOURCE_FIELDS} }
+      article(filter: { slug: { eq: $slug } }) { ${RESOURCE_FIELDS} }
     }
   `,
   homePage: `

--- a/apps/pdf-craft/functions/src/cms/queries.ts
+++ b/apps/pdf-craft/functions/src/cms/queries.ts
@@ -7,6 +7,7 @@ const SECTION_HEADER_FIELDS = `key eyebrow title intro`;
 const STEP_FIELDS = `id number title body`;
 
 const LEGAL_PAGE_FIELDS = `title slug eyebrow metaDescription _updatedAt content`;
+const RESOURCE_FIELDS = `id title slug excerpt content coverImage { url } relatedOperationIds _createdAt _updatedAt`;
 
 export const CMS_QUERIES = {
   legalPage: `
@@ -37,6 +38,16 @@ export const CMS_QUERIES = {
   sectionHeaders: `
     query SectionHeadersQuery($pattern: String!) {
       allSectionHeaders(filter: { key: { matches: { pattern: $pattern } } }) { ${SECTION_HEADER_FIELDS} }
+    }
+  `,
+  resources: `
+    query ResourcesQuery {
+      allResources(orderBy: _createdAt_DESC) { ${RESOURCE_FIELDS} }
+    }
+  `,
+  resource: `
+    query ResourceQuery($slug: String!) {
+      resource(filter: { slug: { eq: $slug } }) { ${RESOURCE_FIELDS} }
     }
   `,
   homePage: `

--- a/apps/pdf-craft/src/components/slices/ResourceList/ResourceList.test.tsx
+++ b/apps/pdf-craft/src/components/slices/ResourceList/ResourceList.test.tsx
@@ -1,0 +1,50 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import ResourceList from "./ResourceList";
+import type { Resource } from "../../../utils";
+
+const makeResource = (overrides: Partial<Resource> = {}): Resource => ({
+  id: "res-1",
+  title: "How to split a PDF",
+  slug: "how-to-split-a-pdf",
+  excerpt: "Learn how to divide a PDF into separate files using Riqa.",
+  content: "# Split PDF\n\nSome content here.",
+  coverImage: null,
+  relatedOperationIds: ["split"],
+  _createdAt: "2026-07-01T10:00:00Z",
+  _updatedAt: "2026-07-01T10:00:00Z",
+  ...overrides,
+});
+
+describe("ResourceList", () => {
+  it("renders a card for each resource", () => {
+    const resources = [
+      makeResource({ id: "1", title: "Split PDF guide", slug: "split-pdf" }),
+      makeResource({ id: "2", title: "Compress PDF guide", slug: "compress-pdf" }),
+    ];
+    render(<ResourceList resources={resources} />);
+    expect(screen.getByText("Split PDF guide")).toBeInTheDocument();
+    expect(screen.getByText("Compress PDF guide")).toBeInTheDocument();
+  });
+
+  it("renders the excerpt on each card", () => {
+    render(<ResourceList resources={[makeResource()]} />);
+    expect(screen.getByText(/divide a PDF into separate files/i)).toBeInTheDocument();
+  });
+
+  it("renders a 'Read article' link pointing to /resources/[slug]", () => {
+    render(<ResourceList resources={[makeResource()]} />);
+    const link = screen.getByRole("link", { name: /Read article/i });
+    expect(link).toHaveAttribute("href", "/resources/how-to-split-a-pdf");
+  });
+
+  it("shows a formatted publication date", () => {
+    render(<ResourceList resources={[makeResource()]} />);
+    expect(screen.getByText(/2026/i)).toBeInTheDocument();
+  });
+
+  it("renders an empty state message when there are no resources", () => {
+    render(<ResourceList resources={[]} />);
+    expect(screen.getByText(/No articles yet/i)).toBeInTheDocument();
+  });
+});

--- a/apps/pdf-craft/src/components/slices/ResourceList/ResourceList.test.tsx
+++ b/apps/pdf-craft/src/components/slices/ResourceList/ResourceList.test.tsx
@@ -10,7 +10,7 @@ const makeResource = (overrides: Partial<Resource> = {}): Resource => ({
   excerpt: "Learn how to divide a PDF into separate files using Riqa.",
   content: "# Split PDF\n\nSome content here.",
   coverImage: null,
-  relatedOperationIds: ["split"],
+  relatedOperationsId: ["split"],
   _createdAt: "2026-07-01T10:00:00Z",
   _updatedAt: "2026-07-01T10:00:00Z",
   ...overrides,

--- a/apps/pdf-craft/src/components/slices/ResourceList/ResourceList.tsx
+++ b/apps/pdf-craft/src/components/slices/ResourceList/ResourceList.tsx
@@ -1,0 +1,49 @@
+import { AutoGrid, Card, Text, Button } from '@fhdamd/threads'
+import type { Resource } from '../../../utils'
+
+interface ResourceListProps {
+  readonly resources: Resource[]
+}
+
+function ResourceCard({ resource }: { readonly resource: Resource }) {
+  const date = new Date(resource._createdAt).toLocaleDateString('en-GB', {
+    day: 'numeric', month: 'long', year: 'numeric',
+  })
+
+  return (
+    <Card variant="elevated" style={{ display: 'flex', flexDirection: 'column', height: '100%' }}>
+      <div style={{ display: 'flex', flexDirection: 'column', gap: 'var(--th-space-3)', padding: 'var(--th-space-5)', flex: 1 }}>
+        <Text as="p" size="xs" color="3">{date}</Text>
+        <Text as="h2" size="lg" color="1" weight={650} style={{ lineHeight: 1.3 }}>
+          {resource.title}
+        </Text>
+        <Text as="p" size="sm" color="2" style={{ flex: 1 }}>
+          {resource.excerpt}
+        </Text>
+        <div style={{ paddingTop: 'var(--th-space-2)' }}>
+          <Button href={`/resources/${resource.slug}`} variant="ghost" size="sm">
+            Read article →
+          </Button>
+        </div>
+      </div>
+    </Card>
+  )
+}
+
+export default function ResourceList({ resources }: ResourceListProps) {
+  if (!resources.length) {
+    return (
+      <Text as="p" size="base" color="2" style={{ fontStyle: 'italic' }}>
+        No articles yet — check back soon.
+      </Text>
+    )
+  }
+
+  return (
+    <AutoGrid minColWidth="280px" gap={5}>
+      {resources.map(resource => (
+        <ResourceCard key={resource.id} resource={resource} />
+      ))}
+    </AutoGrid>
+  )
+}

--- a/apps/pdf-craft/src/components/slices/ResourceList/index.ts
+++ b/apps/pdf-craft/src/components/slices/ResourceList/index.ts
@@ -1,0 +1,1 @@
+export { default as ResourceList } from './ResourceList';

--- a/apps/pdf-craft/src/components/slices/index.ts
+++ b/apps/pdf-craft/src/components/slices/index.ts
@@ -2,7 +2,7 @@ export { default as MultiPdfUploader } from "./MultiPdfUploader";
 export { default as Operations } from "./Operations";
 export { default as Pricing } from "./Pricing";
 export { default as UserFileList } from "./UserFileList";
-export { default as ResourceList } from "./ResourceList";
+export { ResourceList } from "./ResourceList";
 export * from "./MultiPdfUploader";
 export * from "./Operations";
 export * from "./UserFileList";

--- a/apps/pdf-craft/src/components/slices/index.ts
+++ b/apps/pdf-craft/src/components/slices/index.ts
@@ -2,6 +2,7 @@ export { default as MultiPdfUploader } from "./MultiPdfUploader";
 export { default as Operations } from "./Operations";
 export { default as Pricing } from "./Pricing";
 export { default as UserFileList } from "./UserFileList";
+export { default as ResourceList } from "./ResourceList";
 export * from "./MultiPdfUploader";
 export * from "./Operations";
 export * from "./UserFileList";

--- a/apps/pdf-craft/src/components/ui/Header/Header.tsx
+++ b/apps/pdf-craft/src/components/ui/Header/Header.tsx
@@ -54,6 +54,7 @@ export default function Header() {
     { href: '/#tools',        label: 'Tools' },
     { href: '/#how-it-works', label: 'How it works' },
     { href: '/#pricing',      label: 'Pricing' },
+    { href: '/resources',     label: 'Resources' },
     { href: '/#faq',          label: 'FAQ' },
   ]
 

--- a/apps/pdf-craft/src/pages/resources/[slug].astro
+++ b/apps/pdf-craft/src/pages/resources/[slug].astro
@@ -8,8 +8,11 @@ import '../../styles/prose.css';
 
 type ResourcesResponse = { data: { allArticles: Resource[] } }
 
-// getStaticPaths is required so @astrojs/sitemap can discover these routes at
-// build time and include them in the generated sitemap-0.xml.
+// prerender = true opts this page into static generation so that:
+// 1. getStaticPaths() is called at build/dev time (required for SSR output mode)
+// 2. @astrojs/sitemap discovers all article routes at build time
+export const prerender = true
+
 export async function getStaticPaths() {
   const { data } = await fetchCms<ResourcesResponse>('resources')
   return data.allArticles.map(r => ({

--- a/apps/pdf-craft/src/pages/resources/[slug].astro
+++ b/apps/pdf-craft/src/pages/resources/[slug].astro
@@ -6,14 +6,13 @@ import { Container, Section, Stack, Text, Button } from "@fhdamd/threads";
 import type { Resource } from "../../utils";
 import '../../styles/prose.css';
 
-type ResourcesResponse = { data: { allResources: Resource[] } }
-type ResourceResponse = { data: { resource: Resource | null } }
+type ResourcesResponse = { data: { allArticles: Resource[] } }
 
 // getStaticPaths is required so @astrojs/sitemap can discover these routes at
 // build time and include them in the generated sitemap-0.xml.
 export async function getStaticPaths() {
   const { data } = await fetchCms<ResourcesResponse>('resources')
-  return data.allResources.map(r => ({
+  return data.allArticles.map(r => ({
     params: { slug: r.slug },
     props: { resource: r },
   }))

--- a/apps/pdf-craft/src/pages/resources/[slug].astro
+++ b/apps/pdf-craft/src/pages/resources/[slug].astro
@@ -1,0 +1,82 @@
+---
+import { marked } from 'marked';
+import Layout from "../../layouts/Layout.astro";
+import { fetchCms } from "../../utils/lib/cms";
+import { Container, Section, Stack, Text, Button } from "@fhdamd/threads";
+import type { Resource } from "../../utils";
+import '../../styles/prose.css';
+
+type ResourcesResponse = { data: { allResources: Resource[] } }
+type ResourceResponse = { data: { resource: Resource | null } }
+
+// getStaticPaths is required so @astrojs/sitemap can discover these routes at
+// build time and include them in the generated sitemap-0.xml.
+export async function getStaticPaths() {
+  const { data } = await fetchCms<ResourcesResponse>('resources')
+  return data.allResources.map(r => ({
+    params: { slug: r.slug },
+    props: { resource: r },
+  }))
+}
+
+const { resource } = Astro.props as { resource: Resource }
+
+const publishDate = new Date(resource._createdAt).toLocaleDateString('en-GB', {
+  day: 'numeric', month: 'long', year: 'numeric',
+})
+
+const contentHtml = resource.content ? (marked(resource.content) as string) : ''
+const ogImage = resource.coverImage?.url ?? undefined
+---
+
+<Layout
+  title={`${resource.title} — Riqa`}
+  description={resource.excerpt}
+  ogImage={ogImage}
+>
+  <Fragment slot="head">
+    <script
+      is:inline
+      type="application/ld+json"
+      set:html={JSON.stringify({
+        "@context": "https://schema.org",
+        "@type": "Article",
+        headline: resource.title,
+        description: resource.excerpt,
+        datePublished: resource._createdAt,
+        dateModified: resource._updatedAt,
+        publisher: {
+          "@type": "Organization",
+          name: "Riqa",
+          url: "https://riqa.app",
+        },
+        ...(ogImage ? { image: ogImage } : {}),
+      })}
+    />
+  </Fragment>
+
+  <Container>
+    <Section size="md">
+      <Stack gap={8} style={{ maxWidth: '720px', marginInline: 'auto' }}>
+
+        {/* Back link */}
+        <Button href="/resources" variant="ghost" size="sm">
+          ← All articles
+        </Button>
+
+        {/* Header */}
+        <Stack gap={3}>
+          <Text as="p" size="xs" color="3">{publishDate}</Text>
+          <Text as="h1" size="3xl" color="1" weight={650} style={{ lineHeight: 1.2 }}>
+            {resource.title}
+          </Text>
+          <Text as="p" size="lg" color="2">{resource.excerpt}</Text>
+        </Stack>
+
+        {/* Body */}
+        <div class="prose" set:html={contentHtml} />
+
+      </Stack>
+    </Section>
+  </Container>
+</Layout>

--- a/apps/pdf-craft/src/pages/resources/index.astro
+++ b/apps/pdf-craft/src/pages/resources/index.astro
@@ -5,10 +5,10 @@ import { fetchCms } from "../../utils/lib/cms";
 import { Container, Section, Stack, Text } from "@fhdamd/threads";
 import type { Resource } from "../../utils";
 
-type ResourcesResponse = { data: { allResources: Resource[] } }
+type ResourcesResponse = { data: { allArticles: Resource[] } }
 
 const { data } = await fetchCms<ResourcesResponse>('resources')
-const resources = data.allResources
+const resources = data.allArticles
 ---
 
 <Layout

--- a/apps/pdf-craft/src/pages/resources/index.astro
+++ b/apps/pdf-craft/src/pages/resources/index.astro
@@ -1,0 +1,32 @@
+---
+import Layout from "../../layouts/Layout.astro";
+import { ResourceList } from "../../components";
+import { fetchCms } from "../../utils/lib/cms";
+import { Container, Section, Stack, Text } from "@fhdamd/threads";
+import type { Resource } from "../../utils";
+
+type ResourcesResponse = { data: { allResources: Resource[] } }
+
+const { data } = await fetchCms<ResourcesResponse>('resources')
+const resources = data.allResources
+---
+
+<Layout
+  title="Resources — Riqa"
+  description="How-to guides, tips, and tutorials for working with PDFs using Riqa."
+>
+  <Container>
+    <Section size="md">
+      <Stack gap={8}>
+        <Stack gap={2}>
+          <Text as="h1" size="3xl" color="1" weight={650} width={90}>Resources</Text>
+          <Text as="p" size="base" color="2">
+            Practical guides for getting the most out of Riqa's PDF tools.
+          </Text>
+        </Stack>
+
+        <ResourceList resources={resources} client:load />
+      </Stack>
+    </Section>
+  </Container>
+</Layout>

--- a/apps/pdf-craft/src/utils/lib/cms.ts
+++ b/apps/pdf-craft/src/utils/lib/cms.ts
@@ -1,4 +1,4 @@
-type CmsQueryKey = "faqs" | "pricing" | "operations" | "testimonials" | "sectionHeaders" | "homePage" | "legalPage";
+type CmsQueryKey = "faqs" | "pricing" | "operations" | "testimonials" | "sectionHeaders" | "homePage" | "legalPage" | "resources" | "resource";
 
 const _cache = new Map<string, { data: unknown; expiresAt: number }>();
 const CACHE_TTL = 5 * 60 * 1000;

--- a/apps/pdf-craft/src/utils/types.ts
+++ b/apps/pdf-craft/src/utils/types.ts
@@ -54,6 +54,18 @@ export type HeroData = {
   secondaryCtaHref: string;
 };
 
+export type Resource = {
+  id: string;
+  title: string;
+  slug: string;
+  excerpt: string;
+  content: string;
+  coverImage?: { url: string } | null;
+  relatedOperationIds: string[];
+  _createdAt: string;
+  _updatedAt: string;
+};
+
 export type Step = {
   id: string;
   number: string;

--- a/apps/pdf-craft/src/utils/types.ts
+++ b/apps/pdf-craft/src/utils/types.ts
@@ -61,7 +61,7 @@ export type Resource = {
   excerpt: string;
   content: string;
   coverImage?: { url: string } | null;
-  relatedOperationIds: string[];
+  relatedOperationsId: string[] | null;
   _createdAt: string;
   _updatedAt: string;
 };


### PR DESCRIPTION
Closes #223

## Summary

DatoCMS-backed how-to blog for Riqa, following the same `fetchCms` / `CmsQueryKey` pattern used by every other content type.

### Data layer
- **`Resource` type** — `{ id, title, slug, excerpt, content, coverImage?, relatedOperationIds: string[], _createdAt, _updatedAt }`
- **CMS queries** — `resources` (full list, newest first) and `resource` (single by slug) — mirrors the `legalPage` pattern

### Pages
- **`/resources`** — listing page with `ResourceList` card grid
- **`/resources/[slug]`** — single post; content rendered via `marked` into existing `prose.css`; `getStaticPaths()` used so `@astrojs/sitemap` discovers routes at build time; `Article` JSON-LD included

### Components
- **`ResourceList`** — `AutoGrid` of `ResourceCard`s with title, excerpt, date, "Read article →" link; empty state when no posts; 5 tests

### Navigation
- "Resources" link added to the header between Pricing and FAQ

## Test plan
- [ ] Create a Resource record in DatoCMS (`dev` environment) with title, slug, excerpt, content, `relatedOperationIds: ["split"]`
- [ ] `/resources` shows the card with title, excerpt, date and link
- [ ] `/resources/[slug]` renders the full article with Markdown content
- [ ] View source → confirm `Article` JSON-LD present
- [ ] Production build → confirm `sitemap-0.xml` includes `/resources/[slug]`
- [ ] `pnpm test` → 350/350

🤖 Generated with [Claude Code](https://claude.com/claude-code)