### PR TITLE
fix(e2e): exact button selectors to avoid FAQ accordion collisions

### DIFF
--- a/apps/pdf-craft/e2e/operation.spec.ts
+++ b/apps/pdf-craft/e2e/operation.spec.ts
@@ -23,7 +23,7 @@ test('compress a PDF end to end through pdf-processor', async ({ page }) => {
   await expect(page).toHaveURL('/compresspdf');
 
   await page.getByLabel('Upload PDF').setInputFiles(SAMPLE_PDF);
-  await page.getByRole('button', { name: /compress pdf/i }).click();
+  await page.getByRole('button', { name: 'Compress PDF', exact: true }).click();
 
   // Authenticated users see "Compression complete" callout + download link.
   // Anonymous users see "Your PDF has been compressed" — different text, so check the link.
@@ -39,11 +39,11 @@ test('split a PDF end to end using extract mode', async ({ page }) => {
   // Wait for pdfjs to parse the PDF and render at least the first page before switching mode.
   // Without this, selectAll fires against an empty page list and Extract stays disabled.
   await expect(page.getByLabel('Page 1')).toBeVisible({ timeout: 30_000 });
-  await page.getByRole('button', { name: /extract/i }).click();
+  await page.getByRole('button', { name: 'Extract Pages', exact: true }).click();
 
   // Select all pages and extract
   await page.getByRole('button', { name: /select all/i }).click();
-  await page.getByRole('button', { name: /extract/i, exact: true }).last().click();
+  await page.getByRole('button', { name: 'Extract', exact: true }).click();
 
   await expect(page.getByText(/your pdf has been processed/i)).toBeVisible({ timeout: 60_000 });
   await expect(page.getByRole('link', { name: /download pdf/i })).toBeVisible();


### PR DESCRIPTION
## Summary

- FAQs added to `/compresspdf` and `/splitpdf` in DatoCMS introduced accordion trigger buttons whose labels contain "Compress PDF" and "Extract", causing strict-mode violations in the Playwright tests
- Switch all three affected selectors from broad regexes to exact string matches that uniquely identify the operation buttons

| Location | Old | New |
|---|---|---|
| compress test (line 26) | `/compress pdf/i` | `'Compress PDF', exact: true` |
| split mode tab (line 42) | `/extract/i` | `'Extract Pages', exact: true` |
| split submit (line 46) | `/extract/i, exact: true` + `.last()` | `'Extract', exact: true` |

No behaviour change — same buttons are targeted, just unambiguously.

## Test plan
- [ ] Re-run `riqa-v1.1.1-rc.1` e2e gate passes after this merges and a new RC is cut

🤖 Generated with [Claude Code](https://claude.com/claude-code)