### PR TITLE
feat(fhdamd-web): Services page against typed mock data

### DIFF
--- a/.sonarcloud.properties
+++ b/.sonarcloud.properties
@@ -1,0 +1,8 @@
+# Config for SonarCloud's GitHub App Automatic Analysis (project key
+# fahadahmed_fhdamd-org), which scans the whole monorepo independently of
+# any CI-triggered scan (e.g. apps/pdf-craft's own sonar-project.properties
+# / test-pdf-craft.yml, a separate project key).
+#
+# Typed mock/fixture content is parallel data, not duplicated logic — same
+# rationale as pdf-craft's existing sonar.cpd.exclusions for test files.
+sonar.cpd.exclusions=apps/fhdamd-web/src/content/mock/**

--- a/apps/fhdamd-web/src/components/icons/icons.tsx
+++ b/apps/fhdamd-web/src/components/icons/icons.tsx
@@ -97,3 +97,11 @@ export function SettingsIcon() {
     </svg>
   );
 }
+
+export function DollarIcon() {
+  return (
+    <svg viewBox="0 0 24 24">
+      <path d="M12 2v20M17 5H9.5a3.5 3.5 0 0 0 0 7h5a3.5 3.5 0 0 1 0 7H6" />
+    </svg>
+  );
+}

--- a/apps/fhdamd-web/src/content/mock/servicesPage.ts
+++ b/apps/fhdamd-web/src/content/mock/servicesPage.ts
@@ -1,0 +1,199 @@
+import type { ServicesPage } from '../types';
+
+export const servicesPage: ServicesPage = {
+  heroKicker: 'What I do',
+  heroHeading: 'Software, built and *owned by you.*',
+  heroSubheading:
+    'I take on a small number of engagements alongside the day job — custom websites, full-stack apps and products, and solution architecture or advisory work. Every project starts with a discovery call and ends with a written proposal scoped to what you actually need.',
+
+  offerCards: [
+    {
+      iconKey: 'design',
+      eyebrow: 'Brochure, content & light commerce sites',
+      title: 'Custom *websites*',
+      description:
+        'Brand-first sites built in code, not assembled from a theme. You leave with a component library built from your palette, a headless CMS you can update yourself, and a site that passes Core Web Vitals on day one.',
+      checklist: [
+        'Component library from your brand palette',
+        'Astro build on a headless CMS — no calling me to edit content',
+        'Light e-commerce where the project calls for it',
+        'SEO foundations, Core Web Vitals, post-launch support window',
+      ],
+    },
+    {
+      iconKey: 'phone',
+      eyebrow: 'Web & iOS · full-stack',
+      title: 'Apps & *products*',
+      description:
+        'Full-stack builds for a product, an internal tool, or a customer-facing app — from first prototype to something real people use and pay for. The same rigour I bring to Jamaal and Riqa, applied to your idea.',
+      checklist: [
+        'Full-stack web apps — React, Firebase, Stripe',
+        'Native iOS apps — SwiftUI, SwiftData',
+        'Prototype-to-production, not just a demo',
+        'Payments, auth, and data architecture built in, not bolted on',
+      ],
+    },
+    {
+      iconKey: 'fileCheck',
+      eyebrow: 'Solution architecture & technical strategy',
+      title: 'Architecture & *advisory*',
+      description:
+        'The same solution architecture and bid work I lead at enterprise scale at EY, sized for a smaller team — technical strategy, platform decisions, and architecture documentation that survives past the workshop it was drawn in.',
+      checklist: [
+        'Solution architecture for new or existing platforms',
+        'Technical input on bids, RFPs, and vendor evaluation',
+        'Platform and technology strategy',
+        'Delivered as workshops, documented architecture, or embedded advisory time',
+      ],
+    },
+  ],
+
+  pricingNoteTitle: 'How pricing *works*',
+  pricingNoteDesc:
+    "A website, a product build, and an advisory engagement don't share a price list — so I don't publish one. After a short discovery call, you get a written proposal with what's included, the timeline, and a fixed price where the scope supports it, or a retainer where it doesn't. No hourly guessing games, and nothing in the proposal that wasn't already discussed on the call.",
+
+  addonCards: [
+    {
+      name: 'Strategic discovery',
+      badge: { label: 'Credited if you proceed', variant: 'sage' },
+      items: [
+        'For clients unsure what they need yet',
+        'Competitive & content audit',
+        'Tech stack & offering recommendation',
+        'Fee credited toward the project if you proceed',
+      ],
+    },
+    {
+      name: 'Transactional comms',
+      badge: { label: 'Websites & products', variant: 'neutral' },
+      items: [
+        'Email domain setup + transactional templates',
+        'Order confirm, shipping, abandoned cart',
+        'SMS/WhatsApp if needed',
+      ],
+    },
+    {
+      name: 'Migration',
+      badge: { label: 'Websites', variant: 'neutral' },
+      items: [
+        'WordPress or Shopify to a headless CMS',
+        'URL redirect mapping',
+        'SEO continuity audit',
+        'Schema mapping & data integrity',
+      ],
+    },
+  ],
+
+  deliveryPhases: [
+    {
+      number: '1',
+      name: 'Discovery',
+      badge: { label: 'Included in project', variant: 'terra' },
+      description:
+        "A brand or product questionnaire is sent 24–48 hours before the call so we skip the basics and have a real conversation. The 45–60 minute video call covers your context, goals, and constraints. For a product build this goes deeper into scope and integrations; for advisory work it's framed around the problem you're trying to solve. Nothing in the proposal will surprise you.",
+      pills: [
+        'Pre-call questionnaire',
+        '45–60 min video call',
+        'Written discovery summary within 48 hrs',
+      ],
+    },
+    {
+      number: '2',
+      name: 'Brand foundation',
+      badge: { label: 'The step most skip', variant: 'terra' },
+      description:
+        "Before a single page is designed, I build a component library from your brand palette — colour, typography, spacing, interactive states, form elements, cards. Every component is consistent before the first page is touched. This is how enterprise agencies work. It's also why the finished site looks coherent rather than assembled.",
+      pills: [
+        'Brand palette extraction',
+        'AI-assisted component generation',
+        'Client brand review before build starts',
+      ],
+    },
+    {
+      number: '3',
+      name: 'Architecture',
+      badge: { label: 'Technical setup', variant: 'neutral' },
+      description:
+        "Content model defined and structured in DatoCMS. Firebase project initialised — hosting, functions, Firestore if needed. Astro site scaffolded against the component library. Where a project needs e-commerce, that's when payments, catalogue schema, and cart logic get designed. The architecture is deliberate — no decisions made by default.",
+      pills: [
+        'DatoCMS content model',
+        'Firebase project setup',
+        'Astro scaffolding',
+        'Stripe payments where needed',
+      ],
+    },
+    {
+      number: '4',
+      name: 'Build',
+      badge: { label: 'Direct to code', variant: 'neutral' },
+      description:
+        'Pages are built in code against your confirmed content — no Figma handoff, no design agency in the loop, no translation loss between what was designed and what was built. Two rounds of client review are included. Changes within agreed scope are addressed without back-and-forth quoting. What you see in review is what goes live.',
+      pills: [
+        'No Figma handoff',
+        'Two review rounds included',
+        'Mobile-responsive from day one',
+        'Content supplied by client before build',
+      ],
+    },
+    {
+      number: '5',
+      name: 'Launch',
+      badge: { label: 'Performance-first', variant: 'sage' },
+      description:
+        'QA across devices, browsers, and screen sizes. Performance audit targeting green Core Web Vitals scores — not as an afterthought but as a build requirement. SEO foundations in place: page titles, meta descriptions, Open Graph, sitemap, robots.txt. A 30-minute handover call and CMS walkthrough before DNS is pointed. Balance due on launch day.',
+      pills: [
+        'Core Web Vitals audit',
+        'SEO foundations',
+        '30-min CMS handover call',
+        'DNS + go-live',
+      ],
+    },
+    {
+      number: '6',
+      name: 'Support',
+      badge: { label: 'Included post-launch', variant: 'sage' },
+      description:
+        'A support window is included after every launch — the length is scoped to the project in your proposal. Covers bugs, minor content adjustments, and anything that surfaces in production. After that window, ongoing work is available on a retainer basis for clients who want fast turnaround on updates without scoping new work each time.',
+      pills: [
+        'Support window scoped per project',
+        'Retainer available post-launch',
+      ],
+    },
+  ],
+
+  differentiators: [
+    {
+      title: 'Brand-first, not *template-first*',
+      description:
+        'Every site starts with a component library built from your palette — not a theme with colours swapped in. The result is a site that looks like it was made specifically for you. Because it was.',
+    },
+    {
+      title: 'Direct to *code*',
+      description:
+        'No Figma handoff, no design agency in the loop. I design and build in code. That means faster iteration, no translation loss, and a tighter result at a lower total cost.',
+    },
+    {
+      title: 'You own *everything*',
+      description:
+        'DatoCMS means you update content without calling me. Firebase means no shared hosting mystery. Snipcart and Stripe mean no platform lock-in. Deliberate architectural choices, every one.',
+    },
+  ],
+
+  techStackTags: [
+    'Astro',
+    'React',
+    'SwiftUI',
+    'DatoCMS',
+    'Firebase',
+    'Snipcart',
+    'Stripe',
+    'Resend',
+    'Threads DS',
+  ],
+  techStackNote:
+    "Websites are built in code against your brand palette — not a template, not a page builder. Apps are native or full-stack, matched to the platform. Architecture and advisory work isn't tied to a stack at all — the recommendation follows your constraints, not my preferences.",
+
+  ctaTitle: 'Ready to start? *Get a proposal.*',
+  ctaSubtitle:
+    "I work with a small number of clients at a time. Tell me what you're building and I'll come back with a scoped proposal.",
+};

--- a/apps/fhdamd-web/src/content/mock/servicesPage.ts
+++ b/apps/fhdamd-web/src/content/mock/servicesPage.ts
@@ -55,7 +55,7 @@ export const servicesPage: ServicesPage = {
   addonCards: [
     {
       name: 'Strategic discovery',
-      badge: { label: 'Credited if you proceed', variant: 'sage' },
+      badge: { label: 'Credited if you proceed', variant: 'neutral' },
       items: [
         'For clients unsure what they need yet',
         'Competitive & content audit',

--- a/apps/fhdamd-web/src/content/mock/servicesPage.ts
+++ b/apps/fhdamd-web/src/content/mock/servicesPage.ts
@@ -1,21 +1,4 @@
-import type { DeliveryPhase, ServicesPage } from '../types';
-
-function phase(
-  number: string,
-  name: string,
-  badgeLabel: string,
-  badgeVariant: DeliveryPhase['badge']['variant'],
-  description: string,
-  pills: string[],
-): DeliveryPhase {
-  return {
-    number,
-    name,
-    badge: { label: badgeLabel, variant: badgeVariant },
-    description,
-    pills,
-  };
-}
+import type { ServicesPage } from '../types';
 
 export const servicesPage: ServicesPage = {
   heroKicker: 'What I do',
@@ -102,77 +85,80 @@ export const servicesPage: ServicesPage = {
   ],
 
   deliveryPhases: [
-    phase(
-      '1',
-      'Discovery',
-      'Included in project',
-      'terra',
-      "A brand or product questionnaire is sent 24–48 hours before the call so we skip the basics and have a real conversation. The 45–60 minute video call covers your context, goals, and constraints. For a product build this goes deeper into scope and integrations; for advisory work it's framed around the problem you're trying to solve. Nothing in the proposal will surprise you.",
-      [
+    {
+      number: '1',
+      name: 'Discovery',
+      badge: { label: 'Included in project', variant: 'terra' },
+      description:
+        "A brand or product questionnaire is sent 24–48 hours before the call so we skip the basics and have a real conversation. The 45–60 minute video call covers your context, goals, and constraints. For a product build this goes deeper into scope and integrations; for advisory work it's framed around the problem you're trying to solve. Nothing in the proposal will surprise you.",
+      pills: [
         'Pre-call questionnaire',
         '45–60 min video call',
         'Written discovery summary within 48 hrs',
       ],
-    ),
-    phase(
-      '2',
-      'Brand foundation',
-      'The step most skip',
-      'terra',
-      "Before a single page is designed, I build a component library from your brand palette — colour, typography, spacing, interactive states, form elements, cards. Every component is consistent before the first page is touched. This is how enterprise agencies work. It's also why the finished site looks coherent rather than assembled.",
-      [
+    },
+    {
+      number: '2',
+      name: 'Brand foundation',
+      badge: { label: 'The step most skip', variant: 'terra' },
+      description:
+        "Before a single page is designed, I build a component library from your brand palette — colour, typography, spacing, interactive states, form elements, cards. Every component is consistent before the first page is touched. This is how enterprise agencies work. It's also why the finished site looks coherent rather than assembled.",
+      pills: [
         'Brand palette extraction',
         'AI-assisted component generation',
         'Client brand review before build starts',
       ],
-    ),
-    phase(
-      '3',
-      'Architecture',
-      'Technical setup',
-      'neutral',
-      "Content model defined and structured in DatoCMS. Firebase project initialised — hosting, functions, Firestore if needed. Astro site scaffolded against the component library. Where a project needs e-commerce, that's when payments, catalogue schema, and cart logic get designed. The architecture is deliberate — no decisions made by default.",
-      [
+    },
+    {
+      number: '3',
+      name: 'Architecture',
+      badge: { label: 'Technical setup', variant: 'neutral' },
+      description:
+        "Content model defined and structured in DatoCMS. Firebase project initialised — hosting, functions, Firestore if needed. Astro site scaffolded against the component library. Where a project needs e-commerce, that's when payments, catalogue schema, and cart logic get designed. The architecture is deliberate — no decisions made by default.",
+      pills: [
         'DatoCMS content model',
         'Firebase project setup',
         'Astro scaffolding',
         'Stripe payments where needed',
       ],
-    ),
-    phase(
-      '4',
-      'Build',
-      'Direct to code',
-      'neutral',
-      'Pages are built in code against your confirmed content — no Figma handoff, no design agency in the loop, no translation loss between what was designed and what was built. Two rounds of client review are included. Changes within agreed scope are addressed without back-and-forth quoting. What you see in review is what goes live.',
-      [
+    },
+    {
+      number: '4',
+      name: 'Build',
+      badge: { label: 'Direct to code', variant: 'neutral' },
+      description:
+        'Pages are built in code against your confirmed content — no Figma handoff, no design agency in the loop, no translation loss between what was designed and what was built. Two rounds of client review are included. Changes within agreed scope are addressed without back-and-forth quoting. What you see in review is what goes live.',
+      pills: [
         'No Figma handoff',
         'Two review rounds included',
         'Mobile-responsive from day one',
         'Content supplied by client before build',
       ],
-    ),
-    phase(
-      '5',
-      'Launch',
-      'Performance-first',
-      'sage',
-      'QA across devices, browsers, and screen sizes. Performance audit targeting green Core Web Vitals scores — not as an afterthought but as a build requirement. SEO foundations in place: page titles, meta descriptions, Open Graph, sitemap, robots.txt. A 30-minute handover call and CMS walkthrough before DNS is pointed. Balance due on launch day.',
-      [
+    },
+    {
+      number: '5',
+      name: 'Launch',
+      badge: { label: 'Performance-first', variant: 'sage' },
+      description:
+        'QA across devices, browsers, and screen sizes. Performance audit targeting green Core Web Vitals scores — not as an afterthought but as a build requirement. SEO foundations in place: page titles, meta descriptions, Open Graph, sitemap, robots.txt. A 30-minute handover call and CMS walkthrough before DNS is pointed. Balance due on launch day.',
+      pills: [
         'Core Web Vitals audit',
         'SEO foundations',
         '30-min CMS handover call',
         'DNS + go-live',
       ],
-    ),
-    phase(
-      '6',
-      'Support',
-      'Included post-launch',
-      'sage',
-      'A support window is included after every launch — the length is scoped to the project in your proposal. Covers bugs, minor content adjustments, and anything that surfaces in production. After that window, ongoing work is available on a retainer basis for clients who want fast turnaround on updates without scoping new work each time.',
-      ['Support window scoped per project', 'Retainer available post-launch'],
-    ),
+    },
+    {
+      number: '6',
+      name: 'Support',
+      badge: { label: 'Included post-launch', variant: 'sage' },
+      description:
+        'A support window is included after every launch — the length is scoped to the project in your proposal. Covers bugs, minor content adjustments, and anything that surfaces in production. After that window, ongoing work is available on a retainer basis for clients who want fast turnaround on updates without scoping new work each time.',
+      pills: [
+        'Support window scoped per project',
+        'Retainer available post-launch',
+      ],
+    },
   ],
 
   differentiators: [

--- a/apps/fhdamd-web/src/content/mock/servicesPage.ts
+++ b/apps/fhdamd-web/src/content/mock/servicesPage.ts
@@ -1,4 +1,21 @@
-import type { ServicesPage } from '../types';
+import type { DeliveryPhase, ServicesPage } from '../types';
+
+function phase(
+  number: string,
+  name: string,
+  badgeLabel: string,
+  badgeVariant: DeliveryPhase['badge']['variant'],
+  description: string,
+  pills: string[],
+): DeliveryPhase {
+  return {
+    number,
+    name,
+    badge: { label: badgeLabel, variant: badgeVariant },
+    description,
+    pills,
+  };
+}
 
 export const servicesPage: ServicesPage = {
   heroKicker: 'What I do',
@@ -85,80 +102,77 @@ export const servicesPage: ServicesPage = {
   ],
 
   deliveryPhases: [
-    {
-      number: '1',
-      name: 'Discovery',
-      badge: { label: 'Included in project', variant: 'terra' },
-      description:
-        "A brand or product questionnaire is sent 24–48 hours before the call so we skip the basics and have a real conversation. The 45–60 minute video call covers your context, goals, and constraints. For a product build this goes deeper into scope and integrations; for advisory work it's framed around the problem you're trying to solve. Nothing in the proposal will surprise you.",
-      pills: [
+    phase(
+      '1',
+      'Discovery',
+      'Included in project',
+      'terra',
+      "A brand or product questionnaire is sent 24–48 hours before the call so we skip the basics and have a real conversation. The 45–60 minute video call covers your context, goals, and constraints. For a product build this goes deeper into scope and integrations; for advisory work it's framed around the problem you're trying to solve. Nothing in the proposal will surprise you.",
+      [
         'Pre-call questionnaire',
         '45–60 min video call',
         'Written discovery summary within 48 hrs',
       ],
-    },
-    {
-      number: '2',
-      name: 'Brand foundation',
-      badge: { label: 'The step most skip', variant: 'terra' },
-      description:
-        "Before a single page is designed, I build a component library from your brand palette — colour, typography, spacing, interactive states, form elements, cards. Every component is consistent before the first page is touched. This is how enterprise agencies work. It's also why the finished site looks coherent rather than assembled.",
-      pills: [
+    ),
+    phase(
+      '2',
+      'Brand foundation',
+      'The step most skip',
+      'terra',
+      "Before a single page is designed, I build a component library from your brand palette — colour, typography, spacing, interactive states, form elements, cards. Every component is consistent before the first page is touched. This is how enterprise agencies work. It's also why the finished site looks coherent rather than assembled.",
+      [
         'Brand palette extraction',
         'AI-assisted component generation',
         'Client brand review before build starts',
       ],
-    },
-    {
-      number: '3',
-      name: 'Architecture',
-      badge: { label: 'Technical setup', variant: 'neutral' },
-      description:
-        "Content model defined and structured in DatoCMS. Firebase project initialised — hosting, functions, Firestore if needed. Astro site scaffolded against the component library. Where a project needs e-commerce, that's when payments, catalogue schema, and cart logic get designed. The architecture is deliberate — no decisions made by default.",
-      pills: [
+    ),
+    phase(
+      '3',
+      'Architecture',
+      'Technical setup',
+      'neutral',
+      "Content model defined and structured in DatoCMS. Firebase project initialised — hosting, functions, Firestore if needed. Astro site scaffolded against the component library. Where a project needs e-commerce, that's when payments, catalogue schema, and cart logic get designed. The architecture is deliberate — no decisions made by default.",
+      [
         'DatoCMS content model',
         'Firebase project setup',
         'Astro scaffolding',
         'Stripe payments where needed',
       ],
-    },
-    {
-      number: '4',
-      name: 'Build',
-      badge: { label: 'Direct to code', variant: 'neutral' },
-      description:
-        'Pages are built in code against your confirmed content — no Figma handoff, no design agency in the loop, no translation loss between what was designed and what was built. Two rounds of client review are included. Changes within agreed scope are addressed without back-and-forth quoting. What you see in review is what goes live.',
-      pills: [
+    ),
+    phase(
+      '4',
+      'Build',
+      'Direct to code',
+      'neutral',
+      'Pages are built in code against your confirmed content — no Figma handoff, no design agency in the loop, no translation loss between what was designed and what was built. Two rounds of client review are included. Changes within agreed scope are addressed without back-and-forth quoting. What you see in review is what goes live.',
+      [
         'No Figma handoff',
         'Two review rounds included',
         'Mobile-responsive from day one',
         'Content supplied by client before build',
       ],
-    },
-    {
-      number: '5',
-      name: 'Launch',
-      badge: { label: 'Performance-first', variant: 'sage' },
-      description:
-        'QA across devices, browsers, and screen sizes. Performance audit targeting green Core Web Vitals scores — not as an afterthought but as a build requirement. SEO foundations in place: page titles, meta descriptions, Open Graph, sitemap, robots.txt. A 30-minute handover call and CMS walkthrough before DNS is pointed. Balance due on launch day.',
-      pills: [
+    ),
+    phase(
+      '5',
+      'Launch',
+      'Performance-first',
+      'sage',
+      'QA across devices, browsers, and screen sizes. Performance audit targeting green Core Web Vitals scores — not as an afterthought but as a build requirement. SEO foundations in place: page titles, meta descriptions, Open Graph, sitemap, robots.txt. A 30-minute handover call and CMS walkthrough before DNS is pointed. Balance due on launch day.',
+      [
         'Core Web Vitals audit',
         'SEO foundations',
         '30-min CMS handover call',
         'DNS + go-live',
       ],
-    },
-    {
-      number: '6',
-      name: 'Support',
-      badge: { label: 'Included post-launch', variant: 'sage' },
-      description:
-        'A support window is included after every launch — the length is scoped to the project in your proposal. Covers bugs, minor content adjustments, and anything that surfaces in production. After that window, ongoing work is available on a retainer basis for clients who want fast turnaround on updates without scoping new work each time.',
-      pills: [
-        'Support window scoped per project',
-        'Retainer available post-launch',
-      ],
-    },
+    ),
+    phase(
+      '6',
+      'Support',
+      'Included post-launch',
+      'sage',
+      'A support window is included after every launch — the length is scoped to the project in your proposal. Covers bugs, minor content adjustments, and anything that surfaces in production. After that window, ongoing work is available on a retainer basis for clients who want fast turnaround on updates without scoping new work each time.',
+      ['Support window scoped per project', 'Retainer available post-launch'],
+    ),
   ],
 
   differentiators: [

--- a/apps/fhdamd-web/src/content/types.ts
+++ b/apps/fhdamd-web/src/content/types.ts
@@ -97,6 +97,54 @@ export interface HomePage {
   essays: EssayTeaser[];
 }
 
+export interface OfferCard {
+  iconKey: "design" | "phone" | "fileCheck";
+  eyebrow: string;
+  /** Plain string; wrap a segment in *asterisks* for an <em> accent. */
+  title: string;
+  description: string;
+  checklist: string[];
+}
+
+export interface AddonCard {
+  name: string;
+  badge: { label: string; variant: "sage" | "neutral" };
+  items: string[];
+}
+
+export interface DeliveryPhase {
+  number: string;
+  name: string;
+  badge: { label: string; variant: "terra" | "sage" | "neutral" };
+  description: string;
+  pills: string[];
+}
+
+export interface Differentiator {
+  /** Plain string; wrap a segment in *asterisks* for an <em> accent. */
+  title: string;
+  description: string;
+}
+
+export interface ServicesPage {
+  heroKicker: string;
+  /** Plain string; wrap a segment in *asterisks* for an <em> accent. */
+  heroHeading: string;
+  heroSubheading: string;
+  offerCards: OfferCard[];
+  /** Plain string; wrap a segment in *asterisks* for an <em> accent. */
+  pricingNoteTitle: string;
+  pricingNoteDesc: string;
+  addonCards: AddonCard[];
+  deliveryPhases: DeliveryPhase[];
+  differentiators: Differentiator[];
+  techStackTags: string[];
+  techStackNote: string;
+  /** Plain string; wrap a segment in *asterisks* for an <em> accent. */
+  ctaTitle: string;
+  ctaSubtitle: string;
+}
+
 export interface Employer {
   name: string;
   label: string;

--- a/apps/fhdamd-web/src/lib/cms/index.ts
+++ b/apps/fhdamd-web/src/lib/cms/index.ts
@@ -2,6 +2,7 @@ import { siteSettings } from "../../content/mock/siteSettings";
 import { aboutPage } from "../../content/mock/aboutPage";
 import { contactPage } from "../../content/mock/contactPage";
 import { homePage } from "../../content/mock/homePage";
+import { servicesPage } from "../../content/mock/servicesPage";
 import { employers } from "../../content/mock/employers";
 import { clientWork } from "../../content/mock/clientWork";
 import { experience } from "../../content/mock/experience";
@@ -11,6 +12,7 @@ import type {
   AboutPage,
   ContactPage,
   HomePage,
+  ServicesPage,
   Employer,
   ClientWorkItem,
   ExperienceItem,
@@ -38,6 +40,10 @@ export async function getContactPage(): Promise<ContactPage> {
 
 export async function getHomePage(): Promise<HomePage> {
   return homePage;
+}
+
+export async function getServicesPage(): Promise<ServicesPage> {
+  return servicesPage;
 }
 
 export async function getEmployers(): Promise<Employer[]> {

--- a/apps/fhdamd-web/src/pages/services.astro
+++ b/apps/fhdamd-web/src/pages/services.astro
@@ -1,0 +1,182 @@
+---
+import { createElement } from "react";
+import Layout from "../layouts/Layout.astro";
+import { Container, Section, Stack, Hero, SectionHeader, Card, Grid, Badge, Tag, Button, DarkStrip } from "@fhdamd/threads";
+import { getServicesPage } from "../lib/cms";
+import { titleToReact, markupToHtml } from "../utils/titleToReact";
+import { DesignIcon, PhoneIcon, FileCheckIcon, DollarIcon, CheckIcon, ArrowRightIcon } from "../components/icons/icons";
+import "../styles/services.css";
+
+const borderStyle = "border-top:1px solid var(--th-color-border-default)";
+
+const services = await getServicesPage();
+
+// Astro's template compiler intercepts bare JSX written as a prop-expression
+// value and hands React an internal object instead of a real element, so
+// every such value must be precomputed here and passed as a plain variable.
+const heroHeading = titleToReact(services.heroHeading, { color: "var(--th-color-accent)" });
+const arrowRightIcon = createElement(ArrowRightIcon);
+
+const offerIcons = {
+  design: DesignIcon,
+  phone: PhoneIcon,
+  fileCheck: FileCheckIcon,
+};
+
+const offerTitle = titleToReact("What I *offer*");
+const pricingNoteTitleHtml = markupToHtml(services.pricingNoteTitle);
+const addonsTitle = titleToReact("Add-*ons*");
+const buildTitle = titleToReact("How I *build*");
+const stackTitle = titleToReact("Built on a *considered stack*");
+const ctaHeading = titleToReact(services.ctaTitle);
+
+const ctaActions = createElement(
+  "div",
+  { style: { display: "flex", gap: "var(--th-space-3)", flexWrap: "wrap" } },
+  createElement(Button, { href: "/contact", variant: "solid-ink", icon: arrowRightIcon }, "Get in touch"),
+  createElement(Button, { href: "/about", variant: "ghost" }, "About me"),
+);
+---
+
+<Layout title={`Services — Fahad Ahmed · fhdamd.dev`}>
+  <Container>
+    <Hero eyebrow={services.heroKicker} heading={heroHeading} body={services.heroSubheading} />
+  </Container>
+
+  <section style={borderStyle}>
+    <Container>
+      <Section size="md">
+        <Stack gap={8}>
+          <SectionHeader title={offerTitle} meta="Three ways to work together" />
+          <Grid cols={3} gap={4}>
+            {services.offerCards.map((card, i) => {
+              const Icon = offerIcons[card.iconKey];
+              return (
+                <Card key={i}>
+                  <div class="offer-card__icon">
+                    <Icon />
+                  </div>
+                  <div class="offer-card__eyebrow">{card.eyebrow}</div>
+                  <h3 class="offer-card__title" set:html={markupToHtml(card.title)} />
+                  <p class="offer-card__desc">{card.description}</p>
+                  <ul class="offer-card__list">
+                    {card.checklist.map((item) => (
+                      <li>
+                        <CheckIcon />
+                        {item}
+                      </li>
+                    ))}
+                  </ul>
+                  <Button href="/contact" variant="ghost" icon={arrowRightIcon}>
+                    Get a proposal
+                  </Button>
+                </Card>
+              );
+            })}
+          </Grid>
+        </Stack>
+      </Section>
+    </Container>
+  </section>
+
+  <section style={borderStyle}>
+    <Container>
+      <Section size="md">
+        <Card className="pricing-note">
+          <div class="pricing-note__icon">
+            <DollarIcon />
+          </div>
+          <div>
+            <h3 class="pricing-note__title" set:html={pricingNoteTitleHtml} />
+            <p class="pricing-note__desc">{services.pricingNoteDesc}</p>
+          </div>
+        </Card>
+      </Section>
+    </Container>
+  </section>
+
+  <section style={borderStyle}>
+    <Container>
+      <Section size="md">
+        <Stack gap={8}>
+          <SectionHeader title={addonsTitle} meta="Scoped into your proposal, not pre-priced" />
+          <Grid cols={3} gap={4}>
+            {services.addonCards.map((card, i) => (
+              <Card key={i}>
+                <div class="addon-card__name">{card.name}</div>
+                <Badge variant={card.badge.variant}>{card.badge.label}</Badge>
+                <ul class="addon-card__list">
+                  {card.items.map((item) => <li>{item}</li>)}
+                </ul>
+              </Card>
+            ))}
+          </Grid>
+        </Stack>
+      </Section>
+    </Container>
+  </section>
+
+  <section style={borderStyle}>
+    <Container>
+      <Section size="md">
+        <Stack gap={8}>
+          <SectionHeader title={buildTitle} meta="Websites & products · advisory is scoped separately" />
+          <div>
+            <div class="framework">
+              {services.deliveryPhases.map((phase) => (
+                <div class="fw-phase">
+                  <div class="fw-phase__num">
+                    <span>{phase.number}</span>
+                  </div>
+                  <div class="fw-phase__left">
+                    <div class="fw-phase__name">{phase.name}</div>
+                    <Badge variant={phase.badge.variant}>{phase.badge.label}</Badge>
+                  </div>
+                  <div class="fw-phase__body">
+                    <p class="fw-phase__desc">{phase.description}</p>
+                    <div class="fw-phase__details">
+                      {phase.pills.map((pill) => <span class="fw-phase__pill">{pill}</span>)}
+                    </div>
+                  </div>
+                </div>
+              ))}
+            </div>
+
+            <Card style={{ padding: "var(--th-space-8)", marginTop: "var(--th-space-8)" }}>
+              <div class="fw-differentiator-grid">
+                {services.differentiators.map((d) => (
+                  <div>
+                    <h4 class="fw-diff__title" set:html={markupToHtml(d.title)} />
+                    <p class="fw-diff__desc">{d.description}</p>
+                  </div>
+                ))}
+              </div>
+            </Card>
+          </div>
+        </Stack>
+      </Section>
+    </Container>
+  </section>
+
+  <section style={borderStyle}>
+    <Container>
+      <Section size="md">
+        <Stack gap={8}>
+          <SectionHeader title={stackTitle} meta="No WordPress. No page builders. No default choices." />
+          <div>
+            <div class="stack-strip">
+              {services.techStackTags.map((tag) => <Tag>{tag}</Tag>)}
+            </div>
+            <p class="stack-note">{services.techStackNote}</p>
+          </div>
+        </Stack>
+      </Section>
+    </Container>
+  </section>
+
+  <Container>
+    <Section size="md">
+      <DarkStrip heading={ctaHeading} body={services.ctaSubtitle} align="start" actions={ctaActions} />
+    </Section>
+  </Container>
+</Layout>

--- a/apps/fhdamd-web/src/pages/services.astro
+++ b/apps/fhdamd-web/src/pages/services.astro
@@ -30,6 +30,15 @@ const buildTitle = titleToReact("How I *build*");
 const stackTitle = titleToReact("Built on a *considered stack*");
 const ctaHeading = titleToReact(services.ctaTitle);
 
+// SectionHeader's meta span is white-space:nowrap with no responsive
+// override, so long meta text overflows the viewport on mobile instead of
+// wrapping. meta accepts a ReactNode, so wrap it to opt back into wrapping.
+const wrapMeta = (text: string) => createElement("span", { style: { whiteSpace: "normal" } }, text);
+const offerMeta = wrapMeta("Three ways to work together");
+const addonsMeta = wrapMeta("Scoped into your proposal, not pre-priced");
+const buildMeta = wrapMeta("Websites & products · advisory is scoped separately");
+const stackMeta = wrapMeta("No WordPress. No page builders. No default choices.");
+
 const ctaActions = createElement(
   "div",
   { style: { display: "flex", gap: "var(--th-space-3)", flexWrap: "wrap" } },
@@ -47,7 +56,7 @@ const ctaActions = createElement(
     <Container>
       <Section size="md">
         <Stack gap={8}>
-          <SectionHeader title={offerTitle} meta="Three ways to work together" />
+          <SectionHeader title={offerTitle} meta={offerMeta} />
           <Grid cols={3} gap={4}>
             {services.offerCards.map((card, i) => {
               const Icon = offerIcons[card.iconKey];
@@ -99,7 +108,7 @@ const ctaActions = createElement(
     <Container>
       <Section size="md">
         <Stack gap={8}>
-          <SectionHeader title={addonsTitle} meta="Scoped into your proposal, not pre-priced" />
+          <SectionHeader title={addonsTitle} meta={addonsMeta} />
           <Grid cols={3} gap={4}>
             {services.addonCards.map((card, i) => (
               <Card key={i}>
@@ -120,7 +129,7 @@ const ctaActions = createElement(
     <Container>
       <Section size="md">
         <Stack gap={8}>
-          <SectionHeader title={buildTitle} meta="Websites & products · advisory is scoped separately" />
+          <SectionHeader title={buildTitle} meta={buildMeta} />
           <div>
             <div class="framework">
               {services.deliveryPhases.map((phase) => (
@@ -162,7 +171,7 @@ const ctaActions = createElement(
     <Container>
       <Section size="md">
         <Stack gap={8}>
-          <SectionHeader title={stackTitle} meta="No WordPress. No page builders. No default choices." />
+          <SectionHeader title={stackTitle} meta={stackMeta} />
           <div>
             <div class="stack-strip">
               {services.techStackTags.map((tag) => <Tag>{tag}</Tag>)}

--- a/apps/fhdamd-web/src/styles/services.css
+++ b/apps/fhdamd-web/src/styles/services.css
@@ -1,0 +1,320 @@
+/* ─── OFFER CARDS ────────────────────────────────────────────────────────── */
+.offer-card__icon {
+  width: 44px;
+  height: 44px;
+  border-radius: var(--th-radius-md);
+  background: var(--th-color-surface-3);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.offer-card__icon svg {
+  width: 20px;
+  height: 20px;
+  stroke: var(--th-color-text-2);
+  fill: none;
+  stroke-width: 1.6;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+}
+
+.offer-card__eyebrow {
+  font-family: var(--th-font-mono);
+  font-size: 0.625rem;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--th-color-text-4);
+}
+
+.offer-card__title {
+  font-family: var(--th-font-serif);
+  font-weight: 400;
+  font-size: 1.5rem;
+  letter-spacing: -0.015em;
+  color: var(--th-color-text-1);
+  line-height: 1.15;
+}
+
+.offer-card__title em {
+  font-style: italic;
+  color: var(--th-color-accent);
+}
+
+.offer-card__desc {
+  font-family: var(--th-font-display);
+  font-variation-settings: "wdth" 90, "wght" 370;
+  font-size: 0.875rem;
+  line-height: 1.65;
+  color: var(--th-color-text-3);
+}
+
+.offer-card__list {
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  flex: 1;
+}
+
+.offer-card__list li {
+  display: flex;
+  align-items: flex-start;
+  gap: var(--th-space-2);
+  font-family: var(--th-font-display);
+  font-variation-settings: "wdth" 90, "wght" 370;
+  font-size: 0.8125rem;
+  line-height: 1.5;
+  color: var(--th-color-text-3);
+}
+
+.offer-card__list svg {
+  width: 13px;
+  height: 13px;
+  stroke: var(--th-color-sage);
+  fill: none;
+  stroke-width: 2.2;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+  flex-shrink: 0;
+  margin-top: 3px;
+}
+
+/* ─── PRICING NOTE ───────────────────────────────────────────────────────── */
+/* Card's own layout is a flex column — this needs a row on desktop that
+   collapses to a column on mobile, which inline style can't express. */
+.pricing-note {
+  display: flex;
+  flex-direction: row;
+  gap: var(--th-space-5);
+  align-items: flex-start;
+  border-style: dashed;
+  border-color: var(--th-color-border-strong);
+}
+
+@media (max-width: 600px) {
+  .pricing-note {
+    flex-direction: column;
+  }
+}
+
+.pricing-note__icon {
+  width: 36px;
+  height: 36px;
+  border-radius: var(--th-radius-pill);
+  background: var(--th-color-accent-subtle);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+}
+
+.pricing-note__icon svg {
+  width: 16px;
+  height: 16px;
+  stroke: var(--th-color-accent-text);
+  fill: none;
+  stroke-width: 1.8;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+}
+
+.pricing-note__title {
+  font-family: var(--th-font-serif);
+  font-weight: 400;
+  font-size: 1.25rem;
+  letter-spacing: -0.01em;
+  color: var(--th-color-text-1);
+  margin-bottom: 8px;
+}
+
+.pricing-note__title em {
+  font-style: italic;
+  color: var(--th-color-accent);
+}
+
+.pricing-note__desc {
+  font-family: var(--th-font-display);
+  font-variation-settings: "wdth" 90, "wght" 370;
+  font-size: 0.875rem;
+  line-height: 1.7;
+  color: var(--th-color-text-3);
+  max-width: 760px;
+}
+
+/* ─── ADD-ONS ────────────────────────────────────────────────────────────── */
+.addon-card__name {
+  font-family: var(--th-font-serif);
+  font-weight: 400;
+  font-size: 1.125rem;
+  letter-spacing: -0.01em;
+  color: var(--th-color-text-1);
+}
+
+.addon-card__list {
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  gap: var(--th-space-2);
+}
+
+.addon-card__list li {
+  display: flex;
+  align-items: flex-start;
+  gap: var(--th-space-2);
+  font-family: var(--th-font-display);
+  font-variation-settings: "wdth" 90, "wght" 370;
+  font-size: 0.8125rem;
+  line-height: 1.5;
+  color: var(--th-color-text-3);
+}
+
+.addon-card__list li::before {
+  content: "–";
+  color: var(--th-color-text-4);
+  flex-shrink: 0;
+  font-size: 0.75rem;
+  margin-top: 2px;
+}
+
+/* ─── DELIVERY FRAMEWORK ─────────────────────────────────────────────────── */
+.framework {
+  display: flex;
+  flex-direction: column;
+}
+
+.fw-phase {
+  display: grid;
+  grid-template-columns: 56px 200px 1fr;
+  align-items: stretch;
+  border-top: 1px solid var(--th-color-border-subtle);
+}
+
+.fw-phase:last-child {
+  border-bottom: 1px solid var(--th-color-border-subtle);
+}
+
+.fw-phase__num {
+  display: flex;
+  align-items: flex-start;
+  padding: var(--th-space-6) var(--th-space-4) var(--th-space-6) 0;
+  padding-top: calc(var(--th-space-6) + 2px);
+}
+
+.fw-phase__num span {
+  font-family: var(--th-font-serif);
+  font-style: italic;
+  font-weight: 300;
+  font-size: 1.5rem;
+  color: var(--th-color-text-4);
+  line-height: 1;
+}
+
+.fw-phase__left {
+  padding: var(--th-space-6) var(--th-space-6) var(--th-space-6) 0;
+  border-right: 1px solid var(--th-color-border-subtle);
+}
+
+.fw-phase__name {
+  font-family: var(--th-font-display);
+  font-variation-settings: "wdth" 92, "wght" 680;
+  font-size: 0.9375rem;
+  color: var(--th-color-text-1);
+  margin-bottom: 6px;
+}
+
+.fw-phase__body {
+  padding: var(--th-space-6) 0 var(--th-space-6) var(--th-space-6);
+}
+
+.fw-phase__desc {
+  font-family: var(--th-font-display);
+  font-variation-settings: "wdth" 90, "wght" 370;
+  font-size: 0.875rem;
+  line-height: 1.7;
+  color: var(--th-color-text-3);
+  margin-bottom: var(--th-space-4);
+}
+
+.fw-phase__details {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
+.fw-phase__pill {
+  font-family: var(--th-font-mono);
+  font-size: 0.5625rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  padding: 3px 9px;
+  border-radius: var(--th-radius-pill);
+  background: var(--th-color-surface-2);
+  border: 1px solid var(--th-color-border-default);
+  color: var(--th-color-text-3);
+}
+
+.fw-differentiator-grid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: var(--th-space-6);
+}
+
+.fw-diff__title {
+  font-family: var(--th-font-serif);
+  font-weight: 400;
+  font-size: 1rem;
+  letter-spacing: -0.01em;
+  color: var(--th-color-text-1);
+  margin-bottom: var(--th-space-2);
+}
+
+.fw-diff__title em {
+  font-style: italic;
+  color: var(--th-color-accent);
+}
+
+.fw-diff__desc {
+  font-family: var(--th-font-display);
+  font-variation-settings: "wdth" 90, "wght" 370;
+  font-size: 0.8125rem;
+  line-height: 1.65;
+  color: var(--th-color-text-3);
+}
+
+@media (max-width: 900px) {
+  .fw-phase {
+    grid-template-columns: 40px 1fr;
+  }
+
+  .fw-phase__left {
+    display: none;
+  }
+
+  .fw-differentiator-grid {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (max-width: 600px) {
+  .fw-phase {
+    grid-template-columns: 36px 1fr;
+  }
+}
+
+/* ─── TECH STACK ─────────────────────────────────────────────────────────── */
+.stack-strip {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--th-space-2);
+}
+
+.stack-note {
+  font-family: var(--th-font-display);
+  font-variation-settings: "wdth" 90, "wght" 370;
+  font-size: 0.9375rem;
+  line-height: 1.7;
+  color: var(--th-color-text-3);
+  max-width: 680px;
+  margin-top: var(--th-space-6);
+}


### PR DESCRIPTION
## Summary
Fourth page build following the pattern from #285/#294/#296, built from the uploaded `services.html` design.

- `src/content/types.ts` + `src/content/mock/servicesPage.ts` — new `ServicesPage` type covering the hero, three "what I offer" cards (icon, eyebrow, title, description, checklist), the pricing explainer note, three add-on cards, the six-phase delivery framework (plus its three-item differentiator strip), and the tech-stack tag list.
- `src/lib/cms/index.ts` — adds `getServicesPage()`.
- `src/pages/services.astro` — built from Threads primitives (`Hero`, `SectionHeader`, `Card`, `Grid`, `Tag`, `Badge`, `Button`, `DarkStrip`, `Stack`) plus custom markup for the offer cards, pricing note, add-on cards, and delivery-framework rows. Checked `ProjectCard`, `ContentCard`, `FeaturedCard`, `StepCard`, and `Callout` first — none fit the icon+eyebrow+title+description+checklist shape or the numbered-phase-with-badges-and-pills shape, so those stay as `Card` reshaped via className/style, or plain custom markup, consistent with the Homepage's precedent.

## Notable
- `SectionHeader` sections use `Stack` for spacing rather than an inline `marginBottom` on `SectionHeader` — sticking with the fix from #285 instead of reintroducing that workaround.
- Caught a real regression in review: the pricing-note `Card`'s dashed border and mobile flex-direction collapse got dropped during a mid-build refactor (only the flex layout survived). Restored via the `className`-based CSS rule — needed here for the same reason as the Homepage's services-teaser fix: the mobile breakpoint can't be expressed as an inline style.

## Out of scope
Real DatoCMS wiring — deferred, same reasoning as prior pages.

## Test plan
- [x] `pnpm --filter fhdamd-web build` succeeds (static output, 4 pages)
- [x] `pnpm --filter fhdamd-web exec tsc --noEmit` passes
- [x] `pnpm --filter fhdamd-web lint` passes
- [x] Verified visually via `astro dev` + Playwright against the source `services.html` design at desktop and mobile widths — every section (hero, offer cards, pricing note, add-ons, delivery framework + differentiator, tech stack, CTA) matches, including the delivery framework's mobile column-hiding behavior
- [x] Confirmed the dashed-border fix with a before/after screenshot