### PR TITLE
feat(threads): batch 2 components for fhdamd-web — Blog, Case Studies, Lab listing pages

### DIFF
--- a/packages/threads/src/components/ContentCard/ContentCard.module.css
+++ b/packages/threads/src/components/ContentCard/ContentCard.module.css
@@ -1,0 +1,105 @@
+.card {
+  background: var(--th-color-surface-1);
+  border: 1px solid var(--th-color-border-default);
+  border-radius: var(--th-radius-lg);
+  padding: var(--th-space-5);
+  display: flex;
+  flex-direction: column;
+  cursor: pointer;
+  text-decoration: none;
+  color: inherit;
+  transition:
+    transform 0.16s var(--th-ease-out),
+    box-shadow 0.16s var(--th-ease-out),
+    border-color 0.16s;
+}
+
+.card:hover {
+  transform: translateY(-3px);
+  box-shadow: var(--th-shadow-md);
+  border-color: var(--th-color-border-strong);
+}
+
+.badges {
+  display: flex;
+  gap: 6px;
+  margin-block-end: 14px;
+}
+
+.title {
+  font-family: var(--th-font-serif);
+  font-weight: 400;
+  font-size: 1.25rem;
+  letter-spacing: -0.01em;
+  line-height: 1.18;
+  margin-block-end: var(--th-space-2);
+  color: var(--th-color-text-1);
+  flex: 1;
+}
+
+.title em {
+  font-style: italic;
+  color: var(--th-color-accent);
+}
+
+.desc {
+  font-family: var(--th-font-display);
+  font-variation-settings: "wdth" 90, "wght" 370;
+  font-size: 0.8125rem;
+  line-height: 1.58;
+  color: var(--th-color-text-3);
+  margin-block-end: var(--th-space-4);
+}
+
+.foot {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding-block-start: var(--th-space-3);
+  border-block-start: 1px solid var(--th-color-border-subtle);
+}
+
+.date {
+  font-family: var(--th-font-mono);
+  font-size: 0.6875rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--th-color-text-4);
+}
+
+.arr {
+  width: 26px;
+  height: 26px;
+  border-radius: 99px;
+  border: 1px solid var(--th-color-border-strong);
+  background: var(--th-color-bg);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  transition: all 0.14s;
+  color: var(--th-color-text-2);
+}
+
+.card:hover .arr {
+  background: var(--th-color-text-1);
+  color: var(--th-color-text-inverse);
+}
+
+/* ─── COMING SOON — dashed, non-interactive placeholder ─────────────────── */
+.comingSoon {
+  border-style: dashed;
+  cursor: default;
+  background: transparent;
+}
+
+.comingSoon:hover {
+  transform: none;
+  box-shadow: none;
+  border-color: var(--th-color-border-default);
+}
+
+.comingSoon .title,
+.comingSoon .date {
+  color: var(--th-color-text-4);
+}

--- a/packages/threads/src/components/ContentCard/ContentCard.stories.tsx
+++ b/packages/threads/src/components/ContentCard/ContentCard.stories.tsx
@@ -1,0 +1,60 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { ContentCard } from "./ContentCard";
+
+const meta = {
+  title: "Threads/Components/ContentCard",
+  component: ContentCard,
+  parameters: { layout: "padded" },
+  tags: ["autodocs"],
+  args: {
+    badges:      [{ label: "Product", variant: "terra" }],
+    title:       <>Why Jamaal has no <em>subscription</em></>,
+    description: "On pricing honestly and respecting the people who pay you.",
+    date:        "May 2026",
+    href:        "#",
+  },
+} satisfies Meta<typeof ContentCard>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};
+
+export const ComingSoon: Story = {
+  args: {
+    badges:      [{ label: "Apps & products", variant: "neutral" }],
+    title:       "Next case study",
+    description: "Reserved for the next apps & products engagement — same template, new client.",
+    date:        "Coming soon",
+    comingSoon:  true,
+    href:        undefined,
+  },
+};
+
+export const Grid: Story = {
+  render: () => (
+    <div style={{ display: "grid", gridTemplateColumns: "repeat(3, 1fr)", gap: "14px", maxWidth: "900px" }}>
+      <ContentCard
+        badges={[{ label: "Product", variant: "terra" }]}
+        title={<>Why Jamaal has no <em>subscription</em></>}
+        description="On pricing honestly and respecting the people who pay you."
+        date="May 2026"
+        href="#"
+      />
+      <ContentCard
+        badges={[{ label: "Design", variant: "sage" }]}
+        title="One design system for four platforms"
+        description="How Threads tokens survive iOS, macOS, web, and watchOS."
+        date="Mar 2026"
+        href="#"
+      />
+      <ContentCard
+        badges={[{ label: "Apps & products", variant: "neutral" }]}
+        title="Next case study"
+        description="Reserved for the next apps & products engagement."
+        date="Coming soon"
+        comingSoon
+      />
+    </div>
+  ),
+};

--- a/packages/threads/src/components/ContentCard/ContentCard.test.tsx
+++ b/packages/threads/src/components/ContentCard/ContentCard.test.tsx
@@ -1,0 +1,42 @@
+import { render, screen } from "@testing-library/react";
+import { ContentCard } from "./ContentCard";
+
+describe("ContentCard", () => {
+  it("renders title, description, and date", () => {
+    render(<ContentCard title="A post" description="A description" date="May 2026" href="#" />);
+    expect(screen.getByText("A post")).toBeInTheDocument();
+    expect(screen.getByText("A description")).toBeInTheDocument();
+    expect(screen.getByText("May 2026")).toBeInTheDocument();
+  });
+
+  it("renders badges", () => {
+    render(<ContentCard title="A post" date="May 2026" href="#" badges={[{ label: "Product" }]} />);
+    expect(screen.getByText("Product")).toBeInTheDocument();
+  });
+
+  it("renders as a link when href is provided", () => {
+    render(<ContentCard title="A post" date="May 2026" href="/blog/a-post" />);
+    expect(screen.getByRole("link")).toHaveAttribute("href", "/blog/a-post");
+  });
+
+  it("renders as a non-link element when comingSoon is true, even with href", () => {
+    render(<ContentCard title="Next post" date="Coming soon" href="/should-not-link" comingSoon />);
+    expect(screen.queryByRole("link")).not.toBeInTheDocument();
+  });
+
+  it("does not render the arrow affordance when comingSoon is true", () => {
+    const { container: comingSoon } = render(
+      <ContentCard title="Next post" date="Coming soon" comingSoon />
+    );
+    const { container: normal } = render(
+      <ContentCard title="A post" date="May 2026" href="#" />
+    );
+    expect(comingSoon.querySelector("svg")).not.toBeInTheDocument();
+    expect(normal.querySelector("svg")).toBeInTheDocument();
+  });
+
+  it("merges custom className", () => {
+    render(<ContentCard title="A post" date="May 2026" href="#" className="custom" data-testid="card" />);
+    expect(screen.getByTestId("card")).toHaveClass("custom");
+  });
+});

--- a/packages/threads/src/components/ContentCard/ContentCard.tsx
+++ b/packages/threads/src/components/ContentCard/ContentCard.tsx
@@ -1,0 +1,61 @@
+import type { HTMLAttributes, ReactNode } from "react";
+import { Badge, type BadgeVariant } from "../Badge/Badge";
+import styles from "./ContentCard.module.css";
+
+export interface ContentCardBadge {
+  label: string;
+  variant?: BadgeVariant;
+}
+
+export interface ContentCardProps extends Omit<HTMLAttributes<HTMLElement>, "title"> {
+  badges?: ContentCardBadge[];
+  title: ReactNode;
+  description?: string;
+  /** e.g. "May 2026" — or "Coming soon" when comingSoon is true */
+  date: string;
+  href?: string;
+  /** Dashed, non-interactive placeholder state — no href, no hover lift, no arrow */
+  comingSoon?: boolean;
+}
+
+const ArrowIcon = () => (
+  <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+    <path d="M5 12h14M12 5l7 7-7 7" />
+  </svg>
+);
+
+export function ContentCard({
+  badges = [],
+  title,
+  description,
+  date,
+  href,
+  comingSoon = false,
+  className,
+  ...rest
+}: ContentCardProps) {
+  const Tag = comingSoon || !href ? "div" : "a";
+  const cls = [styles.card, comingSoon ? styles.comingSoon : "", className]
+    .filter(Boolean)
+    .join(" ");
+
+  return (
+    <Tag className={cls} href={comingSoon ? undefined : href} {...rest}>
+      {badges.length > 0 && (
+        <div className={styles.badges}>
+          {badges.map((b) => <Badge key={b.label} variant={b.variant}>{b.label}</Badge>)}
+        </div>
+      )}
+      <div className={styles.title}>{title}</div>
+      {description && <p className={styles.desc}>{description}</p>}
+      <div className={styles.foot}>
+        <span className={styles.date}>{date}</span>
+        {!comingSoon && (
+          <div className={styles.arr}>
+            <ArrowIcon />
+          </div>
+        )}
+      </div>
+    </Tag>
+  );
+}

--- a/packages/threads/src/components/FeaturedCard/FeaturedCard.module.css
+++ b/packages/threads/src/components/FeaturedCard/FeaturedCard.module.css
@@ -1,0 +1,69 @@
+.card {
+  display: block;
+  background: var(--th-color-surface-1);
+  border: 1px solid var(--th-color-border-default);
+  border-radius: var(--th-radius-xl);
+  padding: var(--th-space-8);
+  position: relative;
+  overflow: hidden;
+  text-decoration: none;
+  color: inherit;
+  transition: border-color 0.16s;
+}
+
+.card:hover {
+  border-color: var(--th-color-border-strong);
+}
+
+.card::before {
+  content: "";
+  position: absolute;
+  inset-block-start: 0;
+  inset-inline: 0;
+  block-size: 3px;
+  background: var(--th-color-accent);
+}
+
+.eyebrow {
+  font-family: var(--th-font-mono);
+  font-size: 0.6875rem;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--th-color-text-4);
+  margin-block-end: 14px;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.title {
+  font-family: var(--th-font-serif);
+  font-weight: 300;
+  font-size: clamp(1.5rem, 3vw, 2.5rem);
+  letter-spacing: -0.02em;
+  line-height: 1.08;
+  color: var(--th-color-text-1);
+  margin-block-end: 12px;
+}
+
+.title em {
+  font-style: italic;
+  color: var(--th-color-accent);
+}
+
+.desc {
+  font-family: var(--th-font-display);
+  font-variation-settings: "wdth" 90, "wght" 370;
+  font-size: var(--th-text-md);
+  line-height: 1.7;
+  color: var(--th-color-text-3);
+  max-inline-size: 640px;
+  margin-block-end: 20px;
+}
+
+.meta {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  flex-wrap: wrap;
+}

--- a/packages/threads/src/components/FeaturedCard/FeaturedCard.stories.tsx
+++ b/packages/threads/src/components/FeaturedCard/FeaturedCard.stories.tsx
@@ -1,0 +1,30 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { FeaturedCard } from "./FeaturedCard";
+
+const meta = {
+  title: "Threads/Components/FeaturedCard",
+  component: FeaturedCard,
+  parameters: { layout: "padded" },
+  tags: ["autodocs"],
+  args: {
+    eyebrowMeta: "July 2026 · 9 min read",
+    title:       <>Building a sequence diagram <em>you can trust</em></>,
+    description: "A walkthrough of how the Kindergarten Arrival Funding platform's prefill flow is documented — with Mermaid diagrams checked into the same repo as the code they describe, so the docs can't drift.",
+    metaBadges:  [{ label: "Dev", variant: "neutral" }, { label: "Architecture", variant: "neutral" }],
+    href:        "#",
+  },
+} satisfies Meta<typeof FeaturedCard>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};
+
+export const CaseStudyVariant: Story = {
+  args: {
+    eyebrowMeta: "Structural engineering · New Delhi",
+    title:       <>RZest Engineers — <em>a Presence build in under three weeks</em></>,
+    description: "A brochure-and-portfolio site for a New Delhi structural engineering firm — a filterable project portfolio, DatoCMS-backed case study pages, and full OG/meta implementation, built on Astro and delivered in under three weeks.",
+    metaBadges:  [{ label: "Custom website", variant: "terra" }, { label: "Astro · DatoCMS", variant: "neutral" }],
+  },
+};

--- a/packages/threads/src/components/FeaturedCard/FeaturedCard.test.tsx
+++ b/packages/threads/src/components/FeaturedCard/FeaturedCard.test.tsx
@@ -1,0 +1,36 @@
+import { render, screen } from "@testing-library/react";
+import { FeaturedCard } from "./FeaturedCard";
+
+describe("FeaturedCard", () => {
+  it("renders the Featured badge and eyebrow meta text", () => {
+    render(
+      <FeaturedCard eyebrowMeta="July 2026 · 9 min read" title="A post" description="d" href="#" />
+    );
+    expect(screen.getByText("Featured")).toBeInTheDocument();
+    expect(screen.getByText(/July 2026/)).toBeInTheDocument();
+  });
+
+  it("renders title and description", () => {
+    render(<FeaturedCard eyebrowMeta="e" title="A featured post" description="A description" href="#" />);
+    expect(screen.getByText("A featured post")).toBeInTheDocument();
+    expect(screen.getByText("A description")).toBeInTheDocument();
+  });
+
+  it("renders as a link to the given href", () => {
+    render(<FeaturedCard eyebrowMeta="e" title="t" description="d" href="/blog/featured-post" />);
+    expect(screen.getByRole("link")).toHaveAttribute("href", "/blog/featured-post");
+  });
+
+  it("renders meta badges when provided", () => {
+    render(
+      <FeaturedCard eyebrowMeta="e" title="t" description="d" href="#" metaBadges={[{ label: "Dev" }, { label: "Architecture" }]} />
+    );
+    expect(screen.getByText("Dev")).toBeInTheDocument();
+    expect(screen.getByText("Architecture")).toBeInTheDocument();
+  });
+
+  it("merges custom className", () => {
+    render(<FeaturedCard eyebrowMeta="e" title="t" description="d" href="#" className="custom" data-testid="fc" />);
+    expect(screen.getByTestId("fc")).toHaveClass("custom");
+  });
+});

--- a/packages/threads/src/components/FeaturedCard/FeaturedCard.tsx
+++ b/packages/threads/src/components/FeaturedCard/FeaturedCard.tsx
@@ -1,0 +1,42 @@
+import type { HTMLAttributes, ReactNode } from "react";
+import { Badge, type BadgeVariant } from "../Badge/Badge";
+import styles from "./FeaturedCard.module.css";
+
+export interface FeaturedCardBadge {
+  label: string;
+  variant?: BadgeVariant;
+}
+
+export interface FeaturedCardProps extends Omit<HTMLAttributes<HTMLAnchorElement>, "title"> {
+  /** Text after the fixed "Featured" badge, e.g. "July 2026 · 9 min read" */
+  eyebrowMeta: string;
+  title: ReactNode;
+  description: string;
+  metaBadges?: FeaturedCardBadge[];
+  href: string;
+}
+
+export function FeaturedCard({
+  eyebrowMeta,
+  title,
+  description,
+  metaBadges = [],
+  href,
+  className,
+  ...rest
+}: FeaturedCardProps) {
+  return (
+    <a className={[styles.card, className].filter(Boolean).join(" ")} href={href} {...rest}>
+      <div className={styles.eyebrow}>
+        <Badge variant="neutral">Featured</Badge> {eyebrowMeta}
+      </div>
+      <div className={styles.title}>{title}</div>
+      <p className={styles.desc}>{description}</p>
+      {metaBadges.length > 0 && (
+        <div className={styles.meta}>
+          {metaBadges.map((b) => <Badge key={b.label} variant={b.variant}>{b.label}</Badge>)}
+        </div>
+      )}
+    </a>
+  );
+}

--- a/packages/threads/src/components/TagFilterBar/TagFilterBar.module.css
+++ b/packages/threads/src/components/TagFilterBar/TagFilterBar.module.css
@@ -1,0 +1,30 @@
+.bar {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.pill {
+  font-family: var(--th-font-mono);
+  font-size: 0.6875rem;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  padding: 8px 16px;
+  border-radius: var(--th-radius-pill);
+  border: 1px solid var(--th-color-border-default);
+  background: var(--th-color-surface-1);
+  color: var(--th-color-text-3);
+  cursor: pointer;
+  transition: all var(--th-duration-base) var(--th-ease-out);
+}
+
+.pill:hover {
+  border-color: var(--th-color-border-strong);
+  color: var(--th-color-text-1);
+}
+
+.pill.active {
+  background: var(--th-color-text-1);
+  border-color: var(--th-color-text-1);
+  color: var(--th-color-text-inverse);
+}

--- a/packages/threads/src/components/TagFilterBar/TagFilterBar.stories.tsx
+++ b/packages/threads/src/components/TagFilterBar/TagFilterBar.stories.tsx
@@ -1,0 +1,34 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { TagFilterBar } from "./TagFilterBar";
+
+const meta = {
+  title: "Threads/Components/TagFilterBar",
+  component: TagFilterBar,
+  parameters: { layout: "padded" },
+  tags: ["autodocs"],
+  args: {
+    allLabel: "All posts",
+    tags: [
+      { value: "dev", label: "Dev" },
+      { value: "product", label: "Product" },
+      { value: "design", label: "Design" },
+      { value: "architecture", label: "Architecture" },
+    ],
+  },
+} satisfies Meta<typeof TagFilterBar>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};
+
+export const CaseStudiesVariant: Story = {
+  args: {
+    allLabel: "All case studies",
+    tags: [
+      { value: "website", label: "Custom websites" },
+      { value: "app", label: "Apps & products" },
+      { value: "advisory", label: "Architecture & advisory" },
+    ],
+  },
+};

--- a/packages/threads/src/components/TagFilterBar/TagFilterBar.test.tsx
+++ b/packages/threads/src/components/TagFilterBar/TagFilterBar.test.tsx
@@ -1,0 +1,47 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import { vi } from "vitest";
+import { TagFilterBar } from "./TagFilterBar";
+
+const tags = [
+  { value: "dev", label: "Dev" },
+  { value: "product", label: "Product" },
+];
+
+describe("TagFilterBar", () => {
+  it("renders the all pill plus every tag", () => {
+    render(<TagFilterBar tags={tags} allLabel="All posts" />);
+    expect(screen.getByRole("button", { name: "All posts" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Dev" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Product" })).toBeInTheDocument();
+  });
+
+  it("defaults to the all pill active", () => {
+    render(<TagFilterBar tags={tags} allLabel="All posts" />);
+    expect(screen.getByRole("button", { name: "All posts" }).className).toMatch(/active/);
+  });
+
+  it("marks a tag active on click and calls onChange", () => {
+    const onChange = vi.fn();
+    render(<TagFilterBar tags={tags} onChange={onChange} />);
+    fireEvent.click(screen.getByRole("button", { name: "Dev" }));
+    expect(onChange).toHaveBeenCalledWith("dev");
+    expect(screen.getByRole("button", { name: "Dev" }).className).toMatch(/active/);
+  });
+
+  it("only one pill is active at a time", () => {
+    render(<TagFilterBar tags={tags} allLabel="All posts" />);
+    fireEvent.click(screen.getByRole("button", { name: "Dev" }));
+    expect(screen.getByRole("button", { name: "All posts" }).className).not.toMatch(/active/);
+    expect(screen.getByRole("button", { name: "Dev" }).className).toMatch(/active/);
+  });
+
+  it("respects a custom defaultTag", () => {
+    render(<TagFilterBar tags={tags} defaultTag="product" />);
+    expect(screen.getByRole("button", { name: "Product" }).className).toMatch(/active/);
+  });
+
+  it("merges custom className", () => {
+    render(<TagFilterBar tags={tags} className="custom" data-testid="bar" />);
+    expect(screen.getByTestId("bar")).toHaveClass("custom");
+  });
+});

--- a/packages/threads/src/components/TagFilterBar/TagFilterBar.tsx
+++ b/packages/threads/src/components/TagFilterBar/TagFilterBar.tsx
@@ -1,0 +1,55 @@
+"use client";
+import { useState, type HTMLAttributes } from "react";
+import styles from "./TagFilterBar.module.css";
+
+export interface TagFilterOption {
+  value: string;
+  label: string;
+}
+
+export interface TagFilterBarProps extends Omit<HTMLAttributes<HTMLDivElement>, "onChange"> {
+  /** Distinct tag values present in the collection — computed by the consuming page, not hardcoded here */
+  tags: TagFilterOption[];
+  /** Label for the "show everything" pill — reserved value "all" */
+  allLabel?: string;
+  defaultTag?: string;
+  onChange?: (tag: string) => void;
+}
+
+export function TagFilterBar({
+  tags,
+  allLabel = "All",
+  defaultTag = "all",
+  onChange,
+  className,
+  ...rest
+}: TagFilterBarProps) {
+  const [active, setActive] = useState(defaultTag);
+
+  const select = (tag: string) => {
+    setActive(tag);
+    onChange?.(tag);
+  };
+
+  return (
+    <div className={[styles.bar, className].filter(Boolean).join(" ")} {...rest}>
+      <button
+        type="button"
+        className={[styles.pill, active === "all" ? styles.active : ""].filter(Boolean).join(" ")}
+        onClick={() => select("all")}
+      >
+        {allLabel}
+      </button>
+      {tags.map((tag) => (
+        <button
+          key={tag.value}
+          type="button"
+          className={[styles.pill, active === tag.value ? styles.active : ""].filter(Boolean).join(" ")}
+          onClick={() => select(tag.value)}
+        >
+          {tag.label}
+        </button>
+      ))}
+    </div>
+  );
+}

--- a/packages/threads/src/index.ts
+++ b/packages/threads/src/index.ts
@@ -100,6 +100,15 @@ export type { FormSuccessPanelProps } from "./components/FormSuccessPanel/FormSu
 export { CaseStudySpotlight } from "./components/CaseStudySpotlight/CaseStudySpotlight";
 export type { CaseStudySpotlightProps, CaseStudyStat } from "./components/CaseStudySpotlight/CaseStudySpotlight";
 
+export { ContentCard } from "./components/ContentCard/ContentCard";
+export type { ContentCardProps, ContentCardBadge } from "./components/ContentCard/ContentCard";
+
+export { FeaturedCard } from "./components/FeaturedCard/FeaturedCard";
+export type { FeaturedCardProps, FeaturedCardBadge } from "./components/FeaturedCard/FeaturedCard";
+
+export { TagFilterBar } from "./components/TagFilterBar/TagFilterBar";
+export type { TagFilterBarProps, TagFilterOption } from "./components/TagFilterBar/TagFilterBar";
+
 // Feedback
 export { Callout } from "./components/Callout/Callout";
 export type { CalloutProps, CalloutVariant } from "./components/Callout/Callout";


### PR DESCRIPTION
Part of #281 (sub-issue of #267, #261).

## Summary
New components: `ContentCard`, `FeaturedCard`, `TagFilterBar`.

- **`ContentCard`** consolidates the near-duplicate post-card/case-card/lab-card markup from the source HTML into one component, with a `comingSoon` dashed-placeholder variant matching the `status` field on `CaseStudy`/`LabExperiment` (#264) — renders as a non-interactive `div` with no arrow affordance instead of a link when `comingSoon` is set.
- **`FeaturedCard`** is the larger spotlight card distinct from the grid tile — always carries a fixed "Featured" badge (via the existing `Badge` component) ahead of the consumer-supplied eyebrow text.
- **`TagFilterBar`** is self-contained (owns its own active-pill state, calls `onChange`) but takes no opinion on the tag vocabulary — the pill set is data-driven (distinct `tags` values across a collection, per #264's tag-filtering decision), not a hardcoded config.

Deliberately out of scope for this batch (tracked as the next one under #267): `Prose`/`ArticleBody`, `CodeBlock`, `MermaidDiagramCard`, `EmbedCard`, `TableOfContents`, `FactStrip`, `StatRow`, `AuthorBox`, and the `Testimonial` reserved-state variant — all needed for the long-form article detail pages, not the listing pages this batch covers.

## Test plan
- [x] `pnpm --filter @fhdamd/threads check-types` passes
- [x] `pnpm --filter @fhdamd/threads lint` passes (0 errors/warnings)
- [x] `pnpm --filter @fhdamd/threads test` — 545/545 tests pass across 52 files
- [x] `pnpm --filter @fhdamd/threads test:coverage` — 98.22% overall, every new component at or near 100%
- [x] `pnpm --filter @fhdamd/threads build` succeeds
- [x] `pnpm --filter @fhdamd/threads build-storybook` succeeds

Same as #277 — merging this doesn't publish anything by itself; release-please's pending release PR just absorbs it, and we're deferring that merge until we've bundled the batches we want in this release round.

🤖 Generated with [Claude Code](https://claude.com/claude-code)