### PR TITLE
fix(pdf-craft): resources slug pages return 404 after CMS publish (#258)

### DIFF
--- a/apps/pdf-craft/astro.config.mjs
+++ b/apps/pdf-craft/astro.config.mjs
@@ -19,6 +19,25 @@ const PRIVATE_PATHS = new Set([
   '/reset-password/',
 ]);
 
+async function fetchArticleSlugs() {
+  const functionsUrl = process.env.PUBLIC_BASE_FUNCTIONS_URL;
+  if (!functionsUrl) return [];
+  try {
+    const res = await fetch(`${functionsUrl}/cms`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ queryKey: 'resources' }),
+    });
+    if (!res.ok) return [];
+    const { data } = await res.json();
+    return (data?.allArticles ?? []).map((a) => `https://riqa.app/resources/${a.slug}`);
+  } catch {
+    return [];
+  }
+}
+
+const articlePages = await fetchArticleSlugs();
+
 // https://astro.build/config
 export default defineConfig({
   site: 'https://riqa.app',
@@ -39,6 +58,7 @@ export default defineConfig({
         const path = new URL(page).pathname;
         return !PRIVATE_PATHS.has(path);
       },
+      customPages: articlePages,
     }),
     sentry({
       org: 'fhdamd',

--- a/apps/pdf-craft/src/pages/resources/[slug].astro
+++ b/apps/pdf-craft/src/pages/resources/[slug].astro
@@ -6,22 +6,13 @@ import { Container, Section, Stack, Text, Button } from "@fhdamd/threads";
 import type { Resource } from "../../utils";
 import '../../styles/prose.css';
 
-type ResourcesResponse = { data: { allArticles: Resource[] } }
+type ResourceResponse = { data: { article: Resource | null } }
 
-// prerender = true opts this page into static generation so that:
-// 1. getStaticPaths() is called at build/dev time (required for SSR output mode)
-// 2. @astrojs/sitemap discovers all article routes at build time
-export const prerender = true
+const { slug } = Astro.params
+const { data } = await fetchCms<ResourceResponse>('resource', { slug })
+const resource = data.article
 
-export async function getStaticPaths() {
-  const { data } = await fetchCms<ResourcesResponse>('resources')
-  return data.allArticles.map(r => ({
-    params: { slug: r.slug },
-    props: { resource: r },
-  }))
-}
-
-const { resource } = Astro.props as { resource: Resource }
+if (!resource) return Astro.redirect('/resources', 307)
 
 const publishDate = new Date(resource._createdAt).toLocaleDateString('en-GB', {
   day: 'numeric', month: 'long', year: 'numeric',


### PR DESCRIPTION
## Summary

- Convert `resources/[slug].astro` from `prerender = true` + `getStaticPaths()` to full SSR — article is fetched by slug at request time; unknown slugs redirect to `/resources` with 307
- Add `fetchArticleSlugs()` in `astro.config.mjs` that calls the CMS proxy at build time (`PUBLIC_BASE_FUNCTIONS_URL` is available in the App Hosting build env) and passes slugs as `customPages` to `@astrojs/sitemap` so articles are discoverable without re-deploying

Closes #258

## Why not a webhook?
Firebase App Hosting has no native rebuild webhook — triggering a new deploy on CMS publish would need a Cloud Function intermediary (new infra + maintenance overhead). SSR costs one extra CMS fetch per page view, which is negligible and already cached by DatoCMS edge.

## Sitemap impact
Existing articles are included at build time via `fetchArticleSlugs()`. Articles published after the last deploy are served live immediately (SSR) but won't appear in the sitemap until the next release — this is acceptable for a low-frequency content cadence.

## Test plan
- [ ] Deploy `riqa-v1.1.1-rc.1` to staging
- [ ] Publish a new article in DatoCMS; navigate to `/resources/[new-slug]` — should return 200
- [ ] Existing articles still load correctly
- [ ] Pass Playwright e2e gate
- [ ] Cut `riqa-v1.1.1` for production

🤖 Generated with [Claude Code](https://claude.com/claude-code)