### PR TITLE
test(pdf-craft): Playwright e2e tests for new operations and Resources

### DIFF
--- a/apps/pdf-craft/e2e/auth.spec.ts
+++ b/apps/pdf-craft/e2e/auth.spec.ts
@@ -27,3 +27,24 @@ test('unauthenticated user can access /mergepdf without being redirected', async
   await expect(page.getByRole('heading', { name: /merge pdfs/i })).toBeVisible();
   await expect(page.getByText(/drag and drop or click to browse/i)).toBeVisible();
 });
+
+test('unauthenticated user can access /splitpdf without being redirected', async ({ page }) => {
+  await page.goto('/splitpdf');
+  await expect(page).toHaveURL('/splitpdf');
+  await expect(page.getByRole('heading', { name: /split pdf/i })).toBeVisible();
+  await expect(page.getByText(/drag and drop or click to browse/i)).toBeVisible();
+});
+
+test('unauthenticated user can access /compresspdf without being redirected', async ({ page }) => {
+  await page.goto('/compresspdf');
+  await expect(page).toHaveURL('/compresspdf');
+  await expect(page.getByRole('heading', { name: /compress pdf/i })).toBeVisible();
+  await expect(page.getByText(/drag and drop or click to browse/i)).toBeVisible();
+});
+
+test('unauthenticated user can access /signpdf without being redirected', async ({ page }) => {
+  await page.goto('/signpdf');
+  await expect(page).toHaveURL('/signpdf');
+  await expect(page.getByRole('heading', { name: /sign pdf/i })).toBeVisible();
+  await expect(page.getByText(/drag and drop or click to browse/i)).toBeVisible();
+});

--- a/apps/pdf-craft/e2e/operation.spec.ts
+++ b/apps/pdf-craft/e2e/operation.spec.ts
@@ -17,3 +17,41 @@ test('encrypt a PDF end to end through pdf-processor', async ({ page }) => {
   await expect(page.getByText(/your pdf is protected/i)).toBeVisible({ timeout: 60_000 });
   await expect(page.getByRole('link', { name: /download protected pdf/i })).toBeVisible();
 });
+
+test('compress a PDF end to end through pdf-processor', async ({ page }) => {
+  await page.goto('/compresspdf');
+  await expect(page).toHaveURL('/compresspdf');
+
+  await page.getByLabel('Upload PDF').setInputFiles(SAMPLE_PDF);
+  await page.getByRole('button', { name: /compress pdf/i }).click();
+
+  await expect(page.getByText(/your pdf has been compressed/i)).toBeVisible({ timeout: 60_000 });
+  await expect(page.getByRole('link', { name: /download compressed pdf/i })).toBeVisible();
+});
+
+test('split a PDF end to end using extract mode', async ({ page }) => {
+  await page.goto('/splitpdf');
+  await expect(page).toHaveURL('/splitpdf');
+
+  await page.getByLabel('Upload PDF').setInputFiles(SAMPLE_PDF);
+
+  // Wait for thumbnails to render via pdfjs, then switch to Extract mode
+  await page.getByRole('button', { name: /extract/i }).click();
+
+  // Select all pages and extract
+  await page.getByRole('button', { name: /select all/i }).click();
+  await page.getByRole('button', { name: /extract/i, exact: true }).last().click();
+
+  await expect(page.getByText(/your pdf has been processed/i)).toBeVisible({ timeout: 60_000 });
+  await expect(page.getByRole('link', { name: /download pdf/i })).toBeVisible();
+});
+
+test('sign pdf page loads and accepts a file upload', async ({ page }) => {
+  await page.goto('/signpdf');
+  await expect(page).toHaveURL('/signpdf');
+
+  await page.getByLabel('Upload PDF').setInputFiles(SAMPLE_PDF);
+
+  // After upload the signature placement canvas should become visible
+  await expect(page.locator('canvas').first()).toBeVisible({ timeout: 30_000 });
+});

--- a/apps/pdf-craft/e2e/resources.spec.ts
+++ b/apps/pdf-craft/e2e/resources.spec.ts
@@ -1,0 +1,23 @@
+import { test, expect } from '@playwright/test';
+
+test('resources listing page loads and shows at least one article', async ({ page }) => {
+  await page.goto('/resources');
+  await expect(page).toHaveURL('/resources');
+  await expect(page.getByRole('heading', { name: /resources/i })).toBeVisible();
+
+  // At least one article card with a "Read article" link should be present
+  const articleLinks = page.getByRole('link', { name: /read article/i });
+  await expect(articleLinks.first()).toBeVisible();
+});
+
+test('clicking an article navigates to the single post and renders the title', async ({ page }) => {
+  await page.goto('/resources');
+
+  // Follow the first article link
+  const firstLink = page.getByRole('link', { name: /read article/i }).first();
+  await firstLink.click();
+
+  // Single post should have an h1 and a back link
+  await expect(page.getByRole('heading', { level: 1 })).toBeVisible();
+  await expect(page.getByRole('link', { name: /all articles/i })).toBeVisible();
+});


### PR DESCRIPTION
Closes #251

## Summary

- **`auth.spec.ts`** — public access assertions for `/splitpdf`, `/compresspdf`, `/signpdf` (matches the existing pattern for `/encryptpdf` and `/mergepdf`)
- **`operation.spec.ts`** — three new tests:
  - Compress PDF end-to-end
  - Split PDF end-to-end (uses Extract mode — more reliable than placing split points via UI)
  - Sign PDF: upload → canvas rendered (full placement skipped; canvas drag interaction is too brittle)
- **`resources.spec.ts`** (new) — listing page shows articles; clicking first article reaches single post

## Test plan
- [ ] Run against staging: `BASE_URL=https://stg.riqa.app pnpm e2e`
- [ ] All 3 auth tests for new operation pages pass
- [ ] Compress PDF and Split PDF operations complete and show download link
- [ ] Sign PDF canvas renders after upload
- [ ] Resources listing and single post navigation pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)