### PR TITLE
feat(fhdamd-web): Homepage against typed mock data

### DIFF
--- a/apps/fhdamd-web/src/components/icons/icons.tsx
+++ b/apps/fhdamd-web/src/components/icons/icons.tsx
@@ -48,3 +48,52 @@ export function CheckIcon() {
     </svg>
   );
 }
+
+export function DesignIcon() {
+  return (
+    <svg viewBox="0 0 24 24">
+      <path d="M12 19l7-7 3 3-7 7-3-3z" />
+      <path d="M18 13l-1.5-7.5L2 2l3.5 14.5L13 18l5-5z" />
+      <path d="M2 2l7.586 7.586" />
+      <circle cx="11" cy="11" r="2" />
+    </svg>
+  );
+}
+
+export function PhoneIcon() {
+  return (
+    <svg viewBox="0 0 24 24">
+      <rect x="5" y="2" width="14" height="20" rx="2" />
+      <path d="M12 18h.01" />
+    </svg>
+  );
+}
+
+export function FileCheckIcon() {
+  return (
+    <svg viewBox="0 0 24 24">
+      <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z" />
+      <polyline points="14 2 14 8 20 8" />
+      <path d="M9 15l2 2 4-4" />
+    </svg>
+  );
+}
+
+export function FileTextIcon() {
+  return (
+    <svg viewBox="0 0 24 24">
+      <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z" />
+      <polyline points="14 2 14 8 20 8" />
+      <path d="M9 13h6M9 17h4" />
+    </svg>
+  );
+}
+
+export function SettingsIcon() {
+  return (
+    <svg viewBox="0 0 24 24">
+      <circle cx="12" cy="12" r="3" />
+      <path d="M12 2v3M12 19v3M4.22 4.22l2.12 2.12M17.66 17.66l2.12 2.12M2 12h3M19 12h3M4.22 19.78l2.12-2.12M17.66 6.34l2.12-2.12" />
+    </svg>
+  );
+}

--- a/apps/fhdamd-web/src/content/mock/homePage.ts
+++ b/apps/fhdamd-web/src/content/mock/homePage.ts
@@ -1,0 +1,112 @@
+import type { HomePage } from "../types";
+
+export const homePage: HomePage = {
+  heroKicker: "Software engineer & solution architect · Melbourne",
+  heroHeading: "I build custom websites *and apps.*",
+  heroBody:
+    "Not templates — code. 14 years shipping production software across government, finance, and utilities. I'm available to build your site, storefront, or internal tool from the ground up. EY keeps me busy by day; Jamaal, Riqa, and Threads keep me building the rest of the time.",
+
+  hireStrip: [
+    {
+      iconKey: "design",
+      title: "Custom websites",
+      description:
+        "Brand-first brochure and content sites — Astro, headless CMS, no page builders. You own the content and the code.",
+    },
+    {
+      iconKey: "phone",
+      title: "Apps & products",
+      description:
+        "Full-stack web and iOS apps — React, Firebase, Stripe, SwiftUI. From first prototype to a shipped, paying product.",
+    },
+    {
+      iconKey: "fileCheck",
+      title: "Architecture & advisory",
+      description:
+        "Solution architecture, technical bids, and platform strategy — the same work I lead at enterprise scale, sized for a smaller team.",
+    },
+  ],
+
+  personalProjects: [
+    {
+      eyebrow: "iOS app · SwiftUI",
+      name: "Jamaal",
+      description:
+        "Privacy-first daily planning for iOS. One intelligent list, ordered each evening by a deterministic rules engine. One-time purchase, no subscription.",
+      tags: ["SwiftUI", "SwiftData"],
+      badge: { label: "In dev", variant: "terra" },
+      accentColor: "terra",
+      jamaalIcon: true,
+    },
+    {
+      eyebrow: "SaaS · Pay-per-use",
+      name: "Ri*qa*",
+      description:
+        "Pay-per-use PDF toolkit — merge, split, compress, encrypt, sign. Credits that don't expire, no subscription. Astro, Firebase, Stripe.",
+      tags: ["Astro", "Firebase"],
+      badge: { label: "Live", variant: "sage" },
+      accentColor: "sage",
+      iconKey: "fileText",
+      pricingPills: [
+        { price: "2cr", label: "Merge" },
+        { price: "3cr", label: "Encrypt" },
+        { price: "4cr", label: "Sign" },
+      ],
+    },
+    {
+      eyebrow: "Design system · Multi-platform",
+      name: "Threads",
+      description:
+        "The token system powering this site, Jamaal, and Riqa. One set of decisions in coffee and sage that works across iOS, macOS, and web.",
+      tags: ["CSS tokens", "iOS", "Web"],
+      badge: { label: "System", variant: "neutral" },
+      accentColor: "ink",
+      iconKey: "settings",
+    },
+  ],
+
+  servicesTeaserTitle: "Custom-designed, code-first, *yours to own.*",
+  servicesTeaserDesc:
+    "I design and build in code — no Figma handoff, no page builder, no theme with your logo swapped in. Every engagement starts with a discovery call and ends with a written proposal scoped to what you actually need.",
+  serviceTiers: [
+    { name: "Custom websites", price: "Brochure & commerce" },
+    { name: "Apps & products", price: "Web & iOS" },
+    { name: "Architecture & advisory", price: "Strategy & bids" },
+  ],
+
+  caseStudyEyebrow: "Custom website · Structural engineering · New Delhi",
+  caseStudyTitle: "RZest Engineers — *a Presence build in under three weeks*",
+  caseStudyDescription:
+    "A brochure-and-portfolio site for a New Delhi structural engineering firm — a filterable project portfolio, DatoCMS-backed case study pages, and full OG/meta implementation, built on Astro and delivered in under three weeks.",
+  caseStudyTags: ["Astro", "DatoCMS", "Custom website"],
+  caseStudyStats: [
+    { value: "<3*wks*", label: "Discovery to launch" },
+    { value: "0", label: "Dev tickets to publish a new project since launch" },
+    { value: "100*%*", label: "Pages with OG/meta coverage" },
+  ],
+
+  labTeaserEyebrow: "Lab",
+  labTeaserTitle: "Curious how the interactions *are built?*",
+  labTeaserDesc: "UI experiments and interaction patterns, played with in the open — the demo-first counterpart to the blog.",
+
+  essays: [
+    {
+      date: "May 2026",
+      title: "Why Jamaal has no subscription",
+      subtitle: "On pricing honestly and respecting the people who pay you",
+      category: "product",
+    },
+    {
+      date: "Apr 2026",
+      title: "Pay-per-use is underrated for small SaaS",
+      subtitle: "What building Riqa taught me about pricing models",
+      category: "product",
+    },
+    {
+      date: "Mar 2026",
+      title: "One design system for four platforms",
+      subtitle: "How Threads tokens survive iOS, macOS, web, and watchOS",
+      category: "design",
+    },
+  ],
+};

--- a/apps/fhdamd-web/src/content/mock/siteSettings.ts
+++ b/apps/fhdamd-web/src/content/mock/siteSettings.ts
@@ -8,7 +8,7 @@ export const siteSettings: SiteSettings = {
   currentTitle: "Technology Consulting Manager · Solution Architect",
   availabilityLabel: "Open to select projects",
   availabilityStatus: true,
-  ctaTitle: "Need something built? Let's talk.",
+  ctaTitle: "Need something built? *Let's talk.*",
   ctaSubtitle: "I take on a small number of consulting projects alongside the day job. If timing works, let's find out.",
   footerCopyrightNote: `fhdamd.dev · Melbourne, VIC · ${new Date().getFullYear()}`,
 };

--- a/apps/fhdamd-web/src/content/types.ts
+++ b/apps/fhdamd-web/src/content/types.ts
@@ -12,6 +12,7 @@ export interface SiteSettings {
   currentTitle: string;
   availabilityLabel: string;
   availabilityStatus: boolean;
+  /** Plain string; wrap a segment in *asterisks* for an <em> accent. */
   ctaTitle: string;
   ctaSubtitle: string;
   footerCopyrightNote: string;
@@ -33,6 +34,67 @@ export interface ContactPage {
   heroSubheading: string;
   formNote: string;
   expectList: string[];
+}
+
+export interface HireStripItem {
+  iconKey: "design" | "phone" | "fileCheck";
+  title: string;
+  description: string;
+}
+
+export interface PersonalProject {
+  eyebrow: string;
+  /** Plain string; wrap a segment in *asterisks* for an <em> accent. */
+  name: string;
+  description: string;
+  tags: string[];
+  badge: { label: string; variant: "sage" | "terra" | "neutral" };
+  accentColor: "terra" | "sage" | "ink";
+  iconKey?: "fileText" | "settings";
+  /** Threads' ProjectCard special-cases Jamaal with a "J" avatar instead of an icon. */
+  jamaalIcon?: boolean;
+  pricingPills?: { price: string; label: string }[];
+}
+
+export interface ServiceTier {
+  name: string;
+  price: string;
+}
+
+export interface CaseStudyStatItem {
+  /** Plain string; wrap a segment in *asterisks* for an <em> unit, e.g. "100*%*". */
+  value: string;
+  label: string;
+}
+
+export interface EssayTeaser {
+  date: string;
+  title: string;
+  subtitle: string;
+  category: "design" | "product" | "dev";
+}
+
+export interface HomePage {
+  heroKicker: string;
+  /** Plain string; wrap a segment in *asterisks* for an <em> accent. */
+  heroHeading: string;
+  heroBody: string;
+  hireStrip: HireStripItem[];
+  personalProjects: PersonalProject[];
+  servicesTeaserTitle: string;
+  servicesTeaserDesc: string;
+  serviceTiers: ServiceTier[];
+  caseStudyEyebrow: string;
+  /** Plain string; wrap a segment in *asterisks* for an <em> accent. */
+  caseStudyTitle: string;
+  caseStudyDescription: string;
+  caseStudyTags: string[];
+  caseStudyStats: CaseStudyStatItem[];
+  labTeaserEyebrow: string;
+  /** Plain string; wrap a segment in *asterisks* for an <em> accent. */
+  labTeaserTitle: string;
+  labTeaserDesc: string;
+  essays: EssayTeaser[];
 }
 
 export interface Employer {

--- a/apps/fhdamd-web/src/lib/cms/index.ts
+++ b/apps/fhdamd-web/src/lib/cms/index.ts
@@ -1,6 +1,7 @@
 import { siteSettings } from "../../content/mock/siteSettings";
 import { aboutPage } from "../../content/mock/aboutPage";
 import { contactPage } from "../../content/mock/contactPage";
+import { homePage } from "../../content/mock/homePage";
 import { employers } from "../../content/mock/employers";
 import { clientWork } from "../../content/mock/clientWork";
 import { experience } from "../../content/mock/experience";
@@ -9,6 +10,7 @@ import type {
   SiteSettings,
   AboutPage,
   ContactPage,
+  HomePage,
   Employer,
   ClientWorkItem,
   ExperienceItem,
@@ -32,6 +34,10 @@ export async function getAboutPage(): Promise<AboutPage> {
 
 export async function getContactPage(): Promise<ContactPage> {
   return contactPage;
+}
+
+export async function getHomePage(): Promise<HomePage> {
+  return homePage;
 }
 
 export async function getEmployers(): Promise<Employer[]> {

--- a/apps/fhdamd-web/src/pages/index.astro
+++ b/apps/fhdamd-web/src/pages/index.astro
@@ -1,61 +1,256 @@
 ---
-import Layout from '../layouts/Layout.astro';
+import { createElement, Fragment as ReactFragment } from "react";
+import Layout from "../layouts/Layout.astro";
+import {
+  Container,
+  Section,
+  Stack,
+  Hero,
+  SectionHeader,
+  Card,
+  Grid,
+  ProjectCard,
+  CaseStudySpotlight,
+  EssayRow,
+  DarkStrip,
+  AvailabilityPill,
+  Button,
+} from "@fhdamd/threads";
+import { getHomePage, getSiteSettings } from "../lib/cms";
+import { titleToReact, markupToHtml } from "../utils/titleToReact";
+import {
+  ArrowRightIcon,
+  MailIcon,
+  DesignIcon,
+  PhoneIcon,
+  FileCheckIcon,
+  FileTextIcon,
+  SettingsIcon,
+} from "../components/icons/icons";
+import "../styles/home.css";
 
-// Welcome to Astro! Wondering what to do next? Check out the Astro documentation at https://docs.astro.build
-// Don't want to use any of this? Delete everything in this file, the `assets`, `components`, and `layouts` directories, and start fresh.
+const borderStyle = "border-top:1px solid var(--th-color-border-default)";
 
-const response = await fetch('https://graphql.datocms.com/', {
-  method: 'POST',
-  headers: {
-    'Content-Type': 'application/json',
-    Accept: 'application/json',
-    Authorization: `Bearer ${import.meta.env.DATOCMS_API_TOKEN}`,
-  },
-  body: JSON.stringify({
-    query: `query PostsQuery {
-					allPosts {
-						id
-						title
-						content
-						_status
-						_firstPublishedAt
-					}
+const home = await getHomePage();
+const settings = await getSiteSettings();
 
-					_allPostsMeta {
-						count
-					}
-				}
-      `,
-  }),
-});
+// Astro's template compiler intercepts bare JSX written as a prop-expression
+// value and hands React an internal object instead of a real element, so
+// every such value must be precomputed here and passed as a plain variable.
+const heroHeading = titleToReact(home.heroHeading, { color: "var(--th-color-accent)" });
+const arrowRightIcon = createElement(ArrowRightIcon);
 
-const json = await response.json();
-const data = json.data.allPosts;
+const heroActions = createElement(
+  ReactFragment,
+  null,
+  createElement(Button, { href: "/services", variant: "solid-ink", icon: arrowRightIcon }, "View services"),
+  createElement(
+    Button,
+    { href: "/contact", variant: "ghost", icon: createElement(MailIcon), iconPosition: "start" },
+    "Get in touch",
+  ),
+  createElement(AvailabilityPill, { label: settings.availabilityLabel, available: settings.availabilityStatus }),
+);
 
+const hireStripIcons = {
+  design: DesignIcon,
+  phone: PhoneIcon,
+  fileCheck: FileCheckIcon,
+};
+
+const builtTitle = titleToReact("Things I've *built*");
+const personalProjectsData = home.personalProjects.map((project) => ({
+  ...project,
+  nameNode: titleToReact(project.name, { color: "var(--th-color-sage-text)" }),
+  iconNode:
+    project.iconKey === "fileText"
+      ? createElement(FileTextIcon)
+      : project.iconKey === "settings"
+        ? createElement(SettingsIcon)
+        : undefined,
+}));
+
+const hireMeTitle = titleToReact("Hire me to *build it*");
+const servicesTeaserTitleHtml = markupToHtml(home.servicesTeaserTitle);
+
+const caseStudiesTitle = titleToReact("Case *studies*");
+const caseStudyTitle = titleToReact(home.caseStudyTitle);
+const caseStudyStatsData = home.caseStudyStats.map((stat) => ({
+  value: titleToReact(stat.value),
+  label: stat.label,
+}));
+const caseStudyActions = createElement(
+  ReactFragment,
+  null,
+  createElement(Button, { href: "/case-studies/rzest", variant: "solid-ink", icon: arrowRightIcon }, "Read the case study"),
+  createElement(Button, { href: "/case-studies", variant: "ghost" }, "View all case studies"),
+);
+
+const labTeaserTitleHtml = markupToHtml(home.labTeaserTitle);
+
+const blogTitle = titleToReact("From the *blog*");
+
+const ctaHeading = titleToReact(settings.ctaTitle);
+const ctaActions = createElement(
+  ReactFragment,
+  null,
+  createElement(Button, { href: "/services", variant: "solid-ink", icon: arrowRightIcon }, "View services"),
+  createElement(Button, { href: "/contact", variant: "ghost" }, "Get in touch"),
+);
 ---
 
 <Layout>
-	<div class="post-container">
-		{data.map((post: any) => (
-			<article>
-				<h2>{post.title}</h2>
-				<div set:html={post.content}></div>
-				<p>Status: {post._status}</p>
-				<p>Published at: {new Date(post._firstPublishedAt).toLocaleDateString()}</p>
-			</article>
-		))}
-	</div>
-</Layout>
+  <Container>
+    <Hero eyebrow={home.heroKicker} heading={heroHeading} body={home.heroBody} actions={heroActions} />
 
-<style>
-	.post-container {
-		padding: 16px;
-	}
-	article {
-		margin-bottom: 24px;
-		padding: 16px;
-		border: 1px solid #ccc;
-		border-radius: 8px;
-		background-color: #f8f8f8;
-	}
-</style>
+    <div class="hire-strip">
+      {home.hireStrip.map((item) => {
+        const Icon = hireStripIcons[item.iconKey];
+        return (
+          <div class="hire-strip__item">
+            <div class="hire-strip__icon">
+              <Icon />
+            </div>
+            <div class="hire-strip__title">{item.title}</div>
+            <p class="hire-strip__desc">{item.description}</p>
+          </div>
+        );
+      })}
+    </div>
+  </Container>
+
+  <section style={borderStyle}>
+    <Container>
+      <Section size="md">
+        <Stack gap={8}>
+          <SectionHeader title={builtTitle} meta="Building in the gaps" />
+          <Grid cols={3} gap={4}>
+            {personalProjectsData.map((project, i) => (
+              <ProjectCard
+                key={i}
+                eyebrow={project.eyebrow}
+                name={project.nameNode}
+                description={project.description}
+                tags={project.tags}
+                badge={project.badge}
+                accentColor={project.accentColor}
+                icon={project.iconNode}
+                jamaalIcon={project.jamaalIcon}
+                pricingPills={project.pricingPills}
+              />
+            ))}
+          </Grid>
+        </Stack>
+      </Section>
+    </Container>
+  </section>
+
+  <section style={borderStyle}>
+    <Container>
+      <Section size="md">
+        <Stack gap={8}>
+          <SectionHeader title={hireMeTitle} meta="Scoped in a proposal" />
+          <Card
+            className="svc-teaser"
+            style={{ padding: "var(--th-space-8)", borderRadius: "var(--th-radius-xl)" }}
+          >
+            <div>
+              <h3 class="svc-teaser__title" set:html={servicesTeaserTitleHtml} />
+              <p class="svc-teaser__desc">{home.servicesTeaserDesc}</p>
+              <Button href="/services" variant="solid-ink" icon={arrowRightIcon}>
+                See what's included
+              </Button>
+            </div>
+            <div class="svc-tiers">
+              {home.serviceTiers.map((tier) => (
+                <a class="svc-tier-row" href="/services">
+                  <span class="svc-tier-row__name">{tier.name}</span>
+                  <span class="svc-tier-row__price">{tier.price}</span>
+                </a>
+              ))}
+            </div>
+          </Card>
+        </Stack>
+      </Section>
+    </Container>
+  </section>
+
+  <section style={borderStyle}>
+    <Container>
+      <Section size="md">
+        <Stack gap={8}>
+          <SectionHeader title={caseStudiesTitle} meta="Client work outside EY" />
+          <CaseStudySpotlight
+            eyebrow={home.caseStudyEyebrow}
+            title={caseStudyTitle}
+            description={home.caseStudyDescription}
+            tags={home.caseStudyTags}
+            stats={caseStudyStatsData}
+            actions={caseStudyActions}
+          />
+        </Stack>
+      </Section>
+    </Container>
+  </section>
+
+  <section style={borderStyle}>
+    <Container>
+      <Section size="md">
+        <Card
+          style={{
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "space-between",
+            gap: "var(--th-space-8)",
+            flexWrap: "wrap",
+            padding: "var(--th-space-7) var(--th-space-8)",
+            borderRadius: "var(--th-radius-xl)",
+            borderStyle: "dashed",
+            borderColor: "var(--th-color-border-strong)",
+          }}
+        >
+          <div>
+            <div class="lab-teaser__eyebrow">{home.labTeaserEyebrow}</div>
+            <h3 class="lab-teaser__title" set:html={labTeaserTitleHtml} />
+            <p class="lab-teaser__desc">{home.labTeaserDesc}</p>
+          </div>
+          <Button href="/lab" variant="ghost" icon={arrowRightIcon}>
+            Visit the lab
+          </Button>
+        </Card>
+      </Section>
+    </Container>
+  </section>
+
+  <section style={borderStyle}>
+    <Container>
+      <Section size="md">
+        <Stack gap={6}>
+          <SectionHeader title={blogTitle} meta="Notes from the work" />
+          <div>
+            {home.essays.map((essay, i) => (
+              <EssayRow
+                key={i}
+                date={essay.date}
+                title={essay.title}
+                subtitle={essay.subtitle}
+                category={essay.category}
+                first={i === 0}
+                href="/blog/post"
+              />
+            ))}
+          </div>
+          <Button href="/blog" variant="ghost" icon={arrowRightIcon}>
+            Read the blog
+          </Button>
+        </Stack>
+      </Section>
+    </Container>
+  </section>
+
+  <Container>
+    <Section size="md">
+      <DarkStrip heading={ctaHeading} body={settings.ctaSubtitle} align="start" actions={ctaActions} />
+    </Section>
+  </Container>
+</Layout>

--- a/apps/fhdamd-web/src/styles/home.css
+++ b/apps/fhdamd-web/src/styles/home.css
@@ -7,7 +7,7 @@
   border: 1px solid var(--th-color-border-default);
   border-radius: var(--th-radius-lg);
   overflow: hidden;
-  margin-top: var(--th-space-10);
+  margin-block: var(--th-space-10) var(--th-space-12);
 }
 
 .hire-strip__item {

--- a/apps/fhdamd-web/src/styles/home.css
+++ b/apps/fhdamd-web/src/styles/home.css
@@ -1,0 +1,167 @@
+/* ─── HIRE STRIP ─────────────────────────────────────────────────────────── */
+.hire-strip {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 1px;
+  background: var(--th-color-border-default);
+  border: 1px solid var(--th-color-border-default);
+  border-radius: var(--th-radius-lg);
+  overflow: hidden;
+  margin-top: var(--th-space-10);
+}
+
+.hire-strip__item {
+  background: var(--th-color-bg);
+  padding: var(--th-space-6);
+}
+
+.hire-strip__icon {
+  width: 34px;
+  height: 34px;
+  border-radius: var(--th-radius-sm);
+  background: var(--th-color-surface-2);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  margin-bottom: var(--th-space-4);
+}
+
+.hire-strip__icon svg {
+  width: 16px;
+  height: 16px;
+  stroke: var(--th-color-text-2);
+  fill: none;
+  stroke-width: 1.6;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+}
+
+.hire-strip__title {
+  font-family: var(--th-font-serif);
+  font-weight: 400;
+  font-size: 1.0625rem;
+  color: var(--th-color-text-1);
+  margin-bottom: 6px;
+}
+
+.hire-strip__desc {
+  font-family: var(--th-font-display);
+  font-variation-settings: "wdth" 90, "wght" 370;
+  font-size: 0.8125rem;
+  line-height: 1.55;
+  color: var(--th-color-text-3);
+}
+
+@media (max-width: 800px) {
+  .hire-strip {
+    grid-template-columns: 1fr;
+  }
+}
+
+/* ─── SERVICES TEASER ────────────────────────────────────────────────────── */
+.svc-teaser__title {
+  font-family: var(--th-font-serif);
+  font-weight: 300;
+  font-size: clamp(1.5rem, 2.6vw, 2.125rem);
+  letter-spacing: -0.02em;
+  line-height: 1.1;
+  color: var(--th-color-text-1);
+  margin-bottom: var(--th-space-4);
+}
+
+.svc-teaser__title em {
+  font-style: italic;
+  color: var(--th-color-accent);
+}
+
+.svc-teaser__desc {
+  font-family: var(--th-font-display);
+  font-variation-settings: "wdth" 90, "wght" 370;
+  font-size: 0.9375rem;
+  line-height: 1.65;
+  color: var(--th-color-text-3);
+  margin-bottom: var(--th-space-5);
+  max-width: 480px;
+}
+
+.svc-tiers {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.svc-tier-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 14px 16px;
+  background: var(--th-color-bg);
+  border: 1px solid var(--th-color-border-default);
+  border-radius: var(--th-radius-md);
+  transition: border-color 0.14s, transform 0.14s;
+}
+
+.svc-tier-row:hover {
+  border-color: var(--th-color-border-strong);
+  transform: translateX(3px);
+}
+
+.svc-tier-row__name {
+  font-family: var(--th-font-display);
+  font-variation-settings: "wdth" 92, "wght" 600;
+  font-size: 0.875rem;
+  color: var(--th-color-text-1);
+}
+
+.svc-tier-row__price {
+  font-family: var(--th-font-mono);
+  font-size: 0.75rem;
+  color: var(--th-color-text-3);
+}
+
+/* Overrides Card's own flex column layout — inline style can't express the
+   mobile breakpoint below, so this needs to be a real class. */
+.svc-teaser {
+  display: grid;
+  grid-template-columns: 1.2fr 1fr;
+  gap: var(--th-space-10);
+  align-items: center;
+}
+
+@media (max-width: 900px) {
+  .svc-teaser {
+    grid-template-columns: 1fr;
+  }
+}
+
+/* ─── LAB TEASER ─────────────────────────────────────────────────────────── */
+.lab-teaser__eyebrow {
+  font-family: var(--th-font-mono);
+  font-size: 0.625rem;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--th-color-text-4);
+  margin-bottom: 8px;
+}
+
+.lab-teaser__title {
+  font-family: var(--th-font-serif);
+  font-weight: 300;
+  font-size: clamp(1.25rem, 2.2vw, 1.625rem);
+  letter-spacing: -0.015em;
+  color: var(--th-color-text-1);
+  margin-bottom: 8px;
+}
+
+.lab-teaser__title em {
+  font-style: italic;
+  color: var(--th-color-accent);
+}
+
+.lab-teaser__desc {
+  font-family: var(--th-font-display);
+  font-variation-settings: "wdth" 90, "wght" 370;
+  font-size: 0.875rem;
+  color: var(--th-color-text-3);
+  max-width: 480px;
+}

--- a/apps/fhdamd-web/src/utils/titleToReact.ts
+++ b/apps/fhdamd-web/src/utils/titleToReact.ts
@@ -13,3 +13,14 @@ export function titleToReact(text: string, emStyle?: CSSProperties): ReactNode {
     );
   return parts.length === 1 ? parts[0] : parts;
 }
+
+/**
+ * String-based sibling of titleToReact, for the rare case where the
+ * asterisk-marked text renders as plain Astro-template HTML (via set:html)
+ * rather than as a prop into a React component — a precomputed React
+ * element inserted as bare Astro children renders as "[object Object]"
+ * instead of being handed off to React, so this stays at the HTML level.
+ */
+export function markupToHtml(text: string): string {
+  return text.replace(/\*([^*]+)\*/g, "<em>$1</em>");
+}


### PR DESCRIPTION
## Summary
Third and largest page build following the pattern from #285/#294, replacing the leftover Astro-starter placeholder at `src/pages/index.astro` with the real homepage design.

- `src/content/types.ts` + `src/content/mock/homePage.ts` — new `HomePage` type covering the hero, "what I build" hire-strip, personal projects, services teaser, case study spotlight, lab teaser, and blog teaser essays. Reuses the existing `SiteSettings` type as-is for the CTA band (`ctaTitle`/`ctaSubtitle` already matched this section's copy verbatim) and availability pill.
- `src/lib/cms/index.ts` — adds `getHomePage()`.
- `src/pages/index.astro` — built almost entirely from existing Threads primitives: `Hero`, `Grid`, `ProjectCard`, `CaseStudySpotlight`, `EssayRow`, `DarkStrip`, `SectionHeader`, `AvailabilityPill`, `Button`. The hire-strip (bordered 3-tile info grid) and services/lab teaser boxes have no directly matching Threads component — checked `FactStrip` as a possible fit for the hire-strip, but it's shaped for compact label/value stat pairs, not icon+title+description tiles, so those two stay as `Card` reshaped via inline style, or plain custom markup, matching pdf-craft's own precedent for genuinely bespoke layout.

## Notable
- `utils/titleToReact.ts` gains `markupToHtml`: a couple of headings (services-teaser and lab-teaser titles) render as plain HTML rather than as a prop into a Threads component, and a precomputed React element inserted as bare Astro children renders as `[object Object]` — same underlying gotcha as the Contact page's checkmark icons, hit here from the opposite direction.
- Caught and fixed a real mobile bug in review: the services-teaser `Card`'s two-column layout was set via inline `style`, which can't express a media-query breakpoint — on mobile the tier-rows column overflowed off-screen instead of collapsing to one column. Moved that layout to a real CSS class (the one case in this PR where `className` on a Threads component is unavoidable, since inline style has no responsive equivalent).
- Added spacing after the hire-strip so it doesn't sit flush against the next section's border-top.

## Out of scope
Real DatoCMS wiring — deferred, same reasoning as #285/#294.

## Test plan
- [x] `pnpm --filter fhdamd-web build` succeeds (static output, 3 pages)
- [x] `pnpm --filter fhdamd-web exec tsc --noEmit` passes
- [x] `pnpm --filter fhdamd-web lint` passes
- [x] Verified visually via `astro dev` + Playwright against the source homepage design at desktop and mobile widths — layout, spacing, and every section (hero, hire-strip, projects, services teaser, case study, lab teaser, blog, CTA) match
- [x] Confirmed the services-teaser mobile-overflow fix and hire-strip spacing fix with before/after screenshots