### PR TITLE
infra(fhdamd-web): point at fahad-web Firebase project, add Hosting config

### DIFF
--- a/apps/fhdamd-web/.firebaserc
+++ b/apps/fhdamd-web/.firebaserc
@@ -1,5 +1,5 @@
 {
   "projects": {
-    "default": "fhdamd-web-dev"
+    "default": "fahad-web"
   }
 }

--- a/apps/fhdamd-web/firebase.json
+++ b/apps/fhdamd-web/firebase.json
@@ -1,13 +1,26 @@
 {
-  "apphosting": {
-    "backendId": "fhdamdssr",
-    "rootDir": "/",
-    "ignore": [
-      "node_modules",
-      ".git",
-      "firebase-debug.log",
-      "firebase-debug.*.log",
-      "functions"
+  "hosting": {
+    "public": "dist",
+    "ignore": ["firebase.json", "**/.*", "**/node_modules/**"],
+    "headers": [
+      {
+        "source": "**/*.@(js|css|woff2)",
+        "headers": [
+          {
+            "key": "Cache-Control",
+            "value": "public, max-age=31536000, immutable"
+          }
+        ]
+      },
+      {
+        "source": "**",
+        "headers": [
+          {
+            "key": "X-Frame-Options",
+            "value": "SAMEORIGIN"
+          }
+        ]
+      }
     ]
   }
 }


### PR DESCRIPTION
Part of #263 (sub-issue of #261).

## Summary
- `apps/fhdamd-web/.firebaserc`: `default` project → `fahad-web` (replaces `fhdamd-web-dev`).
- `apps/fhdamd-web/firebase.json`: `apphosting` block → `hosting` block serving static `dist/`, with immutable caching on hashed JS/CSS/font assets and a baseline `X-Frame-Options` header. Modeled on `packages/threads/firebase.json`, but **without** its SPA catch-all rewrite (`** → /index.html`) — fhdamd-web is a multi-page static Astro site, not a client-routed SPA, so that rewrite would serve the homepage for every unmatched path instead of a real 404.
- Created a dedicated `github-actions-fhdamd-web` service account on the `fahad-web` GCP project, scoped to `roles/firebasehosting.admin` only, and stored its key as the `FIREBASE_SERVICE_ACCOUNT_FAHAD_WEB` repo secret (consumed later by the preview/deploy workflows in #268/#269). Deliberately did *not* reuse the pre-existing `github-action-323482707@...` SA on this project — it's a legacy account (display name still says "fhdamd", pre-rename to fhdamd-org) with 6 keys dating back to 2022 and broader roles than this needs.

## Out of scope (per issue)
Removing `.apphosting/bundle.yaml` and the old `fhdamd-web-dev` App Hosting backend — deferred to the decommission issue (#270), done last once `fahad-web` is verified serving production traffic.

## Test plan
- [x] `pnpm --filter fhdamd-web build` → static `dist/`
- [x] `firebase hosting:channel:deploy` to a temporary 1h preview channel on `fahad-web` — verified 200 response, real DatoCMS content present, and the immutable `Cache-Control` header applied to hashed assets
- [x] Preview channel deleted after verification (no lingering resources)

🤖 Generated with [Claude Code](https://claude.com/claude-code)