### PR TITLE
infra: add CLAIM_SECRET and e2eContactBypassToken to Terraform module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,10 @@ New Playwright tests covering:
 - Stripe `success_url` / `cancel_url` were pointing to the old `pdf-craft.app` domain. Fixed by updating the `APP_BASE_URL` secret in Secret Manager to `riqa.app` for each environment.
 - DatoCMS GraphQL errors (HTTP 200 with `errors` body, no `data` key) were passing through the CMS proxy silently and surfacing as cryptic `Cannot read properties of undefined` errors in Astro pages. Fixed by detecting and throwing on `payload.errors` in `fetchCMSData`.
 
+### Infrastructure
+
+- `CLAIM_SECRET` and `e2eContactBypassToken` added to `terraform/modules/firebase-env/main.tf` so all environments get these secret shells automatically on `terraform apply`. Both were previously missing from the module (created manually), causing the v1.1.0-rc.0 staging deploy to fail with a "secret not found" error.
+
 ---
 
 ## [1.0.5] — 2026-06-30

--- a/docs/sad-pdfcraft.md
+++ b/docs/sad-pdfcraft.md
@@ -631,7 +631,7 @@ All three environments are provisioned by a single reusable Terraform module (`t
 
 - Required GCP APIs (Firestore, Secret Manager, Cloud Functions, Cloud Run, Artifact Registry, Cloud Build, Pub/Sub, Eventarc, Cloud Billing, App Hosting, Identity Toolkit)
 - The Firestore database and the default Storage bucket (`lifecycle { prevent_destroy = true }` on both, since all three environments now hold real or test data)
-- All 23 application secrets as empty shells — the 16 referenced by `apphosting.yaml` plus 7 bound directly by Cloud Functions via `defineSecret()` that aren't visible from `apphosting.yaml` alone (`STRIPE_SECRET_KEY`, `STRIPE_WEBHOOK_SECRET`, `APP_BASE_URL`, `RESEND_API_KEY`, `RESEND_AUDIENCE_ID`, `DATOCMS_API_TOKEN`, `DATOCMS_ENV`). Values are populated out-of-band via `gcloud secrets versions add`, never committed.
+- All 25 application secrets as empty shells — the 18 referenced by `apphosting.yaml` (including `CLAIM_SECRET` for anonymous claim token signing and `e2eContactBypassToken` for the E2E reCAPTCHA bypass) plus 7 bound directly by Cloud Functions via `defineSecret()` that aren't visible from `apphosting.yaml` alone (`STRIPE_SECRET_KEY`, `STRIPE_WEBHOOK_SECRET`, `APP_BASE_URL`, `RESEND_API_KEY`, `RESEND_AUDIENCE_ID`, `DATOCMS_API_TOKEN`, `DATOCMS_ENV`). Values are populated out-of-band via `gcloud secrets versions add`, never committed.
 - An Artifact Registry Docker repository for `pdf-processor` images
 - A per-environment GitHub Actions deploy identity via **Workload Identity Federation** — no long-lived service account keys are stored anywhere, in GitHub or otherwise
 
@@ -720,7 +720,7 @@ This is a deliberately different model from `@fhdamd/threads`, which **is** rele
 
 ### How to update environment variables and secrets in Google Secret Manager
 
-All 23 secrets (16 referenced by `apphosting.yaml`, 7 bound directly by Cloud Functions via `defineSecret()`) are created as empty shells by the Terraform module ([§11.2](#112-infrastructure-as-code)). Populating or rotating a value is a direct `gcloud` call against the target project's Secret Manager — there is no separate "promote a secret" step, since each environment's Secret Manager is independent:
+All 25 secrets (18 referenced by `apphosting.yaml`, 7 bound directly by Cloud Functions via `defineSecret()`) are created as empty shells by the Terraform module ([§11.2](#112-infrastructure-as-code)). Populating or rotating a value is a direct `gcloud` call against the target project's Secret Manager — there is no separate "promote a secret" step, since each environment's Secret Manager is independent:
 
 ```sh
 printf '%s' "the-actual-value" | gcloud secrets versions add <secretName> \

--- a/terraform/modules/firebase-env/main.tf
+++ b/terraform/modules/firebase-env/main.tf
@@ -98,6 +98,9 @@ locals {
     "pdfProcessorUrl",
     "appEnv",
     "resendApiKey",
+    # apphosting.yaml secrets added after initial provisioning
+    "e2eContactBypassToken",  # E2E test reCAPTCHA bypass — was created manually, now tracked here
+    "CLAIM_SECRET",           # HMAC key for anonymous operation claim tokens (v1.1.0)
     # Bound directly by Cloud Functions via defineSecret(), not apphosting.yaml
     "STRIPE_SECRET_KEY",
     "STRIPE_WEBHOOK_SECRET",


### PR DESCRIPTION
Closes #256

## Problem

`riqa-v1.1.0-rc.0` staging deploy failed because `CLAIM_SECRET` didn't exist in `pdf-craft-stg`'s Secret Manager. It was referenced in `apphosting.yaml` but never added to the Terraform module that provisions secret shells.

`e2eContactBypassToken` had the same gap — it existed in Secret Manager (created manually) but wasn't tracked in Terraform.

## Changes

- **`terraform/modules/firebase-env/main.tf`** — added `CLAIM_SECRET` and `e2eContactBypassToken` to `local.secret_names`
- **`docs/sad-pdfcraft.md`** — secret count updated 23 → 25 in §11.2 and Appendix
- **`CHANGELOG.md`** — infra fix noted under v1.1.0

## Post-merge steps (before re-cutting the RC)

```bash
# Run terraform apply for staging and prod to create the CLAIM_SECRET shell
cd terraform/environments/staging && terraform apply
cd terraform/environments/prod && terraform apply

# Populate CLAIM_SECRET in each environment
node -e "console.log(require('crypto').randomBytes(32).toString('hex'))"
# → use the output as the value below (different value per environment)

printf '%s' "<generated-value>" | gcloud secrets versions add CLAIM_SECRET \
  --data-file=- --project=pdf-craft-stg

printf '%s' "<different-generated-value>" | gcloud secrets versions add CLAIM_SECRET \
  --data-file=- --project=pdf-craft-prd

# Grant App Hosting access
firebase apphosting:secrets:grantaccess CLAIM_SECRET --project pdf-craft-stg --backend pdf-craft-web
firebase apphosting:secrets:grantaccess CLAIM_SECRET --project pdf-craft-prd --backend pdf-craft-web

# Re-cut the RC
git push origin :riqa-v1.1.0-rc.0
git push origin riqa-v1.1.0-rc.0
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)