### PR TITLE
feat(fhdamd-web): Blog page against typed mock data

### DIFF
--- a/apps/fhdamd-web/src/components/PostGrid/PostGrid.tsx
+++ b/apps/fhdamd-web/src/components/PostGrid/PostGrid.tsx
@@ -1,0 +1,58 @@
+import { useMemo, useState } from "react";
+import { Stack, Grid, ContentCard, TagFilterBar, type BadgeVariant } from "@fhdamd/threads";
+import { titleToReact } from "../../utils/titleToReact";
+import type { BlogPost } from "../../content/types";
+
+const TAG_LABELS: Record<string, string> = {
+  dev: "Dev",
+  product: "Product",
+  design: "Design",
+  architecture: "Architecture",
+};
+
+const TAG_BADGE_VARIANT: Record<string, BadgeVariant> = {
+  dev: "neutral",
+  product: "terra",
+  design: "sage",
+  architecture: "neutral",
+};
+
+interface PostGridProps {
+  posts: BlogPost[];
+}
+
+/**
+ * Tag pills and grid share filter state, so both live in one island rather
+ * than two — TagFilterBar only reports the active tag via onChange, it
+ * doesn't touch the grid itself.
+ */
+export function PostGrid({ posts }: PostGridProps) {
+  const tagOptions = useMemo(() => {
+    const seen = new Set<string>();
+    posts.forEach((post) => post.tags.forEach((tag) => seen.add(tag)));
+    return Array.from(seen).map((value) => ({ value, label: TAG_LABELS[value] ?? value }));
+  }, [posts]);
+
+  const [activeTag, setActiveTag] = useState("all");
+  const visible = activeTag === "all" ? posts : posts.filter((post) => post.tags.includes(activeTag));
+
+  return (
+    <Stack gap={5}>
+      <TagFilterBar tags={tagOptions} allLabel="All posts" onChange={setActiveTag} />
+      <Grid cols={3} gap={4}>
+        {visible.map((post) => (
+          <ContentCard
+            key={post.slug}
+            href={`/blog/${post.slug}`}
+            date={post.date}
+            description={post.description}
+            title={titleToReact(post.title, { color: "var(--th-color-accent)" })}
+            badges={[
+              { label: TAG_LABELS[post.tags[0]] ?? post.tags[0], variant: TAG_BADGE_VARIANT[post.tags[0]] },
+            ]}
+          />
+        ))}
+      </Grid>
+    </Stack>
+  );
+}

--- a/apps/fhdamd-web/src/content/mock/blogPage.ts
+++ b/apps/fhdamd-web/src/content/mock/blogPage.ts
@@ -1,0 +1,63 @@
+import type { BlogPage } from '../types';
+
+export const blogPage: BlogPage = {
+  heroKicker: 'Blog',
+  heroHeading: 'Notes from the *work.*',
+  heroSubheading:
+    "Engineering tradeoffs, product decisions, and the occasional deep-dive into how a system is actually built — from client engagements at EY to shipping Jamaal and Riqa on nights and weekends.",
+
+  featuredPost: {
+    slug: 'sequence-diagram-you-can-trust',
+    title: 'Building a sequence diagram *you can trust*',
+    description:
+      "A walkthrough of how the Kindergarten Arrival Funding platform's prefill flow is documented — with Mermaid diagrams checked into the same repo as the code they describe, so the docs can't drift.",
+    date: 'July 2026',
+    readTime: '9 min read',
+    tags: ['dev', 'architecture'],
+  },
+
+  posts: [
+    {
+      slug: 'why-jamaal-has-no-subscription',
+      title: 'Why Jamaal has no *subscription*',
+      description: 'On pricing honestly and respecting the people who pay you.',
+      date: 'May 2026',
+      tags: ['product'],
+    },
+    {
+      slug: 'pay-per-use-is-underrated',
+      title: 'Pay-per-use is underrated for small SaaS',
+      description: 'What building Riqa taught me about pricing models.',
+      date: 'Apr 2026',
+      tags: ['product', 'dev'],
+    },
+    {
+      slug: 'one-design-system-four-platforms',
+      title: 'One design system for four platforms',
+      description: 'How Threads tokens survive iOS, macOS, web, and watchOS.',
+      date: 'Mar 2026',
+      tags: ['design'],
+    },
+    {
+      slug: 'deterministic-rules-before-a-model',
+      title: 'Deterministic rules before you reach for a model',
+      description: "Jamaal's rules engine — and why v1 has no ML at all.",
+      date: 'Jan 2026',
+      tags: ['dev', 'architecture'],
+    },
+    {
+      slug: 'swiftdata-after-six-months',
+      title: 'SwiftData after six months in production',
+      description: "The real-world gaps the WWDC sessions don't mention.",
+      date: 'Nov 2025',
+      tags: ['dev'],
+    },
+    {
+      slug: 'winning-a-bid-with-a-diagram',
+      title: 'Winning a $1.3M bid with a diagram',
+      description: 'What actually gets a solution architecture across the line.',
+      date: 'Sep 2025',
+      tags: ['architecture'],
+    },
+  ],
+};

--- a/apps/fhdamd-web/src/content/types.ts
+++ b/apps/fhdamd-web/src/content/types.ts
@@ -145,6 +145,29 @@ export interface ServicesPage {
   ctaSubtitle: string;
 }
 
+export interface BlogPost {
+  slug: string;
+  /** Plain string; wrap a segment in *asterisks* for an <em> accent. */
+  title: string;
+  description: string;
+  date: string;
+  /** First tag is the displayed badge; the full set drives tag-filter matching. */
+  tags: string[];
+}
+
+export interface FeaturedPost extends BlogPost {
+  readTime: string;
+}
+
+export interface BlogPage {
+  heroKicker: string;
+  /** Plain string; wrap a segment in *asterisks* for an <em> accent. */
+  heroHeading: string;
+  heroSubheading: string;
+  featuredPost: FeaturedPost;
+  posts: BlogPost[];
+}
+
 export interface Employer {
   name: string;
   label: string;

--- a/apps/fhdamd-web/src/lib/cms/index.ts
+++ b/apps/fhdamd-web/src/lib/cms/index.ts
@@ -3,6 +3,7 @@ import { aboutPage } from "../../content/mock/aboutPage";
 import { contactPage } from "../../content/mock/contactPage";
 import { homePage } from "../../content/mock/homePage";
 import { servicesPage } from "../../content/mock/servicesPage";
+import { blogPage } from "../../content/mock/blogPage";
 import { employers } from "../../content/mock/employers";
 import { clientWork } from "../../content/mock/clientWork";
 import { experience } from "../../content/mock/experience";
@@ -13,6 +14,7 @@ import type {
   ContactPage,
   HomePage,
   ServicesPage,
+  BlogPage,
   Employer,
   ClientWorkItem,
   ExperienceItem,
@@ -44,6 +46,10 @@ export async function getHomePage(): Promise<HomePage> {
 
 export async function getServicesPage(): Promise<ServicesPage> {
   return servicesPage;
+}
+
+export async function getBlogPage(): Promise<BlogPage> {
+  return blogPage;
 }
 
 export async function getEmployers(): Promise<Employer[]> {

--- a/apps/fhdamd-web/src/pages/blog/index.astro
+++ b/apps/fhdamd-web/src/pages/blog/index.astro
@@ -1,0 +1,60 @@
+---
+import { createElement, Fragment as ReactFragment } from "react";
+import Layout from "../../layouts/Layout.astro";
+import { Container, Section, Stack, Hero, FeaturedCard, Button, DarkStrip } from "@fhdamd/threads";
+import { getBlogPage, getSiteSettings } from "../../lib/cms";
+import { titleToReact } from "../../utils/titleToReact";
+import { ArrowRightIcon } from "../../components/icons/icons";
+import { PostGrid } from "../../components/PostGrid/PostGrid";
+
+const blog = await getBlogPage();
+const settings = await getSiteSettings();
+
+// Astro's template compiler intercepts bare JSX written as a prop-expression
+// value and hands React an internal object instead of a real element, so
+// every such value must be precomputed here and passed as a plain variable.
+const heroHeading = titleToReact(blog.heroHeading, { color: "var(--th-color-accent)" });
+const arrowRightIcon = createElement(ArrowRightIcon);
+const featuredTitle = titleToReact(blog.featuredPost.title, { color: "var(--th-color-accent)" });
+
+const featuredMetaBadges = blog.featuredPost.tags.map((tag) => ({
+  label: tag === "dev" ? "Dev" : tag === "architecture" ? "Architecture" : tag === "product" ? "Product" : "Design",
+  variant: "neutral" as const,
+}));
+
+const ctaHeading = titleToReact(settings.ctaTitle);
+const ctaActions = createElement(
+  ReactFragment,
+  null,
+  createElement(Button, { href: "/services", variant: "solid-ink", icon: arrowRightIcon }, "View services"),
+  createElement(Button, { href: "/contact", variant: "ghost" }, "Get in touch"),
+);
+---
+
+<Layout title={`Blog — Fahad Ahmed · fhdamd.dev`}>
+  <Container>
+    <Hero eyebrow={blog.heroKicker} heading={heroHeading} body={blog.heroSubheading} />
+  </Container>
+
+  <Container>
+    <Section size="md">
+      <Stack gap={8}>
+        <FeaturedCard
+          href={`/blog/${blog.featuredPost.slug}`}
+          eyebrowMeta={`${blog.featuredPost.date} · ${blog.featuredPost.readTime}`}
+          title={featuredTitle}
+          description={blog.featuredPost.description}
+          metaBadges={featuredMetaBadges}
+        />
+
+        <PostGrid client:load posts={blog.posts} />
+      </Stack>
+    </Section>
+  </Container>
+
+  <Container>
+    <Section size="md">
+      <DarkStrip heading={ctaHeading} body={settings.ctaSubtitle} align="start" actions={ctaActions} />
+    </Section>
+  </Container>
+</Layout>


### PR DESCRIPTION
Closes #301.

## Summary
- Fifth page build following the established pattern (typed mock data → `src/lib/cms` → Astro page from Threads components).
- Uses `FeaturedCard`, `ContentCard`, and `TagFilterBar` — already published in `@fhdamd/threads` 0.5.1 (built under #281) — no new Threads components needed.
- Tag filtering is real client-side interactivity, so it's a small React island (`PostGrid`, `client:load`) composing `TagFilterBar` + `Grid` + `ContentCard` with local filter state, matching the existing `ContactForm` island pattern.
- Tag pills are derived from the posts collection's distinct tags at render time, not hardcoded, per the tag-filtering decision in #264.
- Routed under `src/pages/blog/index.astro` (folder, not a flat `blog.astro`) so the upcoming `blog/[slug].astro` detail page (#283) sits alongside it — same convention planned for Case Studies and Lab.

## Note
While reviewing the CTA band, found that `Button`'s `ghost` variant is illegible on `DarkStrip`'s dark surface — a pre-existing Threads gap also present (unnoticed) on the already-merged Homepage and Services pages. Filed as #300 rather than patched here.

## Test plan
- [x] `pnpm --filter fhdamd-web build` succeeds
- [x] `astro check` / `tsc --noEmit` and `eslint` pass
- [x] Visual check against `blog.html` design (desktop + mobile) via Playwright screenshots
- [x] Tag filter pills correctly narrow the grid; featured post stays visible regardless of filter
- [x] No horizontal overflow on mobile (390px viewport)