### PR TITLE
fix(threads): move react/react-dom to peerDependencies

### DIFF
--- a/packages/threads/package.json
+++ b/packages/threads/package.json
@@ -81,10 +81,12 @@
     "vitest": "^3.2.4",
     "@vitest/browser": "^3.2.4",
     "playwright": "^1.56.0",
-    "@vitest/coverage-v8": "^3.2.4"
-  },
-  "dependencies": {
+    "@vitest/coverage-v8": "^3.2.4",
     "react": "^19.1.0",
     "react-dom": "^19.1.0"
+  },
+  "peerDependencies": {
+    "react": "^17.0.2 || ^18.0.0 || ^19.0.0",
+    "react-dom": "^17.0.2 || ^18.0.0 || ^19.0.0"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -41,6 +41,9 @@ importers:
       '@astrojs/react':
         specifier: ^6.0.1
         version: 6.0.1(@types/node@25.9.1)(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(esbuild@0.28.0)(jiti@2.6.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(tsx@4.22.3)(yaml@2.9.0)
+      '@fhdamd/threads':
+        specifier: ^0.5.0
+        version: 0.5.0
       astro:
         specifier: ^7.1.1
         version: 7.1.1(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@25.9.1)(jiti@2.6.1)(rollup@4.60.4)(tsx@4.22.3)(yaml@2.9.0)
@@ -245,13 +248,6 @@ importers:
         version: 5.9.2
 
   packages/threads:
-    dependencies:
-      react:
-        specifier: ^19.1.0
-        version: 19.2.3
-      react-dom:
-        specifier: ^19.1.0
-        version: 19.2.3(react@19.2.3)
     devDependencies:
       '@chromatic-com/storybook':
         specifier: ^5.2.1
@@ -316,6 +312,12 @@ importers:
       playwright:
         specifier: ^1.56.0
         version: 1.57.0
+      react:
+        specifier: ^19.1.0
+        version: 19.2.3
+      react-dom:
+        specifier: ^19.1.0
+        version: 19.2.3(react@19.2.3)
       storybook:
         specifier: ^10.4.1
         version: 10.4.2(@testing-library/dom@10.4.1)(@types/react@19.1.0)(prettier@3.8.3)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
@@ -1522,6 +1524,9 @@ packages:
 
   '@fhdamd/threads@0.4.0':
     resolution: {integrity: sha512-DeAVPkJl1qcHrlxhJ92boVgNISbRGWyCvOQfuZulbRetoenoJCl5AnuLEuHLliWRuRWnwdCs4uri4+rlpKldMw==}
+
+  '@fhdamd/threads@0.5.0':
+    resolution: {integrity: sha512-/SI8fDy4uvVfXvr6lrNivwlIJkQJWpeE041koGT0331yrHPTbq+LU6s/mt4CnJ9kypO+yBEBjwDpSnyrRw90HA==}
 
   '@firebase/ai@2.12.0':
     resolution: {integrity: sha512-b+OL4vdyiSLZL/7dLd67V55CjKJvU9MpNmwnday7eA6GG2+J4iwUEsEHgw0/jKY3A41FfkF0SrnYFvtKbQZ65A==}
@@ -9628,6 +9633,11 @@ snapshots:
   '@fastify/busboy@3.2.0': {}
 
   '@fhdamd/threads@0.4.0':
+    dependencies:
+      react: 19.2.6
+      react-dom: 19.2.6(react@19.2.6)
+
+  '@fhdamd/threads@0.5.0':
     dependencies:
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -41,9 +41,6 @@ importers:
       '@astrojs/react':
         specifier: ^6.0.1
         version: 6.0.1(@types/node@25.9.1)(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(esbuild@0.28.0)(jiti@2.6.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(tsx@4.22.3)(yaml@2.9.0)
-      '@fhdamd/threads':
-        specifier: ^0.5.0
-        version: 0.5.0
       astro:
         specifier: ^7.1.1
         version: 7.1.1(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@25.9.1)(jiti@2.6.1)(rollup@4.60.4)(tsx@4.22.3)(yaml@2.9.0)
@@ -1524,9 +1521,6 @@ packages:
 
   '@fhdamd/threads@0.4.0':
     resolution: {integrity: sha512-DeAVPkJl1qcHrlxhJ92boVgNISbRGWyCvOQfuZulbRetoenoJCl5AnuLEuHLliWRuRWnwdCs4uri4+rlpKldMw==}
-
-  '@fhdamd/threads@0.5.0':
-    resolution: {integrity: sha512-/SI8fDy4uvVfXvr6lrNivwlIJkQJWpeE041koGT0331yrHPTbq+LU6s/mt4CnJ9kypO+yBEBjwDpSnyrRw90HA==}
 
   '@firebase/ai@2.12.0':
     resolution: {integrity: sha512-b+OL4vdyiSLZL/7dLd67V55CjKJvU9MpNmwnday7eA6GG2+J4iwUEsEHgw0/jKY3A41FfkF0SrnYFvtKbQZ65A==}
@@ -9633,11 +9627,6 @@ snapshots:
   '@fastify/busboy@3.2.0': {}
 
   '@fhdamd/threads@0.4.0':
-    dependencies:
-      react: 19.2.6
-      react-dom: 19.2.6(react@19.2.6)
-
-  '@fhdamd/threads@0.5.0':
     dependencies:
       react: 19.2.6
       react-dom: 19.2.6(react@19.2.6)


### PR DESCRIPTION
## Summary
- Consumers whose own React version differs from `@fhdamd/threads`' pinned range got a second, independent React copy resolved because `react`/`react-dom` were declared as regular `dependencies` instead of `peerDependencies`.
- This breaks hooks (`useState` sees a null dispatcher) in any stateful Threads component rendered inside the consumer's own React tree — hit while wiring up `fhdamd-web` (`SiteNav` crashed on render).
- Moves both to `peerDependencies` (kept in `devDependencies` too, for local dev/Storybook/tests). No behavior change for pdf-craft, which happened to already resolve to a matching React version.

Fixes #286.

## Test plan
- [x] `pnpm --filter @fhdamd/threads build` succeeds
- [x] `pnpm --filter @fhdamd/threads check-types` succeeds
- [x] Verified locally with `fhdamd-web` linked via `workspace:*`: `SiteNav` render crash disappears, single resolved React instance (confirmed via `pnpm why react`)