### PR TITLE
feat(fhdamd-web): Contact page against typed mock data

### DIFF
--- a/apps/fhdamd-web/src/components/ContactForm/ContactForm.tsx
+++ b/apps/fhdamd-web/src/components/ContactForm/ContactForm.tsx
@@ -1,0 +1,89 @@
+import { useState } from "react";
+import { Input, Select, Textarea, Button, Stack, FormSuccessPanel } from "@fhdamd/threads";
+import type { SelectOption } from "../../data/contactOptions";
+import { ArrowRightIcon } from "../icons/icons";
+
+interface ContactFormProps {
+  formNote: string;
+  interestOptions: SelectOption[];
+  timelineOptions: SelectOption[];
+}
+
+/**
+ * Real submission (email/backend service) wiring is deferred until that
+ * service exists — see #294. Submitting just shows FormSuccessPanel,
+ * matching the source design's own client-side demo behavior.
+ */
+export function ContactForm({ formNote, interestOptions, timelineOptions }: ContactFormProps) {
+  const [submitted, setSubmitted] = useState(false);
+
+  if (submitted) {
+    return (
+      <FormSuccessPanel
+        title="Message sent."
+        message="I'll be in touch within one business day."
+      />
+    );
+  }
+
+  return (
+    <form
+      onSubmit={(e) => {
+        e.preventDefault();
+        setSubmitted(true);
+      }}
+    >
+      <Stack gap={5}>
+        <div className="form-row">
+          <Input label="Name" name="name" placeholder="Your name" autoComplete="name" required />
+          <Input
+            type="email"
+            label="Email"
+            name="email"
+            placeholder="you@example.com"
+            autoComplete="email"
+            required
+          />
+        </div>
+
+        <Input label="Business name" name="business" placeholder="Your business or organisation" />
+
+        <Select label="What are you interested in?" name="interest" defaultValue="">
+          <option value="" disabled>
+            Select an option
+          </option>
+          {interestOptions.map((option) => (
+            <option key={option.value} value={option.value}>
+              {option.label}
+            </option>
+          ))}
+        </Select>
+
+        <Select label="Ideal timeline" name="timeline" defaultValue="">
+          <option value="" disabled>
+            When do you want to launch?
+          </option>
+          {timelineOptions.map((option) => (
+            <option key={option.value} value={option.value}>
+              {option.label}
+            </option>
+          ))}
+        </Select>
+
+        <Textarea
+          label="Tell me about your project"
+          name="message"
+          placeholder="What does your business do, what do you need, and what's the context? The more you share, the better I can help."
+          rows={5}
+          required
+        />
+
+        <p className="form-note">{formNote}</p>
+
+        <Button type="submit" variant="solid-ink" icon={<ArrowRightIcon />} style={{ alignSelf: "flex-start" }}>
+          Send message
+        </Button>
+      </Stack>
+    </form>
+  );
+}

--- a/apps/fhdamd-web/src/components/icons/icons.tsx
+++ b/apps/fhdamd-web/src/components/icons/icons.tsx
@@ -31,3 +31,20 @@ export function ArrowRightIcon() {
     </svg>
   );
 }
+
+export function MailIcon() {
+  return (
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round">
+      <path d="M4 4h16c1.1 0 2 .9 2 2v12c0 1.1-.9 2-2 2H4c-1.1 0-2-.9-2-2V6c0-1.1.9-2 2-2z" />
+      <polyline points="22,6 12,13 2,6" />
+    </svg>
+  );
+}
+
+export function CheckIcon() {
+  return (
+    <svg viewBox="0 0 24 24">
+      <polyline points="20 6 9 17 4 12" />
+    </svg>
+  );
+}

--- a/apps/fhdamd-web/src/content/mock/contactPage.ts
+++ b/apps/fhdamd-web/src/content/mock/contactPage.ts
@@ -1,0 +1,16 @@
+import type { ContactPage } from "../types";
+
+export const contactPage: ContactPage = {
+  heroKicker: "Get in touch",
+  heroHeading: "Let's talk about your *project.*",
+  heroSubheading:
+    "Whether it's a new website, an app, an advisory engagement, or you're not sure yet — fill in the form and I'll come back to you within one business day.",
+  formNote:
+    "I work with a small number of clients at a time. If timing and fit align I'll come back to you quickly. All enquiries are treated with care and confidentiality.",
+  expectList: [
+    "Reply within one business day",
+    "A 45–60 min discovery call if we're a fit",
+    "Written summary + fixed-price proposal within 48 hrs of the call",
+    "No hard sell — if it's not the right fit I'll say so",
+  ],
+};

--- a/apps/fhdamd-web/src/content/types.ts
+++ b/apps/fhdamd-web/src/content/types.ts
@@ -26,6 +26,15 @@ export interface AboutPage {
   sidebarLabel: string;
 }
 
+export interface ContactPage {
+  heroKicker: string;
+  /** Plain string; wrap a segment in *asterisks* for an <em> accent. */
+  heroHeading: string;
+  heroSubheading: string;
+  formNote: string;
+  expectList: string[];
+}
+
 export interface Employer {
   name: string;
   label: string;

--- a/apps/fhdamd-web/src/data/contactOptions.ts
+++ b/apps/fhdamd-web/src/data/contactOptions.ts
@@ -1,0 +1,26 @@
+export interface SelectOption {
+  value: string;
+  label: string;
+}
+
+/**
+ * Contact form select options. Deliberately code-level config, not DatoCMS
+ * content — these are structural form choices, not editorial copy. See #264.
+ */
+export const INTEREST_OPTIONS: SelectOption[] = [
+  { value: "website", label: "Custom website — brochure, content, or commerce" },
+  { value: "app", label: "App or product build" },
+  { value: "advisory", label: "Architecture & advisory" },
+  { value: "retainer", label: "Ongoing retainer" },
+  { value: "migration", label: "Migration from WordPress / Shopify" },
+  { value: "strategic", label: "Strategic discovery session" },
+  { value: "unsure", label: "Not sure yet — let's talk" },
+  { value: "other", label: "Something else" },
+];
+
+export const TIMELINE_OPTIONS: SelectOption[] = [
+  { value: "asap", label: "As soon as possible" },
+  { value: "1-3", label: "1–3 months" },
+  { value: "3-6", label: "3–6 months" },
+  { value: "flexible", label: "Flexible — no hard deadline" },
+];

--- a/apps/fhdamd-web/src/layouts/Layout.astro
+++ b/apps/fhdamd-web/src/layouts/Layout.astro
@@ -1,6 +1,7 @@
 ---
 import "@fhdamd/threads/tokens";
 import "@fhdamd/threads/styles";
+import "../styles/global.css";
 import Header from "../components/Header/Header";
 import Footer from "../components/Footer/Footer";
 
@@ -75,12 +76,3 @@ const canonicalUrl = new URL(Astro.url.pathname, "https://fhdamd.dev").href;
     <Footer copyright={`fhdamd.dev · Melbourne, VIC · ${new Date().getFullYear()}`} />
   </body>
 </html>
-
-<style is:global>
-  html,
-  body {
-    margin: 0;
-    padding: 0;
-    background: var(--th-color-bg);
-  }
-</style>

--- a/apps/fhdamd-web/src/lib/cms/index.ts
+++ b/apps/fhdamd-web/src/lib/cms/index.ts
@@ -1,5 +1,6 @@
 import { siteSettings } from "../../content/mock/siteSettings";
 import { aboutPage } from "../../content/mock/aboutPage";
+import { contactPage } from "../../content/mock/contactPage";
 import { employers } from "../../content/mock/employers";
 import { clientWork } from "../../content/mock/clientWork";
 import { experience } from "../../content/mock/experience";
@@ -7,6 +8,7 @@ import { skills } from "../../content/mock/skills";
 import type {
   SiteSettings,
   AboutPage,
+  ContactPage,
   Employer,
   ClientWorkItem,
   ExperienceItem,
@@ -26,6 +28,10 @@ export async function getSiteSettings(): Promise<SiteSettings> {
 
 export async function getAboutPage(): Promise<AboutPage> {
   return aboutPage;
+}
+
+export async function getContactPage(): Promise<ContactPage> {
+  return contactPage;
 }
 
 export async function getEmployers(): Promise<Employer[]> {

--- a/apps/fhdamd-web/src/pages/contact.astro
+++ b/apps/fhdamd-web/src/pages/contact.astro
@@ -1,0 +1,69 @@
+---
+import { createElement } from "react";
+import Layout from "../layouts/Layout.astro";
+import { Container, Section, Hero, Card, CardTitle, IconDetailRow, AvailabilityPill } from "@fhdamd/threads";
+import { getContactPage, getSiteSettings } from "../lib/cms";
+import { titleToReact } from "../utils/titleToReact";
+import { MailIcon, GithubIcon, LocationIcon, CheckIcon } from "../components/icons/icons";
+import { ContactForm } from "../components/ContactForm/ContactForm";
+import { INTEREST_OPTIONS, TIMELINE_OPTIONS } from "../data/contactOptions";
+import "../styles/contact.css";
+
+const borderStyle = "border-top:1px solid var(--th-color-border-default)";
+
+const contact = await getContactPage();
+const settings = await getSiteSettings();
+
+// Astro's template compiler intercepts bare JSX written as a prop-expression
+// value and hands React an internal object instead of a real element, so
+// every such value must be precomputed here and passed as a plain variable.
+const heroHeading = titleToReact(contact.heroHeading, { color: "var(--th-color-accent)" });
+
+const mailIcon = createElement(MailIcon);
+const githubIcon = createElement(GithubIcon);
+const locationIcon = createElement(LocationIcon);
+---
+
+<Layout title={`Contact — Fahad Ahmed · fhdamd.dev`}>
+  <Container>
+    <Hero eyebrow={contact.heroKicker} heading={heroHeading} body={contact.heroSubheading} />
+  </Container>
+
+  <section style={borderStyle}>
+    <Container>
+      <Section size="md">
+        <div class="contact-grid">
+          <ContactForm
+            client:load
+            formNote={contact.formNote}
+            interestOptions={INTEREST_OPTIONS}
+            timelineOptions={TIMELINE_OPTIONS}
+          />
+
+          <div class="contact-aside">
+            <AvailabilityPill label={settings.availabilityLabel} available={settings.availabilityStatus} />
+
+            <Card>
+              <CardTitle>Direct contact</CardTitle>
+              <IconDetailRow variant="labeled" label="Email" value={settings.email} icon={mailIcon} />
+              <IconDetailRow variant="labeled" label="GitHub" value={settings.github} icon={githubIcon} />
+              <IconDetailRow variant="labeled" label="Based in" value={settings.location} icon={locationIcon} />
+            </Card>
+
+            <Card>
+              <CardTitle>What to expect</CardTitle>
+              <ul class="expect-list">
+                {contact.expectList.map((item) => (
+                  <li>
+                    <span class="expect-list__icon"><CheckIcon /></span>
+                    {item}
+                  </li>
+                ))}
+              </ul>
+            </Card>
+          </div>
+        </div>
+      </Section>
+    </Container>
+  </section>
+</Layout>

--- a/apps/fhdamd-web/src/styles/contact.css
+++ b/apps/fhdamd-web/src/styles/contact.css
@@ -1,0 +1,74 @@
+.contact-grid {
+  display: grid;
+  grid-template-columns: 1fr 360px;
+  gap: var(--th-space-12);
+  align-items: start;
+}
+
+.contact-aside {
+  position: sticky;
+  top: 80px;
+  display: flex;
+  flex-direction: column;
+  gap: var(--th-space-4);
+}
+
+.form-row {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: var(--th-space-4);
+}
+
+.form-note {
+  font-family: var(--th-font-mono);
+  font-size: 0.625rem;
+  letter-spacing: 0.08em;
+  color: var(--th-color-text-4);
+  line-height: 1.6;
+}
+
+.expect-list {
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  gap: var(--th-space-3);
+}
+
+.expect-list li {
+  display: flex;
+  align-items: flex-start;
+  gap: var(--th-space-3);
+  font-family: var(--th-font-display);
+  font-variation-settings: "wdth" 90, "wght" 370;
+  font-size: 0.875rem;
+  line-height: 1.5;
+  color: var(--th-color-text-3);
+}
+
+.expect-list__icon svg {
+  width: 14px;
+  height: 14px;
+  stroke: var(--th-color-accent);
+  fill: none;
+  stroke-width: 2;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+  flex-shrink: 0;
+  margin-top: 2px;
+}
+
+@media (max-width: 900px) {
+  .contact-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .contact-aside {
+    position: static;
+  }
+}
+
+@media (max-width: 600px) {
+  .form-row {
+    grid-template-columns: 1fr;
+  }
+}

--- a/apps/fhdamd-web/src/styles/global.css
+++ b/apps/fhdamd-web/src/styles/global.css
@@ -1,0 +1,54 @@
+/* ─── BASE ───────────────────────────────────────────────────────────────── */
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+html {
+  font-size: 106.25%; /* 17px base */
+  -webkit-text-size-adjust: 100%;
+  scroll-behavior: smooth;
+}
+
+/* Use Threads tokens — responds to data-theme on <html> */
+body {
+  background: var(--th-color-bg);
+  color: var(--th-color-text-1);
+  font-family: var(--th-font-display);
+  font-size: var(--th-text-base);
+  line-height: 1.6;
+  -webkit-font-smoothing: antialiased;
+  min-height: 100dvh;
+  display: flex;
+  flex-direction: column;
+}
+
+/* main grows to fill available space, pushing the footer to the bottom */
+body > main {
+  flex: 1;
+}
+
+h1, h2, h3, h4, h5, h6 {
+  margin: 0;
+}
+
+a {
+  color: inherit;
+  text-decoration: none;
+}
+
+img {
+  display: block;
+  max-width: 100%;
+}
+
+:focus { outline: none; }
+
+:focus-visible {
+  outline: 2px solid var(--th-color-focus-ring);
+  outline-offset: 3px;
+  border-radius: 4px;
+}


### PR DESCRIPTION
## Summary
- `src/content/types.ts` + `src/content/mock/contactPage.ts` — new `ContactPage` type with real copy from the uploaded `contact.html` design. Reuses the existing `SiteSettings` type as-is for the aside's direct-contact details (email/github/location) and availability pill — no new fields needed there.
- `src/lib/cms/index.ts` — adds `getContactPage()`, same thin-fetch shape as the existing functions.
- `src/data/contactOptions.ts` — interest/timeline select options as code-level config, matching the nav-links convention from #285 (structural form choices, not editorial CMS content).
- `src/pages/contact.astro` + `src/components/ContactForm/ContactForm.tsx` — built entirely from existing Threads primitives (`Hero`, `Input`, `Select`, `Textarea`, `Button`, `AvailabilityPill`, `IconDetailRow` labeled variant, `Card`/`CardTitle`, `FormSuccessPanel`) — no `className` overrides on any of them, following the precedent from the About page cleanup.

## Notable
- The form is a `client:load` island (`ContactForm.tsx`) since the interactive submit/success toggle needs real React state — everything else on the page is server-rendered.
- Real form submission (email/backend service) wiring is out of scope, same reasoning as deferring real DatoCMS wiring in #285. Submitting shows `FormSuccessPanel` via local component state, matching the source design's own client-side demo behavior, not an actual network call.
- Hit and fixed a new variant of the Astro-JSX gotcha: precomputing an icon via `createElement` and inserting it as bare Astro template *children* (`{icon}` inside a plain `<span>`) renders as `[object Object]` — Astro doesn't know to hand a raw already-instantiated React element off to React's renderer. The fix is to use the component directly as a tag in the template (`<CheckIcon />`) instead — that path *is* handled by Astro's React integration. Precomputing via `createElement` is only needed when passing the element as a *prop* into a React component.

## Test plan
- [x] `pnpm --filter fhdamd-web build` succeeds (static output, 3 pages)
- [x] `pnpm --filter fhdamd-web exec tsc --noEmit` passes
- [x] `pnpm --filter fhdamd-web lint` passes
- [x] Verified visually via `astro dev` + Playwright against the source `contact.html` design — layout, spacing, and icon colors match
- [x] Verified the interactive form: filled fields, submitted, confirmed `FormSuccessPanel` renders via the hydrated island with no console errors