### PR TITLE
feat(fhdamd-web): Blog post detail page against typed mock data

### DIFF
--- a/apps/fhdamd-web/package.json
+++ b/apps/fhdamd-web/package.json
@@ -14,8 +14,10 @@
     "@astrojs/react": "^6.0.1",
     "@fhdamd/threads": "^0.5.1",
     "astro": "^7.1.1",
+    "mermaid": "^11.16.0",
     "react": "^19.2.0",
-    "react-dom": "^19.2.0"
+    "react-dom": "^19.2.0",
+    "shiki": "^4.3.1"
   },
   "devDependencies": {
     "@fhdamd/tooling": "workspace:*",

--- a/apps/fhdamd-web/src/components/ArticleReadingProgress/ArticleReadingProgress.tsx
+++ b/apps/fhdamd-web/src/components/ArticleReadingProgress/ArticleReadingProgress.tsx
@@ -1,0 +1,24 @@
+import { useRef } from 'react';
+import { ReadingProgressBar } from '@fhdamd/threads';
+
+interface ArticleReadingProgressProps {
+  targetSelector: string;
+}
+
+/**
+ * ReadingProgressBar takes a RefObject to the tracked element, but that
+ * element is plain static Astro markup elsewhere on the page, not something
+ * this island renders — so the ref is resolved once via a DOM query rather
+ * than passed down from a parent. Safe to do during render (not an effect):
+ * the target already exists in the DOM by the time this island hydrates.
+ */
+export function ArticleReadingProgress({
+  targetSelector,
+}: ArticleReadingProgressProps) {
+  const targetRef = useRef<HTMLElement | null>(null);
+  if (targetRef.current === null && typeof document !== 'undefined') {
+    targetRef.current = document.querySelector<HTMLElement>(targetSelector);
+  }
+
+  return <ReadingProgressBar targetRef={targetRef} />;
+}

--- a/apps/fhdamd-web/src/components/CopyLinkButton/CopyLinkButton.tsx
+++ b/apps/fhdamd-web/src/components/CopyLinkButton/CopyLinkButton.tsx
@@ -1,0 +1,25 @@
+import { useState } from 'react';
+import { CheckIcon, LinkIcon } from '../icons/icons';
+
+export function CopyLinkButton() {
+  const [copied, setCopied] = useState(false);
+
+  const copy = () => {
+    navigator.clipboard.writeText(window.location.href).then(() => {
+      setCopied(true);
+      setTimeout(() => setCopied(false), 1600);
+    });
+  };
+
+  return (
+    <button
+      type="button"
+      className="share-btn"
+      aria-label="Copy link"
+      title="Copy link"
+      onClick={copy}
+    >
+      {copied ? <CheckIcon /> : <LinkIcon />}
+    </button>
+  );
+}

--- a/apps/fhdamd-web/src/components/MermaidDiagram/MermaidDiagram.tsx
+++ b/apps/fhdamd-web/src/components/MermaidDiagram/MermaidDiagram.tsx
@@ -1,0 +1,62 @@
+import { useEffect, useRef } from "react";
+
+interface MermaidDiagramProps {
+  id: string;
+  source: string;
+}
+
+/**
+ * MermaidDiagramCard (Threads) only provides the chrome — this renders the
+ * actual SVG client-side and re-renders on theme toggle, since Header's
+ * theme toggle just flips document.documentElement's data-theme attribute
+ * rather than dispatching an event.
+ */
+export function MermaidDiagram({ id, source }: MermaidDiagramProps) {
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    async function render() {
+      const { default: mermaid } = await import("mermaid");
+      const theme =
+        document.documentElement.dataset.theme === "dark" ? "dark" : "base";
+      mermaid.initialize({
+        startOnLoad: false,
+        theme,
+        fontFamily: "JetBrains Mono, monospace",
+      });
+      const { svg } = await mermaid.render(id, source);
+      if (!cancelled && containerRef.current) {
+        containerRef.current.innerHTML = svg;
+        // Mermaid sets a fixed width/height matching its own small intrinsic
+        // layout size — scale the (viewBox-based, so proportional) SVG up to
+        // fill the available card width instead of rendering it tiny.
+        const svgEl = containerRef.current.querySelector("svg");
+        if (svgEl) {
+          svgEl.removeAttribute("height");
+          svgEl.style.width = "100%";
+          svgEl.style.height = "auto";
+        }
+      }
+    }
+
+    render();
+
+    const observer = new MutationObserver(render);
+    observer.observe(document.documentElement, {
+      attributes: true,
+      attributeFilter: ["data-theme"],
+    });
+
+    return () => {
+      cancelled = true;
+      observer.disconnect();
+    };
+  }, [id, source]);
+
+  // A plain block, not flex: a flex container with justify-content:center
+  // sizes its item to content instead of letting width:100% (set on the
+  // rendered SVG above) actually fill the available width.
+  return <div ref={containerRef} style={{ width: "100%" }} />;
+}

--- a/apps/fhdamd-web/src/components/PostGrid/PostGrid.tsx
+++ b/apps/fhdamd-web/src/components/PostGrid/PostGrid.tsx
@@ -1,21 +1,8 @@
-import { useMemo, useState } from "react";
-import { Stack, Grid, ContentCard, TagFilterBar, type BadgeVariant } from "@fhdamd/threads";
-import { titleToReact } from "../../utils/titleToReact";
-import type { BlogPost } from "../../content/types";
-
-const TAG_LABELS: Record<string, string> = {
-  dev: "Dev",
-  product: "Product",
-  design: "Design",
-  architecture: "Architecture",
-};
-
-const TAG_BADGE_VARIANT: Record<string, BadgeVariant> = {
-  dev: "neutral",
-  product: "terra",
-  design: "sage",
-  architecture: "neutral",
-};
+import { useMemo, useState } from 'react';
+import { Stack, Grid, ContentCard, TagFilterBar } from '@fhdamd/threads';
+import { titleToReact } from '../../utils/titleToReact';
+import { BLOG_TAG_LABELS, BLOG_TAG_BADGE_VARIANT } from '../../utils/blogTags';
+import type { BlogPost } from '../../content/types';
 
 interface PostGridProps {
   posts: BlogPost[];
@@ -30,15 +17,25 @@ export function PostGrid({ posts }: PostGridProps) {
   const tagOptions = useMemo(() => {
     const seen = new Set<string>();
     posts.forEach((post) => post.tags.forEach((tag) => seen.add(tag)));
-    return Array.from(seen).map((value) => ({ value, label: TAG_LABELS[value] ?? value }));
+    return Array.from(seen).map((value) => ({
+      value,
+      label: BLOG_TAG_LABELS[value] ?? value,
+    }));
   }, [posts]);
 
-  const [activeTag, setActiveTag] = useState("all");
-  const visible = activeTag === "all" ? posts : posts.filter((post) => post.tags.includes(activeTag));
+  const [activeTag, setActiveTag] = useState('all');
+  const visible =
+    activeTag === 'all'
+      ? posts
+      : posts.filter((post) => post.tags.includes(activeTag));
 
   return (
     <Stack gap={5}>
-      <TagFilterBar tags={tagOptions} allLabel="All posts" onChange={setActiveTag} />
+      <TagFilterBar
+        tags={tagOptions}
+        allLabel="All posts"
+        onChange={setActiveTag}
+      />
       <Grid cols={3} gap={4}>
         {visible.map((post) => (
           <ContentCard
@@ -46,9 +43,14 @@ export function PostGrid({ posts }: PostGridProps) {
             href={`/blog/${post.slug}`}
             date={post.date}
             description={post.description}
-            title={titleToReact(post.title, { color: "var(--th-color-accent)" })}
+            title={titleToReact(post.title, {
+              color: 'var(--th-color-accent)',
+            })}
             badges={[
-              { label: TAG_LABELS[post.tags[0]] ?? post.tags[0], variant: TAG_BADGE_VARIANT[post.tags[0]] },
+              {
+                label: BLOG_TAG_LABELS[post.tags[0]] ?? post.tags[0],
+                variant: BLOG_TAG_BADGE_VARIANT[post.tags[0]],
+              },
             ]}
           />
         ))}

--- a/apps/fhdamd-web/src/components/icons/icons.tsx
+++ b/apps/fhdamd-web/src/components/icons/icons.tsx
@@ -1,6 +1,13 @@
 export function LocationIcon() {
   return (
-    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round">
+    <svg
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.8"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    >
       <path d="M21 10c0 7-9 13-9 13s-9-6-9-13a9 9 0 0 1 18 0z" />
       <circle cx="12" cy="10" r="3" />
     </svg>
@@ -9,7 +16,14 @@ export function LocationIcon() {
 
 export function BriefcaseIcon() {
   return (
-    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round">
+    <svg
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.8"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    >
       <rect x="2" y="7" width="20" height="14" rx="2" />
       <path d="M16 21V5a2 2 0 0 0-2-2h-4a2 2 0 0 0-2 2v16" />
     </svg>
@@ -18,7 +32,14 @@ export function BriefcaseIcon() {
 
 export function GithubIcon() {
   return (
-    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round">
+    <svg
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.8"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    >
       <path d="M9 19c-5 1.5-5-2.5-7-3m14 6v-3.87a3.37 3.37 0 0 0-.94-2.61c3.14-.35 6.44-1.54 6.44-7A5.44 5.44 0 0 0 20 4.77 5.07 5.07 0 0 0 19.91 1S18.73.65 16 2.48a13.38 13.38 0 0 0-7 0C6.27.65 5.09 1 5.09 1A5.07 5.07 0 0 0 5 4.77a5.44 5.44 0 0 0-1.5 3.78c0 5.42 3.3 6.61 6.44 7A3.37 3.37 0 0 0 9 18.13V22" />
     </svg>
   );
@@ -34,7 +55,14 @@ export function ArrowRightIcon() {
 
 export function MailIcon() {
   return (
-    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round">
+    <svg
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.8"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    >
       <path d="M4 4h16c1.1 0 2 .9 2 2v12c0 1.1-.9 2-2 2H4c-1.1 0-2-.9-2-2V6c0-1.1.9-2 2-2z" />
       <polyline points="22,6 12,13 2,6" />
     </svg>
@@ -102,6 +130,62 @@ export function DollarIcon() {
   return (
     <svg viewBox="0 0 24 24">
       <path d="M12 2v20M17 5H9.5a3.5 3.5 0 0 0 0 7h5a3.5 3.5 0 0 1 0 7H6" />
+    </svg>
+  );
+}
+
+export function TwitterIcon() {
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.8"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    >
+      <path d="M23 3a10.9 10.9 0 0 1-3.14 1.53 4.48 4.48 0 0 0-7.86 3v1A10.66 10.66 0 0 1 3 4s-4 9 5 13a11.64 11.64 0 0 1-7 2c9 5 20 0 20-11.5a4.5 4.5 0 0 0-.08-.83A7.72 7.72 0 0 0 23 3z" />
+    </svg>
+  );
+}
+
+export function LinkedInIcon() {
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.8"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    >
+      <path d="M16 8a6 6 0 0 1 6 6v7h-4v-7a2 2 0 0 0-2-2 2 2 0 0 0-2 2v7h-4v-7a6 6 0 0 1 6-6z" />
+      <rect x="2" y="9" width="4" height="12" />
+      <circle cx="4" cy="4" r="2" />
+    </svg>
+  );
+}
+
+export function LinkIcon() {
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.8"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    >
+      <path d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71" />
+      <path d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71" />
+    </svg>
+  );
+}
+
+export function StarIcon() {
+  return (
+    <svg viewBox="0 0 24 24">
+      <path d="M12 2l2.4 7.2H22l-6 4.4 2.3 7.1-6.3-4.5-6.3 4.5 2.3-7.1-6-4.4h7.6z" />
     </svg>
   );
 }

--- a/apps/fhdamd-web/src/content/mock/blogPostDetails.ts
+++ b/apps/fhdamd-web/src/content/mock/blogPostDetails.ts
@@ -1,0 +1,161 @@
+import type { BlogPostDetail } from '../types';
+
+export const blogPostDetails: BlogPostDetail[] = [
+  {
+    slug: 'sequence-diagram-you-can-trust',
+    breadcrumbCategory: 'Architecture',
+    badges: ['dev', 'architecture'],
+    title: 'Building a sequence diagram *you can trust*',
+    dek: "Docs rot the moment they're written down separately from the code. Here's how the prefill flow on a government platform is documented with Mermaid diagrams that live in the same repo — and the same pull request — as the code they describe.",
+    authorInitials: 'FA',
+    authorName: 'Fahad Ahmed',
+    authorRole: 'Solution Architect',
+    publishedDate: '14 Jul 2026',
+    readTime: '9 min read',
+    postTags: ['Architecture', 'Mermaid', 'Documentation', 'EY'],
+    relatedSlugs: [
+      'why-jamaal-has-no-subscription',
+      'deterministic-rules-before-a-model',
+      'winning-a-bid-with-a-diagram',
+    ],
+    body: [
+      { type: 'heading', id: 'problem', text: 'The problem with *docs*' },
+      {
+        type: 'html',
+        html: "<p>Every architecture diagram I've inherited on a client engagement has been wrong by the time I opened it. Not maliciously — just quietly out of date, drawn in a tool nobody on the delivery team has a licence for, exported once as a PNG, and never touched again. The system moved on. The picture didn't.</p><p>On the <b>Kindergarten Arrival Funding</b> platform, the prefill flow touches four services, two queues, and an external IBM ODM integration. A diagram that goes stale here doesn't just look bad in a wiki — it costs a new team member a day of tracing logs to rebuild a mental model that used to be free.</p><blockquote>If a diagram can't be reviewed in the same pull request as the code it describes, it will eventually lie to you.</blockquote>",
+      },
+      {
+        type: 'callout',
+        variant: 'tip',
+        title: 'Why this matters for client work',
+        body: 'Bid documentation with diagrams that survive past the bid win is one of the differentiators that actually gets referenced by the review panel — not just the fixed-price number.',
+      },
+      { type: 'heading', id: 'approach', text: 'Diagrams as *code*' },
+      {
+        type: 'html',
+        html: "<p>The fix is boring: write the diagram in text, check it into the same directory as the service it documents, and render it at build time. Mermaid is the format I've settled on — it's supported natively by GitHub and GitLab previews, and it renders identically whether you're looking at a PR or the published docs site.</p><p>Here's the flow definition that documents the prefill sequence. It lives at <code>docs/prefill-sequence.mmd</code>, next to the handler it describes:</p>",
+      },
+      {
+        type: 'code',
+        filename: 'prefill-handler.ts',
+        code: `import { PrefillClient } from './odm-client';
+import { QueueProducer } from './queue';
+
+// Triggered when a guardian submits the arrival funding form.
+// Runs the ODM ruleset, then queues the funding decision.
+export async function handlePrefillRequest(applicationId: string) {
+  const application = await getApplication(applicationId);
+  const decision = await PrefillClient.evaluate(application);
+
+  if (decision.status === 'approved') {
+    await QueueProducer.publish('funding.approved', {
+      applicationId,
+      amount: decision.amount,
+    });
+  }
+
+  return decision;
+}`,
+      },
+      {
+        type: 'html',
+        html: '<p>And the sequence diagram sitting right beside it, rendered from source rather than pasted as an image:</p>',
+      },
+      {
+        type: 'diagram',
+        label: 'Sequence diagram · Mermaid',
+        caption:
+          'Rendered live from the .mmd source at build time — no exported PNG to go stale',
+        source: `sequenceDiagram
+    accTitle: Prefill request sequence
+    accDescr: Guardian submits the funding form, which calls the prefill handler, which evaluates the application against IBM ODM and publishes an approval or returns a rejection reason.
+    participant G as Guardian
+    participant F as Funding Form
+    participant H as Prefill Handler
+    participant ODM as IBM ODM
+    participant Q as Queue
+
+    G->>F: Submit application
+    F->>H: handlePrefillRequest(id)
+    H->>ODM: evaluate(application)
+    ODM-->>H: decision
+    alt approved
+        H->>Q: publish(funding.approved)
+        Q-->>G: Confirmation email
+    else declined
+        H-->>F: Rejection reason
+    end`,
+      },
+      { type: 'heading', id: 'example', text: 'A worked *example*' },
+      {
+        type: 'html',
+        html: "<p>The same approach works for state and flow diagrams. Here's the funding application's lifecycle — useful for onboarding, and honest about the one state most diagrams quietly omit: the dead end.</p>",
+      },
+      {
+        type: 'diagram',
+        label: 'Flowchart · Mermaid',
+        source: `flowchart LR
+    accTitle: Funding application lifecycle
+    accDescr: An application moves from draft to submitted, then to an ODM decision that results in funded, rejected with an appeal window, or sent back for more information.
+    A[Draft] --> B[Submitted]
+    B --> C{ODM decision}
+    C -->|Approved| D[Funded]
+    C -->|Declined| E[Rejected]
+    C -->|Needs info| F[Awaiting docs]
+    F --> B
+    E --> G[Appeal window]
+    G -->|Upheld| D
+    G -->|Denied| H[Closed]`,
+      },
+      {
+        type: 'html',
+        html: '<p>A short clip from the internal walkthrough I recorded for the delivery team when this pattern was rolled out:</p>',
+      },
+      {
+        type: 'embed',
+        kind: 'youtube',
+        videoUrl: 'https://www.youtube.com/embed/dQw4w9WgXcQ',
+        title: 'YouTube video player',
+      },
+      {
+        type: 'html',
+        html: '<p>The pattern got a bit of attention when I wrote it up publicly:</p>',
+      },
+      {
+        type: 'embed',
+        kind: 'tweet',
+        authorName: 'Fahad Ahmed',
+        handle: '@fahadahmed · Jul 2026',
+        text: 'Checked-in Mermaid diagrams next to the code they describe. Docs review in the same PR as the change. No more architecture diagrams that lie to you six months later.',
+        foot: '142 reposts · 890 likes',
+      },
+      {
+        type: 'html',
+        html: '<p>And a look at the whiteboard session where the sequence above started life:</p>',
+      },
+      {
+        type: 'embed',
+        kind: 'instagram',
+        accountName: 'fhdamd.dev',
+        caption:
+          'Whiteboard session — the messy version before it became a Mermaid diagram.',
+      },
+      { type: 'heading', id: 'pitfalls', text: 'Where this breaks *down*' },
+      {
+        type: 'html',
+        html: "<p>Text-based diagrams aren't free. Mermaid's auto-layout struggles past roughly a dozen participants — beyond that, hand-tuned tools still win on readability. And a diagram checked into a repo is only as trustworthy as the review discipline around it; nothing stops it from going stale, it's just now a code review problem instead of a wiki problem, which in my experience is a discipline most engineering teams already have.</p>",
+      },
+      {
+        type: 'callout',
+        variant: 'warn',
+        title: "Don't diagram everything",
+        body: 'A sequence diagram for every function call is worse than no diagram at all — reserve it for flows that cross a service boundary, involve an external system, or trip people up in onboarding.',
+      },
+      { type: 'heading', id: 'takeaways', text: 'Takeaways' },
+      {
+        type: 'html',
+        html: "<ul><li>Keep diagrams as text, in the same repo as the code they describe.</li><li>Review diagram changes in the same pull request as the behaviour change.</li><li>Reserve diagrams for service boundaries and external integrations — not every function call.</li><li>Mermaid renders natively in GitHub/GitLab previews, so there's no extra tooling tax for reviewers.</li></ul>",
+      },
+    ],
+  },
+];

--- a/apps/fhdamd-web/src/content/types.ts
+++ b/apps/fhdamd-web/src/content/types.ts
@@ -168,6 +168,50 @@ export interface BlogPage {
   posts: BlogPost[];
 }
 
+export type BlogEmbed =
+  | { kind: "youtube"; videoUrl: string; title: string }
+  | {
+      kind: "tweet";
+      authorName: string;
+      handle: string;
+      text: string;
+      foot?: string;
+    }
+  | { kind: "instagram"; accountName: string; caption?: string };
+
+export type BlogContentBlock =
+  /** id must be unique on the page — TableOfContents links to it and scroll-spies it. */
+  | { type: "heading"; id: string; text: string }
+  | { type: "subheading"; id: string; text: string }
+  /** Raw HTML for a paragraph, blockquote, or list — rendered inside <Prose>, whose
+   *  descendant selectors style p/blockquote/ul/li/code/b regardless of wrapper depth. */
+  | { type: "html"; html: string }
+  | { type: "callout"; variant: "tip" | "warn"; title: string; body: string }
+  /** lang is a Shiki grammar name (e.g. "ts") — defaults to "ts" when unset. */
+  | { type: "code"; filename?: string; lang?: string; code: string }
+  /** source is raw Mermaid syntax, rendered client-side — see MermaidDiagram island. */
+  | { type: "diagram"; label: string; caption?: string; source: string }
+  | ({ type: "embed" } & BlogEmbed);
+
+export interface BlogPostDetail {
+  slug: string;
+  breadcrumbCategory: string;
+  badges: string[];
+  /** Plain string; wrap a segment in *asterisks* for an <em> accent. */
+  title: string;
+  dek: string;
+  authorInitials: string;
+  authorName: string;
+  /** Byline title, e.g. "Solution Architect" */
+  authorRole: string;
+  publishedDate: string;
+  readTime: string;
+  body: BlogContentBlock[];
+  postTags: string[];
+  /** Slugs into BlogPage's posts/featuredPost, for the related-posts grid. */
+  relatedSlugs: string[];
+}
+
 export interface Employer {
   name: string;
   label: string;

--- a/apps/fhdamd-web/src/lib/cms/index.ts
+++ b/apps/fhdamd-web/src/lib/cms/index.ts
@@ -1,13 +1,14 @@
-import { siteSettings } from "../../content/mock/siteSettings";
-import { aboutPage } from "../../content/mock/aboutPage";
-import { contactPage } from "../../content/mock/contactPage";
-import { homePage } from "../../content/mock/homePage";
-import { servicesPage } from "../../content/mock/servicesPage";
-import { blogPage } from "../../content/mock/blogPage";
-import { employers } from "../../content/mock/employers";
-import { clientWork } from "../../content/mock/clientWork";
-import { experience } from "../../content/mock/experience";
-import { skills } from "../../content/mock/skills";
+import { siteSettings } from '../../content/mock/siteSettings';
+import { aboutPage } from '../../content/mock/aboutPage';
+import { contactPage } from '../../content/mock/contactPage';
+import { homePage } from '../../content/mock/homePage';
+import { servicesPage } from '../../content/mock/servicesPage';
+import { blogPage } from '../../content/mock/blogPage';
+import { blogPostDetails } from '../../content/mock/blogPostDetails';
+import { employers } from '../../content/mock/employers';
+import { clientWork } from '../../content/mock/clientWork';
+import { experience } from '../../content/mock/experience';
+import { skills } from '../../content/mock/skills';
 import type {
   SiteSettings,
   AboutPage,
@@ -15,11 +16,12 @@ import type {
   HomePage,
   ServicesPage,
   BlogPage,
+  BlogPostDetail,
   Employer,
   ClientWorkItem,
   ExperienceItem,
   SkillCategory,
-} from "../../content/types";
+} from '../../content/types';
 
 /**
  * Thin data-access layer — one function per content type, each currently
@@ -50,6 +52,10 @@ export async function getServicesPage(): Promise<ServicesPage> {
 
 export async function getBlogPage(): Promise<BlogPage> {
   return blogPage;
+}
+
+export async function getBlogPostDetails(): Promise<BlogPostDetail[]> {
+  return blogPostDetails;
 }
 
 export async function getEmployers(): Promise<Employer[]> {

--- a/apps/fhdamd-web/src/pages/blog/[slug].astro
+++ b/apps/fhdamd-web/src/pages/blog/[slug].astro
@@ -1,0 +1,309 @@
+---
+import { createElement, Fragment as ReactFragment } from "react";
+import Layout from "../../layouts/Layout.astro";
+import {
+  Container,
+  Section,
+  Stack,
+  Cluster,
+  Grid,
+  Badge,
+  Tag,
+  Button,
+  DarkStrip,
+  Breadcrumb,
+  Prose,
+  CodeBlock,
+  MermaidDiagramCard,
+  EmbedCard,
+  TableOfContents,
+  Callout,
+  ContentCard,
+  SectionHeader,
+} from "@fhdamd/threads";
+import {
+  getBlogPostDetails,
+  getBlogPage,
+  getSiteSettings,
+} from "../../lib/cms";
+import { titleToReact, markupToHtml } from "../../utils/titleToReact";
+import { BLOG_TAG_LABELS, BLOG_TAG_BADGE_VARIANT } from "../../utils/blogTags";
+import {
+  ArrowRightIcon,
+  TwitterIcon,
+  LinkedInIcon,
+  StarIcon,
+} from "../../components/icons/icons";
+import { MermaidDiagram } from "../../components/MermaidDiagram/MermaidDiagram";
+import { ArticleReadingProgress } from "../../components/ArticleReadingProgress/ArticleReadingProgress";
+import { CopyLinkButton } from "../../components/CopyLinkButton/CopyLinkButton";
+import { highlightCode } from "../../utils/highlightCode";
+import type { BlogContentBlock } from "../../content/types";
+import "../../styles/blogPost.css";
+
+export async function getStaticPaths() {
+  const posts = await getBlogPostDetails();
+  return posts.map((post) => ({ params: { slug: post.slug } }));
+}
+
+const { slug } = Astro.params;
+const posts = await getBlogPostDetails();
+// getStaticPaths only generates a route per mock post above, so this is always found.
+const post = posts.find((p) => p.slug === slug)!;
+
+const blog = await getBlogPage();
+const settings = await getSiteSettings();
+
+const heroTitleHtml = markupToHtml(post.title);
+const arrowRightIcon = createElement(ArrowRightIcon);
+const starIcon = createElement(StarIcon);
+
+const breadcrumbItems = [
+  { label: "Blog", href: "/blog" },
+  { label: post.breadcrumbCategory },
+];
+
+const isHeading = (
+  block: BlogContentBlock,
+): block is Extract<BlogContentBlock, { type: "heading" }> =>
+  block.type === "heading";
+const tocItems = post.body
+  .filter(isHeading)
+  .map((block) => ({ id: block.id, label: block.text.replace(/\*/g, "") }));
+
+// Astro templates can't await inline, so every code block's syntax
+// highlighting is resolved up front here, keyed by its index in post.body.
+const highlightedCode = new Map<
+  number,
+  Awaited<ReturnType<typeof highlightCode>>
+>();
+for (let i = 0; i < post.body.length; i++) {
+  const block = post.body[i];
+  if (block.type === "code") {
+    highlightedCode.set(i, await highlightCode(block.code, block.lang ?? "ts"));
+  }
+}
+
+const allPosts = [blog.featuredPost, ...blog.posts];
+const relatedPosts = post.relatedSlugs
+  .map((relSlug) => allPosts.find((p) => p.slug === relSlug))
+  .filter((p): p is (typeof allPosts)[number] => Boolean(p));
+const relatedTitle = titleToReact("Related *posts*");
+
+const canonicalUrl = new URL(Astro.url.pathname, "https://fhdamd.dev").href;
+const shareText = encodeURIComponent(post.title.replace(/\*/g, ""));
+const twitterShareHref = `https://twitter.com/intent/tweet?text=${shareText}&url=${encodeURIComponent(canonicalUrl)}`;
+const linkedinShareHref = `https://www.linkedin.com/sharing/share-offsite/?url=${encodeURIComponent(canonicalUrl)}`;
+
+const ctaHeading = titleToReact(settings.ctaTitle);
+const ctaActions = createElement(
+  ReactFragment,
+  null,
+  createElement(
+    Button,
+    { href: "/services", variant: "solid-ink", icon: arrowRightIcon },
+    "View services",
+  ),
+  createElement(Button, { href: "/contact", variant: "ghost" }, "Get in touch"),
+);
+---
+
+<Layout
+  title={`${post.title.replace(/\*/g, "")} — Fahad Ahmed · fhdamd.dev`}
+  description={post.dek}
+>
+  <ArticleReadingProgress client:load targetSelector=".post-article" />
+
+  <Container>
+    <Stack gap={5} className="post-hero">
+      <Breadcrumb items={breadcrumbItems} />
+      <Cluster gap={2}>
+        {
+          post.badges.map((tag) => (
+            <Badge variant="neutral">{BLOG_TAG_LABELS[tag] ?? tag}</Badge>
+          ))
+        }
+      </Cluster>
+      <h1 class="post-hero__title" set:html={heroTitleHtml} />
+      <p class="post-hero__dek">{post.dek}</p>
+      <Cluster gap={3} className="post-byline">
+        <Cluster gap={2}>
+          <div class="post-byline__avatar">{post.authorInitials}</div>
+          <div>
+            <div class="post-byline__name">{post.authorName}</div>
+            <div class="post-byline__role">{post.authorRole}</div>
+          </div>
+        </Cluster>
+        <span class="post-byline__sep">·</span>
+        <span class="post-byline__item">{post.publishedDate}</span>
+        <span class="post-byline__sep">·</span>
+        <span class="post-byline__item">{post.readTime}</span>
+      </Cluster>
+    </Stack>
+  </Container>
+
+  <Container>
+    <div class="post-layout">
+      <TableOfContents client:load items={tocItems} />
+
+      <Prose className="post-article">
+        {
+          post.body.map((block, i) => {
+            if (block.type === "heading") {
+              return <h2 id={block.id} set:html={markupToHtml(block.text)} />;
+            }
+            if (block.type === "subheading") {
+              return <h3 id={block.id} set:html={markupToHtml(block.text)} />;
+            }
+            if (block.type === "html") {
+              return <Fragment set:html={block.html} />;
+            }
+            if (block.type === "callout") {
+              return (
+                <Callout
+                  variant={block.variant === "tip" ? "success" : "warning"}
+                  title={block.title}
+                  icon={block.variant === "tip" ? starIcon : undefined}
+                >
+                  {block.body}
+                </Callout>
+              );
+            }
+            if (block.type === "code") {
+              const tokenLines = highlightedCode.get(i) ?? [];
+              return (
+                <CodeBlock filename={block.filename}>
+                  {tokenLines.map((line, li) => (
+                    <Fragment key={li}>
+                      {line.map((token, ti) => (
+                        <span key={ti} style={{ color: token.color }}>
+                          {token.content}
+                        </span>
+                      ))}
+                      {li < tokenLines.length - 1 ? "\n" : null}
+                    </Fragment>
+                  ))}
+                </CodeBlock>
+              );
+            }
+            if (block.type === "diagram") {
+              return (
+                <MermaidDiagramCard
+                  label={block.label}
+                  caption={block.caption}
+                  className="mermaid-diagram-card"
+                >
+                  <MermaidDiagram
+                    client:load
+                    id={`diagram-${i}`}
+                    source={block.source}
+                  />
+                </MermaidDiagramCard>
+              );
+            }
+            if (block.kind === "youtube") {
+              return (
+                <EmbedCard
+                  type="youtube"
+                  videoUrl={block.videoUrl}
+                  title={block.title}
+                />
+              );
+            }
+            if (block.kind === "tweet") {
+              return (
+                <EmbedCard
+                  type="tweet"
+                  authorName={block.authorName}
+                  handle={block.handle}
+                  text={block.text}
+                  foot={block.foot}
+                />
+              );
+            }
+            return (
+              <EmbedCard
+                type="instagram"
+                accountName={block.accountName}
+                caption={block.caption}
+              />
+            );
+          })
+        }
+
+        <Cluster gap={4} justify="between" className="post-footer-meta">
+          <Cluster gap={2}>
+            {post.postTags.map((tag) => <Tag>{tag}</Tag>)}
+          </Cluster>
+          <Cluster gap={2}>
+            <a
+              class="share-btn"
+              href={twitterShareHref}
+              target="_blank"
+              rel="noopener noreferrer"
+              aria-label="Share on X"
+              title="Share on X"
+            >
+              <TwitterIcon />
+            </a>
+            <a
+              class="share-btn"
+              href={linkedinShareHref}
+              target="_blank"
+              rel="noopener noreferrer"
+              aria-label="Share on LinkedIn"
+              title="Share on LinkedIn"
+            >
+              <LinkedInIcon />
+            </a>
+            <CopyLinkButton client:load />
+          </Cluster>
+        </Cluster>
+      </Prose>
+    </div>
+  </Container>
+
+  {
+    relatedPosts.length > 0 && (
+      <section style="border-top:1px solid var(--th-color-border-default)">
+        <Container>
+          <Section size="md">
+            <Stack gap={8}>
+              <SectionHeader title={relatedTitle} meta="More from the blog" />
+              <Grid cols={3} gap={4}>
+                {relatedPosts.map((rp) => (
+                  <ContentCard
+                    key={rp.slug}
+                    href={`/blog/${rp.slug}`}
+                    date={rp.date}
+                    description={rp.description}
+                    title={titleToReact(rp.title, {
+                      color: "var(--th-color-accent)",
+                    })}
+                    badges={[
+                      {
+                        label: BLOG_TAG_LABELS[rp.tags[0]] ?? rp.tags[0],
+                        variant: BLOG_TAG_BADGE_VARIANT[rp.tags[0]],
+                      },
+                    ]}
+                  />
+                ))}
+              </Grid>
+            </Stack>
+          </Section>
+        </Container>
+      </section>
+    )
+  }
+
+  <Container>
+    <Section size="md">
+      <DarkStrip
+        heading={ctaHeading}
+        body={settings.ctaSubtitle}
+        align="start"
+        actions={ctaActions}
+      />
+    </Section>
+  </Container>
+</Layout>

--- a/apps/fhdamd-web/src/pages/blog/index.astro
+++ b/apps/fhdamd-web/src/pages/blog/index.astro
@@ -1,7 +1,15 @@
 ---
 import { createElement, Fragment as ReactFragment } from "react";
 import Layout from "../../layouts/Layout.astro";
-import { Container, Section, Stack, Hero, FeaturedCard, Button, DarkStrip } from "@fhdamd/threads";
+import {
+  Container,
+  Section,
+  Stack,
+  Hero,
+  FeaturedCard,
+  Button,
+  DarkStrip,
+} from "@fhdamd/threads";
 import { getBlogPage, getSiteSettings } from "../../lib/cms";
 import { titleToReact } from "../../utils/titleToReact";
 import { ArrowRightIcon } from "../../components/icons/icons";
@@ -13,12 +21,23 @@ const settings = await getSiteSettings();
 // Astro's template compiler intercepts bare JSX written as a prop-expression
 // value and hands React an internal object instead of a real element, so
 // every such value must be precomputed here and passed as a plain variable.
-const heroHeading = titleToReact(blog.heroHeading, { color: "var(--th-color-accent)" });
+const heroHeading = titleToReact(blog.heroHeading, {
+  color: "var(--th-color-accent)",
+});
 const arrowRightIcon = createElement(ArrowRightIcon);
-const featuredTitle = titleToReact(blog.featuredPost.title, { color: "var(--th-color-accent)" });
+const featuredTitle = titleToReact(blog.featuredPost.title, {
+  color: "var(--th-color-accent)",
+});
 
 const featuredMetaBadges = blog.featuredPost.tags.map((tag) => ({
-  label: tag === "dev" ? "Dev" : tag === "architecture" ? "Architecture" : tag === "product" ? "Product" : "Design",
+  label:
+    tag === "dev"
+      ? "Dev"
+      : tag === "architecture"
+        ? "Architecture"
+        : tag === "product"
+          ? "Product"
+          : "Design",
   variant: "neutral" as const,
 }));
 
@@ -26,14 +45,22 @@ const ctaHeading = titleToReact(settings.ctaTitle);
 const ctaActions = createElement(
   ReactFragment,
   null,
-  createElement(Button, { href: "/services", variant: "solid-ink", icon: arrowRightIcon }, "View services"),
+  createElement(
+    Button,
+    { href: "/services", variant: "solid-ink", icon: arrowRightIcon },
+    "View services",
+  ),
   createElement(Button, { href: "/contact", variant: "ghost" }, "Get in touch"),
 );
 ---
 
 <Layout title={`Blog — Fahad Ahmed · fhdamd.dev`}>
   <Container>
-    <Hero eyebrow={blog.heroKicker} heading={heroHeading} body={blog.heroSubheading} />
+    <Hero
+      eyebrow={blog.heroKicker}
+      heading={heroHeading}
+      body={blog.heroSubheading}
+    />
   </Container>
 
   <Container>
@@ -54,7 +81,12 @@ const ctaActions = createElement(
 
   <Container>
     <Section size="md">
-      <DarkStrip heading={ctaHeading} body={settings.ctaSubtitle} align="start" actions={ctaActions} />
+      <DarkStrip
+        heading={ctaHeading}
+        body={settings.ctaSubtitle}
+        align="start"
+        actions={ctaActions}
+      />
     </Section>
   </Container>
 </Layout>

--- a/apps/fhdamd-web/src/styles/blogPost.css
+++ b/apps/fhdamd-web/src/styles/blogPost.css
@@ -1,0 +1,152 @@
+/* ─── POST HERO ──────────────────────────────────────────────────────────── */
+/* Narrower than Container's own max-width and centered independently within
+   it — overrides Container's max-width via load order. */
+.post-hero {
+  max-width: 820px;
+  margin-inline: auto;
+  padding-top: 56px;
+}
+
+.post-hero__title {
+  font-family: var(--th-font-serif);
+  font-weight: 300;
+  font-size: clamp(1.875rem, 4.4vw, 3.375rem);
+  line-height: 1.05;
+  letter-spacing: -0.03em;
+  color: var(--th-color-text-1);
+}
+
+.post-hero__title em {
+  font-style: italic;
+  color: var(--th-color-accent);
+}
+
+.post-hero__dek {
+  font-family: var(--th-font-display);
+  font-variation-settings:
+    "wdth" 90,
+    "wght" 380;
+  font-size: 1.125rem;
+  line-height: 1.6;
+  color: var(--th-color-text-2);
+}
+
+/* Layout (display/gap/align) comes from the wrapping Cluster — this is just
+   the visual separator above the byline row. */
+.post-byline {
+  padding-top: var(--th-space-6);
+  border-top: 1px solid var(--th-color-border-subtle);
+}
+
+.post-byline__avatar {
+  width: 38px;
+  height: 38px;
+  border-radius: 99px;
+  background: var(--th-color-surface-3);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-family: var(--th-font-serif);
+  font-style: italic;
+  font-size: 1rem;
+  color: var(--th-color-text-2);
+  flex-shrink: 0;
+}
+
+.post-byline__name {
+  font-family: var(--th-font-display);
+  font-variation-settings:
+    "wdth" 92,
+    "wght" 600;
+  font-size: 0.875rem;
+  color: var(--th-color-text-1);
+}
+
+.post-byline__role {
+  font-family: var(--th-font-mono);
+  font-size: 0.6875rem;
+  color: var(--th-color-text-4);
+}
+
+.post-byline__sep {
+  color: var(--th-color-text-4);
+}
+
+.post-byline__item {
+  font-family: var(--th-font-mono);
+  font-size: 0.75rem;
+  color: var(--th-color-text-3);
+}
+
+/* ─── LAYOUT — TOC + article ─────────────────────────────────────────────── */
+.post-layout {
+  display: grid;
+  grid-template-columns: 200px 1fr;
+  gap: var(--th-space-10);
+  padding-bottom: var(--th-space-16);
+}
+
+/* Grid items default to min-width:auto, so a wide code block's <pre> (which
+   handles its own overflow-x) blows out the column instead of scrolling. */
+.post-layout > * {
+  min-width: 0;
+}
+
+@media (max-width: 900px) {
+  .post-layout {
+    grid-template-columns: 1fr;
+  }
+}
+
+/* TableOfContents' mobile bar is sticky at top:0 with no way to offset it via
+   a className prop (only the desktop <aside> forwards one) — it collides
+   with the site header, which is also sticky at top:0 with a higher z-index
+   and wins the stack, covering the bar. Override via its stable data-testid
+   instead, matching the header's real rendered height. */
+[data-testid="toc-mobile"] {
+  top: 59px;
+}
+
+/* Mermaid's rendered SVG is scaled up to fill the card (see MermaidDiagram),
+   so trim the card's own horizontal padding to give it more room to grow. */
+.mermaid-diagram-card {
+  padding-inline: var(--th-space-4);
+}
+
+/* ─── FOOTER META — share + tags ─────────────────────────────────────────── */
+/* Layout comes from the wrapping Cluster — this is just the separator. */
+.post-footer-meta {
+  margin-top: var(--th-space-10);
+  padding-top: var(--th-space-6);
+  border-top: 1px solid var(--th-color-border-subtle);
+}
+
+.share-btn {
+  width: 36px;
+  height: 36px;
+  border-radius: 99px;
+  border: 1px solid var(--th-color-border-default);
+  background: var(--th-color-surface-1);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+  transition: all 0.14s;
+  color: var(--th-color-text-3);
+}
+
+.share-btn:hover {
+  background: var(--th-color-text-1);
+  border-color: var(--th-color-text-1);
+  color: var(--th-color-text-inverse);
+}
+
+.share-btn svg {
+  width: 15px;
+  height: 15px;
+  stroke: currentColor;
+  fill: none;
+  stroke-width: 1.8;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+}

--- a/apps/fhdamd-web/src/utils/blogTags.ts
+++ b/apps/fhdamd-web/src/utils/blogTags.ts
@@ -1,0 +1,15 @@
+import type { BadgeVariant } from '@fhdamd/threads';
+
+export const BLOG_TAG_LABELS: Record<string, string> = {
+  dev: 'Dev',
+  product: 'Product',
+  design: 'Design',
+  architecture: 'Architecture',
+};
+
+export const BLOG_TAG_BADGE_VARIANT: Record<string, BadgeVariant> = {
+  dev: 'neutral',
+  product: 'terra',
+  design: 'sage',
+  architecture: 'neutral',
+};

--- a/apps/fhdamd-web/src/utils/highlightCode.ts
+++ b/apps/fhdamd-web/src/utils/highlightCode.ts
@@ -1,0 +1,21 @@
+import { codeToTokens, type BundledLanguage, type ThemedToken } from "shiki";
+
+/**
+ * CodeBlock (Threads) deliberately does no highlighting itself — it expects
+ * pre-highlighted content from the consuming app (its own doc comment
+ * suggests Shiki at build time). Returns raw tokens rather than precomputed
+ * React nodes: Astro can't safely hand a precomputed element/array off to a
+ * React component as bare children (renders as "[object Object]") — the JSX
+ * has to be built literally in the template's own .map(), not precomputed
+ * here, so this just does the async highlighting work Astro can't do inline.
+ */
+export async function highlightCode(
+  code: string,
+  lang: string,
+): Promise<ThemedToken[][]> {
+  const { tokens } = await codeToTokens(code, {
+    lang: lang as BundledLanguage,
+    theme: "github-dark",
+  });
+  return tokens;
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,16 +10,16 @@ importers:
     devDependencies:
       '@commitlint/cli':
         specifier: ^20.5.3
-        version: 20.5.3(@types/node@25.9.1)(conventional-commits-parser@6.4.0)(typescript@5.9.2)
+        version: 20.5.3(@types/node@26.1.1)(conventional-commits-parser@6.4.0)(typescript@5.9.2)
       '@commitlint/config-conventional':
         specifier: ^20.5.3
         version: 20.5.3
       commitizen:
         specifier: ^4.3.1
-        version: 4.3.1(@types/node@25.9.1)(typescript@5.9.2)
+        version: 4.3.1(@types/node@26.1.1)(typescript@5.9.2)
       cz-conventional-changelog:
         specifier: ^3.3.0
-        version: 3.3.0(@types/node@25.9.1)(typescript@5.9.2)
+        version: 3.3.0(@types/node@26.1.1)(typescript@5.9.2)
       husky:
         specifier: ^9.1.7
         version: 9.1.7
@@ -47,12 +47,18 @@ importers:
       astro:
         specifier: ^7.1.1
         version: 7.1.1(@emnapi/core@1.11.1)(@emnapi/runtime@1.11.1)(@types/node@26.1.1)(jiti@2.6.1)(rollup@4.60.4)(tsx@4.22.3)(yaml@2.9.0)
+      mermaid:
+        specifier: ^11.16.0
+        version: 11.16.0
       react:
         specifier: ^19.2.0
         version: 19.2.3
       react-dom:
         specifier: ^19.2.0
         version: 19.2.3(react@19.2.3)
+      shiki:
+        specifier: ^4.3.1
+        version: 4.3.1
     devDependencies:
       '@fhdamd/tooling':
         specifier: workspace:*
@@ -210,14 +216,14 @@ importers:
         version: 6.7.0
       stripe:
         specifier: ^20.0.0
-        version: 20.1.2(@types/node@26.1.1)
+        version: 20.1.2(@types/node@22.19.3)
       uuid:
         specifier: ^13.0.0
         version: 13.0.0
     devDependencies:
       firebase-functions-test:
         specifier: ^3.1.0
-        version: 3.4.1(firebase-admin@12.7.0)(firebase-functions@7.2.2(firebase-admin@12.7.0))(jest@30.2.0(@types/node@26.1.1)(esbuild-register@3.6.0(esbuild@0.28.0)))
+        version: 3.4.1(firebase-admin@12.7.0)(firebase-functions@7.2.2(firebase-admin@12.7.0))(jest@30.2.0(@types/node@22.19.3)(esbuild-register@3.6.0(esbuild@0.28.0)))
       typescript:
         specifier: ^5.7.3
         version: 5.9.2
@@ -375,6 +381,9 @@ packages:
   '@ampproject/remapping@2.3.0':
     resolution: {integrity: sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==}
     engines: {node: '>=6.0.0'}
+
+  '@antfu/install-pkg@1.1.0':
+    resolution: {integrity: sha512-MGQsmw10ZyI+EJo45CdSER4zEb+p31LpDAFp2Z3gkSd1yqVZGi0Ebx++YTEMonJy4oChEMLsxZ64j8FH6sSqtQ==}
 
   '@apphosting/astro-adapter@0.0.1':
     resolution: {integrity: sha512-+Js7HsJN1rl2hWEMlvivj0aavsjOtpa9kSuK22LkDolX0qDzdGGyCzb6BYj+zEtiYJtkQJx7JXE1DdFPWxPhmg==}
@@ -825,6 +834,9 @@ packages:
     resolution: {integrity: sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==}
     engines: {node: '>=18'}
 
+  '@braintree/sanitize-url@7.1.2':
+    resolution: {integrity: sha512-jigsZK+sMF/cuiB7sERuo9V7N9jx+dhmHHnQyDSVdpZwVutaBu7WvNYqMDLSgFgfB30n452TP3vjDAvFC973mA==}
+
   '@bramus/specificity@2.4.2':
     resolution: {integrity: sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==}
     hasBin: true
@@ -877,6 +889,9 @@ packages:
   '@capsizecss/unpack@4.0.0':
     resolution: {integrity: sha512-VERIM64vtTP1C4mxQ5thVT9fK0apjPFobqybMtA1UdUujWka24ERHbRHFGmpbbhp73MhV+KSsHQH9C6uOTdEQA==}
     engines: {node: '>=18'}
+
+  '@chevrotain/types@11.1.2':
+    resolution: {integrity: sha512-U+HFai5+zmJCkK86QsaJtoITlboZHBqrVketcO2ROv865xfCMSFpELQoz1GkX5GzME8pTa+3kbKrZHQtI0gdbw==}
 
   '@chromatic-com/storybook@5.2.1':
     resolution: {integrity: sha512-z6I7NJk/0VngA64y5TNYaB4Hc2X8+90n4op6lBt9PvWk5TmIlFLDqdX33rlrwbNRkkYijVgA/wO04rVYXi5Mlg==}
@@ -1925,6 +1940,12 @@ packages:
     resolution: {integrity: sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==}
     engines: {node: '>=18.18'}
 
+  '@iconify/types@2.0.0':
+    resolution: {integrity: sha512-+wluvCrRhXrhyOmRDJ3q8mux9JkKy5SJ/v8ol2tu4FVjyYvtEzkc/3pK15ET6RKg4b4w4BmTk1+gsCUhf21Ykg==}
+
+  '@iconify/utils@3.1.4':
+    resolution: {integrity: sha512-b1S7B1k9ohZ+iNTi2ATxbRYG9fTrJmUT0rc46bvVnNxqNRGW7dyo/vRREwyniI5IRN2RSJHDcm+s3BjWrSAjHw==}
+
   '@img/colour@1.1.0':
     resolution: {integrity: sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==}
     engines: {node: '>=18'}
@@ -2189,6 +2210,9 @@ packages:
     peerDependencies:
       '@types/react': '>=16'
       react: '>=16'
+
+  '@mermaid-js/parser@1.2.0':
+    resolution: {integrity: sha512-oYPyv8A4As1yH5Bx+04iQEQxXuIQDe0GKCNSRgao6z8AM9jixXIfP0vsppRLvGf+nKIOb9/LdpWA4YuJiVvESA==}
 
   '@microsoft/api-extractor-model@7.33.8':
     resolution: {integrity: sha512-aIcoQggPyer3B6Ze3usz0YWC/oBwUHfRH5ETUsr+oT2BRA6SfTJl7IKPcPZkX4UR+PohowzW4uMxsvjrn8vm+w==}
@@ -3343,6 +3367,99 @@ packages:
   '@types/cors@2.8.19':
     resolution: {integrity: sha512-mFNylyeyqN93lfe/9CSxOGREz8cpzAhH+E93xJ4xWQf62V8sQ/24reV2nyzUWM6H6Xji+GGHpkbLe7pVoUEskg==}
 
+  '@types/d3-array@3.2.2':
+    resolution: {integrity: sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==}
+
+  '@types/d3-axis@3.0.6':
+    resolution: {integrity: sha512-pYeijfZuBd87T0hGn0FO1vQ/cgLk6E1ALJjfkC0oJ8cbwkZl3TpgS8bVBLZN+2jjGgg38epgxb2zmoGtSfvgMw==}
+
+  '@types/d3-brush@3.0.6':
+    resolution: {integrity: sha512-nH60IZNNxEcrh6L1ZSMNA28rj27ut/2ZmI3r96Zd+1jrZD++zD3LsMIjWlvg4AYrHn/Pqz4CF3veCxGjtbqt7A==}
+
+  '@types/d3-chord@3.0.6':
+    resolution: {integrity: sha512-LFYWWd8nwfwEmTZG9PfQxd17HbNPksHBiJHaKuY1XeqscXacsS2tyoo6OdRsjf+NQYeB6XrNL3a25E3gH69lcg==}
+
+  '@types/d3-color@3.1.3':
+    resolution: {integrity: sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==}
+
+  '@types/d3-contour@3.0.6':
+    resolution: {integrity: sha512-BjzLgXGnCWjUSYGfH1cpdo41/hgdWETu4YxpezoztawmqsvCeep+8QGfiY6YbDvfgHz/DkjeIkkZVJavB4a3rg==}
+
+  '@types/d3-delaunay@6.0.4':
+    resolution: {integrity: sha512-ZMaSKu4THYCU6sV64Lhg6qjf1orxBthaC161plr5KuPHo3CNm8DTHiLw/5Eq2b6TsNP0W0iJrUOFscY6Q450Hw==}
+
+  '@types/d3-dispatch@3.0.7':
+    resolution: {integrity: sha512-5o9OIAdKkhN1QItV2oqaE5KMIiXAvDWBDPrD85e58Qlz1c1kI/J0NcqbEG88CoTwJrYe7ntUCVfeUl2UJKbWgA==}
+
+  '@types/d3-drag@3.0.7':
+    resolution: {integrity: sha512-HE3jVKlzU9AaMazNufooRJ5ZpWmLIoc90A37WU2JMmeq28w1FQqCZswHZ3xR+SuxYftzHq6WU6KJHvqxKzTxxQ==}
+
+  '@types/d3-dsv@3.0.7':
+    resolution: {integrity: sha512-n6QBF9/+XASqcKK6waudgL0pf/S5XHPPI8APyMLLUHd8NqouBGLsU8MgtO7NINGtPBtk9Kko/W4ea0oAspwh9g==}
+
+  '@types/d3-ease@3.0.2':
+    resolution: {integrity: sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==}
+
+  '@types/d3-fetch@3.0.7':
+    resolution: {integrity: sha512-fTAfNmxSb9SOWNB9IoG5c8Hg6R+AzUHDRlsXsDZsNp6sxAEOP0tkP3gKkNSO/qmHPoBFTxNrjDprVHDQDvo5aA==}
+
+  '@types/d3-force@3.0.10':
+    resolution: {integrity: sha512-ZYeSaCF3p73RdOKcjj+swRlZfnYpK1EbaDiYICEEp5Q6sUiqFaFQ9qgoshp5CzIyyb/yD09kD9o2zEltCexlgw==}
+
+  '@types/d3-format@3.0.4':
+    resolution: {integrity: sha512-fALi2aI6shfg7vM5KiR1wNJnZ7r6UuggVqtDA+xiEdPZQwy/trcQaHnwShLuLdta2rTymCNpxYTiMZX/e09F4g==}
+
+  '@types/d3-geo@3.1.0':
+    resolution: {integrity: sha512-856sckF0oP/diXtS4jNsiQw/UuK5fQG8l/a9VVLeSouf1/PPbBE1i1W852zVwKwYCBkFJJB7nCFTbk6UMEXBOQ==}
+
+  '@types/d3-hierarchy@3.1.7':
+    resolution: {integrity: sha512-tJFtNoYBtRtkNysX1Xq4sxtjK8YgoWUNpIiUee0/jHGRwqvzYxkq0hGVbbOGSz+JgFxxRu4K8nb3YpG3CMARtg==}
+
+  '@types/d3-interpolate@3.0.4':
+    resolution: {integrity: sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==}
+
+  '@types/d3-path@3.1.1':
+    resolution: {integrity: sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==}
+
+  '@types/d3-polygon@3.0.2':
+    resolution: {integrity: sha512-ZuWOtMaHCkN9xoeEMr1ubW2nGWsp4nIql+OPQRstu4ypeZ+zk3YKqQT0CXVe/PYqrKpZAi+J9mTs05TKwjXSRA==}
+
+  '@types/d3-quadtree@3.0.6':
+    resolution: {integrity: sha512-oUzyO1/Zm6rsxKRHA1vH0NEDG58HrT5icx/azi9MF1TWdtttWl0UIUsjEQBBh+SIkrpd21ZjEv7ptxWys1ncsg==}
+
+  '@types/d3-random@3.0.4':
+    resolution: {integrity: sha512-UHYId5WTCx4L4YNel7NU00XUXXgvgpgZOvp10PuvsQENjMDXhh2RyFc0KBjO7B45ne4Ha1yVH7ii0vnzKkuzWA==}
+
+  '@types/d3-scale-chromatic@3.1.0':
+    resolution: {integrity: sha512-iWMJgwkK7yTRmWqRB5plb1kadXyQ5Sj8V/zYlFGMUBbIPKQScw+Dku9cAAMgJG+z5GYDoMjWGLVOvjghDEFnKQ==}
+
+  '@types/d3-scale@4.0.9':
+    resolution: {integrity: sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==}
+
+  '@types/d3-selection@3.0.11':
+    resolution: {integrity: sha512-bhAXu23DJWsrI45xafYpkQ4NtcKMwWnAC/vKrd2l+nxMFuvOT3XMYTIj2opv8vq8AO5Yh7Qac/nSeP/3zjTK0w==}
+
+  '@types/d3-shape@3.1.8':
+    resolution: {integrity: sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w==}
+
+  '@types/d3-time-format@4.0.3':
+    resolution: {integrity: sha512-5xg9rC+wWL8kdDj153qZcsJ0FWiFt0J5RB6LYUNZjwSnesfblqrI/bJ1wBdJ8OQfncgbJG5+2F+qfqnqyzYxyg==}
+
+  '@types/d3-time@3.0.4':
+    resolution: {integrity: sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==}
+
+  '@types/d3-timer@3.0.2':
+    resolution: {integrity: sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==}
+
+  '@types/d3-transition@3.0.9':
+    resolution: {integrity: sha512-uZS5shfxzO3rGlu0cC3bjmMFKsXv+SmZZcgp0KD22ts4uGXp5EVYGzu/0YdwZeKmddhcAccYtREJKkPfXkZuCg==}
+
+  '@types/d3-zoom@3.0.8':
+    resolution: {integrity: sha512-iqMC4/YlFCSlO8+2Ii1GGGliCAY4XdeG748w5vQUbevlbDu0zSjH/+jojorQVBK/se0j6DUFNPBGSqD3YWYnDw==}
+
+  '@types/d3@7.4.3':
+    resolution: {integrity: sha512-lZXZ9ckh5R8uiFVt8ogUNf+pIrK4EsWrx2Np75WvF/eTpJ0FMHNhjXk8CKEx/+gpHbNQyJWehbFaTvqmHWB3ww==}
+
   '@types/debug@4.1.13':
     resolution: {integrity: sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw==}
 
@@ -3366,6 +3483,9 @@ packages:
 
   '@types/express@4.17.25':
     resolution: {integrity: sha512-dVd04UKsfpINUnK0yBoYHDF3xu7xVH4BuDotC/xGuycx4CgbP48X/KF/586bcObxT0HENHXEU8Nqtu6NR+eKhw==}
+
+  '@types/geojson@7946.0.16':
+    resolution: {integrity: sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg==}
 
   '@types/hast@3.0.4':
     resolution: {integrity: sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==}
@@ -3425,9 +3545,6 @@ packages:
   '@types/node@24.13.3':
     resolution: {integrity: sha512-Dh8vAsV36ig5wa9OX4pXvMc9D3Veibfw2wix0CUwYODLD8nkj9UsLjASr49nPg+2eKzxhBV+v7L8pXvT4e639Q==}
 
-  '@types/node@25.9.1':
-    resolution: {integrity: sha512-xfrlY7UD5rMJk3ZVJP8BNzS28J36YJg+xp+LPXV1TdWxr8uMH5A860QNxYDGQe/ylDSgjxE52Q9VnO7p75tJxg==}
-
   '@types/node@26.1.1':
     resolution: {integrity: sha512-nxAkRSVkN1Y0JC1W8ky/fTfkGsMmcrRsbx+3XoZE+rMOX71kLYTV7fLXpqud1GpbpP5TuffXFqfX7fH2GgZREw==}
 
@@ -3479,6 +3596,9 @@ packages:
 
   '@types/tough-cookie@4.0.5':
     resolution: {integrity: sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA==}
+
+  '@types/trusted-types@2.0.7':
+    resolution: {integrity: sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==}
 
   '@types/unist@3.0.3':
     resolution: {integrity: sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==}
@@ -3722,6 +3842,9 @@ packages:
     resolution: {integrity: sha512-nAB74NfSNKknqQ1RrYj6uz8FcXEomu/MATJZxh/x+BArzN2U3JbOYC0APYzUIGhVY3m5hRxA8VPNdPBoG8txlA==}
     cpu: [x64]
     os: [win32]
+
+  '@upsetjs/venn.js@2.0.0':
+    resolution: {integrity: sha512-WbBhLrooyePuQ1VZxrJjtLvTc4NVfpOyKx0sKqioq9bX1C1m7Jgykkn8gLrtwumBioXIqam8DLxp88Adbue6Hw==}
 
   '@vitejs/plugin-react@4.7.0':
     resolution: {integrity: sha512-gUu9hwfWvvEDBBmgtAowQCojwZmJ5mcLn3aufeCsitijs3+f2NsrPtlAWIR6OPiqljl96GVCUbLe0HyqIpVaoA==}
@@ -4433,6 +4556,14 @@ packages:
     resolution: {integrity: sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==}
     engines: {node: '>=20'}
 
+  commander@7.2.0:
+    resolution: {integrity: sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==}
+    engines: {node: '>= 10'}
+
+  commander@8.3.0:
+    resolution: {integrity: sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==}
+    engines: {node: '>= 12'}
+
   commitizen@4.3.1:
     resolution: {integrity: sha512-gwAPAVTy/j5YcOOebcCRIijn+mSjWJC+IYKivTu6aG8Ei/scoXgfsMRnuAk6b0GRste2J4NGxVdMN3ZpfNaVaw==}
     engines: {node: '>= 12'}
@@ -4516,6 +4647,12 @@ packages:
     resolution: {integrity: sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==}
     engines: {node: '>= 0.10'}
 
+  cose-base@1.0.3:
+    resolution: {integrity: sha512-s9whTXInMSgAp/NVXVNuVxVKzGH2qck3aQlVHxDCdAEPgtMKwc4Wq6/QKhgdEdgbLSi9rBTAcPoRa6JpiG4ksg==}
+
+  cose-base@2.2.0:
+    resolution: {integrity: sha512-AzlgcsCbUMymkADOJtQm3wO9S3ltPfYOFD5033keQn9NJzIbtnZj+UdBJe7DYml/8TdbtHJW3j58SOnKhWY/5g==}
+
   cosmiconfig-typescript-loader@6.3.0:
     resolution: {integrity: sha512-Akr82WH1Wfqatyiqpj8HDkO2o2KmJRu1FhKfSNJP3K4IdXwHfEyL7MOb62i1AGQVLtIQM+iCE9CGOtrfhR+mmA==}
     engines: {node: '>=v18'}
@@ -4570,9 +4707,165 @@ packages:
   csstype@3.2.3:
     resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
 
+  cytoscape-cose-bilkent@4.1.0:
+    resolution: {integrity: sha512-wgQlVIUJF13Quxiv5e1gstZ08rnZj2XaLHGoFMYXz7SkNfCDOOteKBE6SYRfA9WxxI/iBc3ajfDoc6hb/MRAHQ==}
+    peerDependencies:
+      cytoscape: ^3.2.0
+
+  cytoscape-fcose@2.2.0:
+    resolution: {integrity: sha512-ki1/VuRIHFCzxWNrsshHYPs6L7TvLu3DL+TyIGEsRcvVERmxokbf5Gdk7mFxZnTdiGtnA4cfSmjZJMviqSuZrQ==}
+    peerDependencies:
+      cytoscape: ^3.2.0
+
+  cytoscape@3.34.0:
+    resolution: {integrity: sha512-62rNSrioXw93uliKFBwjukeQyeWwH2PqDrTac31r2P6464u3AUvTk0xS4LVvT251g7IgkFunrI48ZEZGjywSOg==}
+    engines: {node: '>=0.10'}
+
   cz-conventional-changelog@3.3.0:
     resolution: {integrity: sha512-U466fIzU5U22eES5lTNiNbZ+d8dfcHcssH4o7QsdWaCcRs/feIPCxKYSWkYBNs5mny7MvEfwpTLWjvbm94hecw==}
     engines: {node: '>= 10'}
+
+  d3-array@2.12.1:
+    resolution: {integrity: sha512-B0ErZK/66mHtEsR1TkPEEkwdy+WDesimkM5gpZr5Dsg54BiTA5RXtYW5qTLIAcekaS9xfZrzBLF/OAkB3Qn1YQ==}
+
+  d3-array@3.2.4:
+    resolution: {integrity: sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==}
+    engines: {node: '>=12'}
+
+  d3-axis@3.0.0:
+    resolution: {integrity: sha512-IH5tgjV4jE/GhHkRV0HiVYPDtvfjHQlQfJHs0usq7M30XcSBvOotpmH1IgkcXsO/5gEQZD43B//fc7SRT5S+xw==}
+    engines: {node: '>=12'}
+
+  d3-brush@3.0.0:
+    resolution: {integrity: sha512-ALnjWlVYkXsVIGlOsuWH1+3udkYFI48Ljihfnh8FZPF2QS9o+PzGLBslO0PjzVoHLZ2KCVgAM8NVkXPJB2aNnQ==}
+    engines: {node: '>=12'}
+
+  d3-chord@3.0.1:
+    resolution: {integrity: sha512-VE5S6TNa+j8msksl7HwjxMHDM2yNK3XCkusIlpX5kwauBfXuyLAtNg9jCp/iHH61tgI4sb6R/EIMWCqEIdjT/g==}
+    engines: {node: '>=12'}
+
+  d3-color@3.1.0:
+    resolution: {integrity: sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==}
+    engines: {node: '>=12'}
+
+  d3-contour@4.0.2:
+    resolution: {integrity: sha512-4EzFTRIikzs47RGmdxbeUvLWtGedDUNkTcmzoeyg4sP/dvCexO47AaQL7VKy/gul85TOxw+IBgA8US2xwbToNA==}
+    engines: {node: '>=12'}
+
+  d3-delaunay@6.0.4:
+    resolution: {integrity: sha512-mdjtIZ1XLAM8bm/hx3WwjfHt6Sggek7qH043O8KEjDXN40xi3vx/6pYSVTwLjEgiXQTbvaouWKynLBiUZ6SK6A==}
+    engines: {node: '>=12'}
+
+  d3-dispatch@3.0.1:
+    resolution: {integrity: sha512-rzUyPU/S7rwUflMyLc1ETDeBj0NRuHKKAcvukozwhshr6g6c5d8zh4c2gQjY2bZ0dXeGLWc1PF174P2tVvKhfg==}
+    engines: {node: '>=12'}
+
+  d3-drag@3.0.0:
+    resolution: {integrity: sha512-pWbUJLdETVA8lQNJecMxoXfH6x+mO2UQo8rSmZ+QqxcbyA3hfeprFgIT//HW2nlHChWeIIMwS2Fq+gEARkhTkg==}
+    engines: {node: '>=12'}
+
+  d3-dsv@3.0.1:
+    resolution: {integrity: sha512-UG6OvdI5afDIFP9w4G0mNq50dSOsXHJaRE8arAS5o9ApWnIElp8GZw1Dun8vP8OyHOZ/QJUKUJwxiiCCnUwm+Q==}
+    engines: {node: '>=12'}
+    hasBin: true
+
+  d3-ease@3.0.1:
+    resolution: {integrity: sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==}
+    engines: {node: '>=12'}
+
+  d3-fetch@3.0.1:
+    resolution: {integrity: sha512-kpkQIM20n3oLVBKGg6oHrUchHM3xODkTzjMoj7aWQFq5QEM+R6E4WkzT5+tojDY7yjez8KgCBRoj4aEr99Fdqw==}
+    engines: {node: '>=12'}
+
+  d3-force@3.0.0:
+    resolution: {integrity: sha512-zxV/SsA+U4yte8051P4ECydjD/S+qeYtnaIyAs9tgHCqfguma/aAQDjo85A9Z6EKhBirHRJHXIgJUlffT4wdLg==}
+    engines: {node: '>=12'}
+
+  d3-format@3.1.2:
+    resolution: {integrity: sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg==}
+    engines: {node: '>=12'}
+
+  d3-geo@3.1.1:
+    resolution: {integrity: sha512-637ln3gXKXOwhalDzinUgY83KzNWZRKbYubaG+fGVuc/dxO64RRljtCTnf5ecMyE1RIdtqpkVcq0IbtU2S8j2Q==}
+    engines: {node: '>=12'}
+
+  d3-hierarchy@3.1.2:
+    resolution: {integrity: sha512-FX/9frcub54beBdugHjDCdikxThEqjnR93Qt7PvQTOHxyiNCAlvMrHhclk3cD5VeAaq9fxmfRp+CnWw9rEMBuA==}
+    engines: {node: '>=12'}
+
+  d3-interpolate@3.0.1:
+    resolution: {integrity: sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==}
+    engines: {node: '>=12'}
+
+  d3-path@1.0.9:
+    resolution: {integrity: sha512-VLaYcn81dtHVTjEHd8B+pbe9yHWpXKZUC87PzoFmsFrJqgFwDe/qxfp5MlfsfM1V5E/iVt0MmEbWQ7FVIXh/bg==}
+
+  d3-path@3.1.0:
+    resolution: {integrity: sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==}
+    engines: {node: '>=12'}
+
+  d3-polygon@3.0.1:
+    resolution: {integrity: sha512-3vbA7vXYwfe1SYhED++fPUQlWSYTTGmFmQiany/gdbiWgU/iEyQzyymwL9SkJjFFuCS4902BSzewVGsHHmHtXg==}
+    engines: {node: '>=12'}
+
+  d3-quadtree@3.0.1:
+    resolution: {integrity: sha512-04xDrxQTDTCFwP5H6hRhsRcb9xxv2RzkcsygFzmkSIOJy3PeRJP7sNk3VRIbKXcog561P9oU0/rVH6vDROAgUw==}
+    engines: {node: '>=12'}
+
+  d3-random@3.0.1:
+    resolution: {integrity: sha512-FXMe9GfxTxqd5D6jFsQ+DJ8BJS4E/fT5mqqdjovykEB2oFbTMDVdg1MGFxfQW+FBOGoB++k8swBrgwSHT1cUXQ==}
+    engines: {node: '>=12'}
+
+  d3-sankey@0.12.3:
+    resolution: {integrity: sha512-nQhsBRmM19Ax5xEIPLMY9ZmJ/cDvd1BG3UVvt5h3WRxKg5zGRbvnteTyWAbzeSvlh3tW7ZEmq4VwR5mB3tutmQ==}
+
+  d3-scale-chromatic@3.1.0:
+    resolution: {integrity: sha512-A3s5PWiZ9YCXFye1o246KoscMWqf8BsD9eRiJ3He7C9OBaxKhAd5TFCdEx/7VbKtxxTsu//1mMJFrEt572cEyQ==}
+    engines: {node: '>=12'}
+
+  d3-scale@4.0.2:
+    resolution: {integrity: sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==}
+    engines: {node: '>=12'}
+
+  d3-selection@3.0.0:
+    resolution: {integrity: sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==}
+    engines: {node: '>=12'}
+
+  d3-shape@1.3.7:
+    resolution: {integrity: sha512-EUkvKjqPFUAZyOlhY5gzCxCeI0Aep04LwIRpsZ/mLFelJiUfnK56jo5JMDSE7yyP2kLSb6LtF+S5chMk7uqPqw==}
+
+  d3-shape@3.2.0:
+    resolution: {integrity: sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==}
+    engines: {node: '>=12'}
+
+  d3-time-format@4.1.0:
+    resolution: {integrity: sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==}
+    engines: {node: '>=12'}
+
+  d3-time@3.1.0:
+    resolution: {integrity: sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==}
+    engines: {node: '>=12'}
+
+  d3-timer@3.0.1:
+    resolution: {integrity: sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==}
+    engines: {node: '>=12'}
+
+  d3-transition@3.0.1:
+    resolution: {integrity: sha512-ApKvfjsSR6tg06xrL434C0WydLr7JewBB3V+/39RMHsaXTOG0zmt/OAXeng5M5LBm0ojmxJrpomQVZ1aPvBL4w==}
+    engines: {node: '>=12'}
+    peerDependencies:
+      d3-selection: 2 - 3
+
+  d3-zoom@3.0.0:
+    resolution: {integrity: sha512-b8AmV3kfQaqWAuacbPuNbL6vahnOJflOhexLzMMNLga62+/nh0JzvJ0aO/5a5MVgUFGS7Hu1P9P03o3fJkDCyw==}
+    engines: {node: '>=12'}
+
+  d3@7.9.0:
+    resolution: {integrity: sha512-e1U46jVP+w7Iut8Jt8ri1YsPOvFpg46k+K8TpCb0P+zjCkjkPnV7WzfDJzMHy1LnA+wj5pLT1wjO901gLXeEhA==}
+    engines: {node: '>=12'}
+
+  dagre-d3-es@7.0.14:
+    resolution: {integrity: sha512-P4rFMVq9ESWqmOgK+dlXvOtLwYg0i7u0HBGJER0LZDJT2VHIPAMZ/riPxqJceWMStH5+E61QxFra9kIS3AqdMg==}
 
   damerau-levenshtein@1.0.8:
     resolution: {integrity: sha512-sdQSFB7+llfUcQHUQO3+B8ERRj0Oa4w9POWMI/puGtuf7gFywGmkaLCElnudfTiKZV+NvHqL0ifzdrI8Ro7ESA==}
@@ -4596,6 +4889,9 @@ packages:
   data-view-byte-offset@1.0.1:
     resolution: {integrity: sha512-BS8PfmtDGnrgYdOonGZQdLZslWIeCGFP9tpan0hi1Co2Zr2NKADsvGYA8XxuG/4UWgJ6Cjtv+YJnB6MM69QGlQ==}
     engines: {node: '>= 0.4'}
+
+  dayjs@1.11.21:
+    resolution: {integrity: sha512-98IT+HOahAisibz/yjKbzuOBwYcjJ7BCLPzARyHiyEBmRz4fatF+KPJszEHXsGYjUG234aH/cOjW1wwTbKUZlA==}
 
   de-indent@1.0.2:
     resolution: {integrity: sha512-e/1zu3xH5MQryN2zdVaF0OrdNLUbvWxzMbi+iNA6Bky7l1RoP8a2fIbRocyHclXt/arDrrR6lL3TqFD9pMQTsg==}
@@ -4679,6 +4975,9 @@ packages:
   defu@6.1.7:
     resolution: {integrity: sha512-7z22QmUWiQ/2d0KkdYmANbRUVABpZ9SNYyH5vx6PZ+nE5bcC0l7uFvEfHlyld/HcGBFTL536ClDt3DEcSlEJAQ==}
 
+  delaunator@5.1.0:
+    resolution: {integrity: sha512-AGrQ4QSgssa1NGmWmLPqN5NY2KajF5MqxetNEO+o0n3ZwZZeTmt7bBnvzHWrmkZFxGgr4HdyFgelzgi06otLuQ==}
+
   delayed-stream@1.0.0:
     resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
     engines: {node: '>=0.4.0'}
@@ -4754,6 +5053,9 @@ packages:
   domhandler@5.0.3:
     resolution: {integrity: sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==}
     engines: {node: '>= 4'}
+
+  dompurify@3.4.12:
+    resolution: {integrity: sha512-zQvGet8Z2sWbQhCmfFz/T5QWH2oBmjnqK3qvOjaqaNLrLEF912WamU+ohnTp0TCep/MFVHpdJuCZEdFOdTnEFg==}
 
   domutils@3.2.2:
     resolution: {integrity: sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==}
@@ -5512,6 +5814,9 @@ packages:
   h3@1.15.11:
     resolution: {integrity: sha512-L3THSe2MPeBwgIZVSH5zLdBBU90TOxarvhK9d04IDY2AmVS8j2Jz2LIWtwsGOU3lu2I5jCN7FNvVfY2+XyF+mg==}
 
+  hachure-fill@0.5.2:
+    resolution: {integrity: sha512-3GKBOn+m2LX9iq+JC1064cSFprJY4jL1jCXTcpnfER5HYE2l/4EfWSGzkPa/ZDBmYI0ZOEj5VHV/eKnPGkHuOg==}
+
   happy-dom@17.6.3:
     resolution: {integrity: sha512-UVIHeVhxmxedbWPCfgS55Jg2rDfwf2BCKeylcPSqazLz5w3Kri7Q4xdBJubsr/+VUzFLh0VjIvh13RaDA2/Xug==}
     engines: {node: '>=20.0.0'}
@@ -5654,6 +5959,10 @@ packages:
     resolution: {integrity: sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==}
     engines: {node: '>=0.10.0'}
 
+  iconv-lite@0.6.3:
+    resolution: {integrity: sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==}
+    engines: {node: '>=0.10.0'}
+
   idb@7.1.1:
     resolution: {integrity: sha512-gchesWBzyvGHRO9W8tzUWFDycow5gwjvFKfyV9FF32Y7F50yZMp7mP+T2mJIWFx49zicqyC4uefHM17o6xKIVQ==}
 
@@ -5720,6 +6029,13 @@ packages:
   internal-slot@1.1.0:
     resolution: {integrity: sha512-4gd7VpWNQNB4UKKCFFVcp1AVv+FMOgs9NKzjHKusc8jTMhd5eL1NqQqOpE0KzMds804/yHlglp3uxgluOqAPLw==}
     engines: {node: '>= 0.4'}
+
+  internmap@1.0.1:
+    resolution: {integrity: sha512-lDB5YccMydFBtasVtxnZ3MRBHuaoE8GKsppq+EchKL2U4nK/DmEpPHNH8MZe5HkMtpSiTSOZwfN0tzYjO/lJEw==}
+
+  internmap@2.0.3:
+    resolution: {integrity: sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==}
+    engines: {node: '>=12'}
 
   ipaddr.js@1.9.1:
     resolution: {integrity: sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==}
@@ -6158,8 +6474,15 @@ packages:
   jws@4.0.1:
     resolution: {integrity: sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==}
 
+  katex@0.16.47:
+    resolution: {integrity: sha512-Eeo8Ys1doU1z+x8AZsPpQu+p/QcZBI5PeOo7QGQdy2x2m0MU/hYagBbGOmXwr5KVbEfVuWv9LpnQWeehogurjg==}
+    hasBin: true
+
   keyv@4.5.4:
     resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
+
+  khroma@2.1.0:
+    resolution: {integrity: sha512-Ls993zuzfayK269Svk9hzpeGUKob/sIgZzyHYdjQoAdQetRKpOLj+k/QQQ/6Qi0Yz65mlROrfd+Ev+1+7dz9Kw==}
 
   kleur@3.0.3:
     resolution: {integrity: sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==}
@@ -6174,6 +6497,12 @@ packages:
   language-tags@1.0.9:
     resolution: {integrity: sha512-MbjN408fEndfiQXbFQ1vnd+1NoLDsnQW41410oQBXiyXDMYH5z505juWa4KUE1LqxRC7DgOgZDbKLxHIwm27hA==}
     engines: {node: '>=0.10'}
+
+  layout-base@1.0.2:
+    resolution: {integrity: sha512-8h2oVEZNktL4BH2JCOI90iD1yXwL6iNW7KcCKT2QZgQJR2vbqDsldCTPRU9NifTCqHZci57XvQQ15YTu+sTYPg==}
+
+  layout-base@2.0.1:
+    resolution: {integrity: sha512-dp3s92+uNI1hWIpPGH3jK2kxE2lMjdXdr+DH8ynZHpd6PUlH6x6cbuXnoMmiNumznqaNO31xu9e79F0uuZ0JFg==}
 
   leven@3.1.0:
     resolution: {integrity: sha512-qsda+H8jTaUaN/x5vzW2rzc+8Rw4TAQ/4KjB46IwK5VH+IlVeeeje/EoZRpiXvIqjFgK84QffqPztGI3VBLG1A==}
@@ -6282,6 +6611,9 @@ packages:
   locate-path@6.0.0:
     resolution: {integrity: sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==}
     engines: {node: '>=10'}
+
+  lodash-es@4.18.1:
+    resolution: {integrity: sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A==}
 
   lodash.camelcase@4.3.0:
     resolution: {integrity: sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==}
@@ -6392,6 +6724,11 @@ packages:
     engines: {node: '>= 18'}
     hasBin: true
 
+  marked@16.4.2:
+    resolution: {integrity: sha512-TI3V8YYWvkVf3KJe1dRkpnjs68JUPyEa5vjKrp1XEEJUAOaQc+Qj+L1qWbPd0SJuAdQkFU0h73sXXqwDYxsiDA==}
+    engines: {node: '>= 20'}
+    hasBin: true
+
   math-intrinsics@1.1.0:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
     engines: {node: '>= 0.4'}
@@ -6461,6 +6798,9 @@ packages:
 
   merge@2.1.1:
     resolution: {integrity: sha512-jz+Cfrg9GWOZbQAnDQ4hlVnQky+341Yk5ru8bZSe6sIDTCIg8n9i/u7hSQGSVOF3C7lH6mGtqjkiT9G4wFLL0w==}
+
+  mermaid@11.16.0:
+    resolution: {integrity: sha512-Zvm3kbstgdpvIJPPItlL7fppIZ3kibvc1oZIGxdvk9t6UFz6flv+Jw7FtRGKwfcI8OckmH04LqG6LlS6X4B1pA==}
 
   methods@1.1.2:
     resolution: {integrity: sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==}
@@ -6916,6 +7256,9 @@ packages:
   path-browserify@1.0.1:
     resolution: {integrity: sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==}
 
+  path-data-parser@0.1.0:
+    resolution: {integrity: sha512-NOnmBpt5Y2RWbuv0LMzsayp3lVylAHLPUTut412ZA3l+C4uw4ZVkQbjShYCQ8TCpUMdPapr4YjUqLYD6v68j+w==}
+
   path-exists@4.0.0:
     resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
     engines: {node: '>=8'}
@@ -7014,6 +7357,12 @@ packages:
     resolution: {integrity: sha512-Z+7BeeqQPRRzklHsVFP4KTGIyMxKUmfeRA4WisM6G3/XW6nwGeX6fX9qYaDa+CiUqpOkb2f6X3nar05R3kSuJQ==}
     engines: {node: '>=18'}
     hasBin: true
+
+  points-on-curve@0.2.0:
+    resolution: {integrity: sha512-0mYKnYYe9ZcqMCWhUjItv/oHjvgEsfKvnUTg8sAtnHr3GVy7rGkXCb6d5cSyqrWqL4k81b9CPg3urd+T7aop3A==}
+
+  points-on-path@0.2.1:
+    resolution: {integrity: sha512-25ClnWWuw7JbWZcgqY/gJ4FQWadKxGWk+3kR/7kD0tCaDtPPMj7oHu2ToLaVhfpnHrZzYby2w6tUA0eOIuUg8g==}
 
   possible-typed-array-names@1.1.0:
     resolution: {integrity: sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==}
@@ -7337,6 +7686,9 @@ packages:
     resolution: {integrity: sha512-l0OE8wL34P4nJH/H2ffoaniAokM2qSmrtXHmlpvYr5AVVX8msAyW0l8NVJFDxlSK4u3Uh/f41cQheDVdnYijwQ==}
     hasBin: true
 
+  robust-predicates@3.0.3:
+    resolution: {integrity: sha512-NS3levdsRIUOmiJ8FZWCP7LG3QpJyrs/TE0Zpf1yvZu8cAJJ6QMW92H1c7kWpdIHo8RvmLxN/o2JXTKHp74lUA==}
+
   rolldown@1.1.5:
     resolution: {integrity: sha512-t9z29cJjXf/vxQ8dyhCSpt6H6aSwHTk8cT5I3iy6SMXuFpk5mB6PL6XfC8PCwrPTx93udwKUm9HRteAlTGBLiA==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -7346,6 +7698,9 @@ packages:
     resolution: {integrity: sha512-WHeFSbZYsPu3+bLoNRUuAO+wavNlocOPf3wSHTP7hcFKVnJeWsYlCDbr3mTS14FCizf9ccIxXA8sGL8zKeQN3g==}
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
     hasBin: true
+
+  roughjs@4.6.6:
+    resolution: {integrity: sha512-ZUz/69+SYpFN/g/lUlo2FXcIjRkSu3nDarreVdGGndHEBJ6cXPdKguS8JGxwj5HA5xIbVKSmLgr5b3AWxtRfvQ==}
 
   run-applescript@7.1.0:
     resolution: {integrity: sha512-DPe5pVFaAsinSaV6QjQ6gdiedWDcRCbUuiQfQa2wmWV7+xC9bGulGI8+TdRmoFkAPaBXk8CrAbnlY2ISniJ47Q==}
@@ -7357,6 +7712,9 @@ packages:
 
   run-parallel@1.2.0:
     resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
+
+  rw@1.3.3:
+    resolution: {integrity: sha512-PdhdWy89SiZogBLaw42zdeqtRJ//zFd2PgQavcICDUgJT5oW10QCRKbJ6bg4r0/UY2M6BWd5tkxuGFRvCkgfHQ==}
 
   rxjs@7.8.2:
     resolution: {integrity: sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==}
@@ -7713,6 +8071,9 @@ packages:
   stubs@3.0.0:
     resolution: {integrity: sha512-PdHt7hHUJKxvTCgbKX9C1V/ftOcjJQgz8BZwNfV5c4B6dcGqlpelTbJ999jBGZ2jYiPAwcX5dP6oBwVlBlUbxw==}
 
+  stylis@4.4.0:
+    resolution: {integrity: sha512-5Z9ZpRzfuH6l/UAvCPAPUo3665Nk2wLaZU3x+TLHKVzIz33+sbJqbtrYoC3KD4/uVOr2Zp+L0LySezP9OHV9yA==}
+
   suf-log@2.5.3:
     resolution: {integrity: sha512-KvC8OPjzdNOe+xQ4XWJV2whQA0aM1kGVczMQ8+dStAO6KfEB140JEVQ9dE76ONZ0/Ylf67ni4tILPJB41U0eow==}
 
@@ -7982,9 +8343,6 @@ packages:
 
   undici-types@7.18.2:
     resolution: {integrity: sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==}
-
-  undici-types@7.24.6:
-    resolution: {integrity: sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==}
 
   undici-types@8.3.0:
     resolution: {integrity: sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==}
@@ -8614,6 +8972,11 @@ snapshots:
     dependencies:
       '@jridgewell/gen-mapping': 0.3.13
       '@jridgewell/trace-mapping': 0.3.31
+
+  '@antfu/install-pkg@1.1.0':
+    dependencies:
+      package-manager-detector: 1.6.0
+      tinyexec: 1.1.2
 
   '@apphosting/astro-adapter@0.0.1(astro@5.18.1(@types/node@26.1.1)(jiti@2.6.1)(lightningcss@1.32.0)(rollup@4.60.4)(tsx@4.22.3)(typescript@5.9.2)(yaml@2.9.0))':
     dependencies:
@@ -9253,6 +9616,8 @@ snapshots:
 
   '@bcoe/v8-coverage@1.0.2': {}
 
+  '@braintree/sanitize-url@7.1.2': {}
+
   '@bramus/specificity@2.4.2':
     dependencies:
       css-tree: 3.2.1
@@ -9292,6 +9657,8 @@ snapshots:
     dependencies:
       fontkitten: 1.0.3
 
+  '@chevrotain/types@11.1.2': {}
+
   '@chromatic-com/storybook@5.2.1(storybook@10.4.2(@testing-library/dom@10.4.1)(@types/react@19.1.0)(prettier@3.8.3)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))':
     dependencies:
       '@neoconfetti/react': 1.0.0
@@ -9316,11 +9683,11 @@ snapshots:
       fast-wrap-ansi: 0.2.2
       sisteransi: 1.0.5
 
-  '@commitlint/cli@20.5.3(@types/node@25.9.1)(conventional-commits-parser@6.4.0)(typescript@5.9.2)':
+  '@commitlint/cli@20.5.3(@types/node@26.1.1)(conventional-commits-parser@6.4.0)(typescript@5.9.2)':
     dependencies:
       '@commitlint/format': 20.5.0
       '@commitlint/lint': 20.5.3
-      '@commitlint/load': 20.5.3(@types/node@25.9.1)(typescript@5.9.2)
+      '@commitlint/load': 20.5.3(@types/node@26.1.1)(typescript@5.9.2)
       '@commitlint/read': 20.5.0(conventional-commits-parser@6.4.0)
       '@commitlint/types': 20.5.0
       tinyexec: 1.1.2
@@ -9374,14 +9741,14 @@ snapshots:
       '@commitlint/rules': 20.5.3
       '@commitlint/types': 20.5.0
 
-  '@commitlint/load@20.5.3(@types/node@25.9.1)(typescript@5.9.2)':
+  '@commitlint/load@20.5.3(@types/node@26.1.1)(typescript@5.9.2)':
     dependencies:
       '@commitlint/config-validator': 20.5.0
       '@commitlint/execute-rule': 20.0.0
       '@commitlint/resolve-extends': 20.5.3
       '@commitlint/types': 20.5.0
       cosmiconfig: 9.0.1(typescript@5.9.2)
-      cosmiconfig-typescript-loader: 6.3.0(@types/node@25.9.1)(cosmiconfig@9.0.1(typescript@5.9.2))(typescript@5.9.2)
+      cosmiconfig-typescript-loader: 6.3.0(@types/node@26.1.1)(cosmiconfig@9.0.1(typescript@5.9.2))(typescript@5.9.2)
       es-toolkit: 1.46.1
       is-plain-obj: 4.1.0
       picocolors: 1.1.1
@@ -9389,14 +9756,14 @@ snapshots:
       - '@types/node'
       - typescript
 
-  '@commitlint/load@21.0.1(@types/node@25.9.1)(typescript@5.9.2)':
+  '@commitlint/load@21.0.1(@types/node@26.1.1)(typescript@5.9.2)':
     dependencies:
       '@commitlint/config-validator': 21.0.1
       '@commitlint/execute-rule': 21.0.1
       '@commitlint/resolve-extends': 21.0.1
       '@commitlint/types': 21.0.1
       cosmiconfig: 9.0.1(typescript@5.9.2)
-      cosmiconfig-typescript-loader: 6.3.0(@types/node@25.9.1)(cosmiconfig@9.0.1(typescript@5.9.2))(typescript@5.9.2)
+      cosmiconfig-typescript-loader: 6.3.0(@types/node@26.1.1)(cosmiconfig@9.0.1(typescript@5.9.2))(typescript@5.9.2)
       es-toolkit: 1.46.1
       is-plain-obj: 4.1.0
       picocolors: 1.1.1
@@ -10375,6 +10742,14 @@ snapshots:
 
   '@humanwhocodes/retry@0.4.3': {}
 
+  '@iconify/types@2.0.0': {}
+
+  '@iconify/utils@3.1.4':
+    dependencies:
+      '@antfu/install-pkg': 1.1.0
+      '@iconify/types': 2.0.0
+      import-meta-resolve: 4.2.0
+
   '@img/colour@1.1.0':
     optional: true
 
@@ -10494,7 +10869,7 @@ snapshots:
   '@jest/console@30.2.0':
     dependencies:
       '@jest/types': 30.2.0
-      '@types/node': 26.1.1
+      '@types/node': 22.19.3
       chalk: 4.1.2
       jest-message-util: 30.2.0
       jest-util: 30.2.0
@@ -10508,14 +10883,14 @@ snapshots:
       '@jest/test-result': 30.2.0
       '@jest/transform': 30.2.0
       '@jest/types': 30.2.0
-      '@types/node': 26.1.1
+      '@types/node': 22.19.3
       ansi-escapes: 4.3.2
       chalk: 4.1.2
       ci-info: 4.4.0
       exit-x: 0.2.2
       graceful-fs: 4.2.11
       jest-changed-files: 30.2.0
-      jest-config: 30.2.0(@types/node@26.1.1)(esbuild-register@3.6.0(esbuild@0.28.0))
+      jest-config: 30.2.0(@types/node@22.19.3)(esbuild-register@3.6.0(esbuild@0.28.0))
       jest-haste-map: 30.2.0
       jest-message-util: 30.2.0
       jest-regex-util: 30.0.1
@@ -10542,7 +10917,7 @@ snapshots:
     dependencies:
       '@jest/fake-timers': 30.2.0
       '@jest/types': 30.2.0
-      '@types/node': 26.1.1
+      '@types/node': 22.19.3
       jest-mock: 30.2.0
 
   '@jest/expect-utils@30.2.0':
@@ -10560,7 +10935,7 @@ snapshots:
     dependencies:
       '@jest/types': 30.2.0
       '@sinonjs/fake-timers': 13.0.5
-      '@types/node': 26.1.1
+      '@types/node': 22.19.3
       jest-message-util: 30.2.0
       jest-mock: 30.2.0
       jest-util: 30.2.0
@@ -10578,7 +10953,7 @@ snapshots:
 
   '@jest/pattern@30.0.1':
     dependencies:
-      '@types/node': 26.1.1
+      '@types/node': 22.19.3
       jest-regex-util: 30.0.1
 
   '@jest/reporters@30.2.0':
@@ -10589,7 +10964,7 @@ snapshots:
       '@jest/transform': 30.2.0
       '@jest/types': 30.2.0
       '@jridgewell/trace-mapping': 0.3.31
-      '@types/node': 26.1.1
+      '@types/node': 22.19.3
       chalk: 4.1.2
       collect-v8-coverage: 1.0.3
       exit-x: 0.2.2
@@ -10666,7 +11041,7 @@ snapshots:
       '@jest/schemas': 30.0.5
       '@types/istanbul-lib-coverage': 2.0.6
       '@types/istanbul-reports': 3.0.4
-      '@types/node': 26.1.1
+      '@types/node': 22.19.3
       '@types/yargs': 17.0.35
       chalk: 4.1.2
 
@@ -10704,6 +11079,10 @@ snapshots:
       '@types/mdx': 2.0.13
       '@types/react': 19.1.0
       react: 19.2.6
+
+  '@mermaid-js/parser@1.2.0':
+    dependencies:
+      '@chevrotain/types': 11.1.2
 
   '@microsoft/api-extractor-model@7.33.8(@types/node@22.19.3)':
     dependencies:
@@ -11746,6 +12125,123 @@ snapshots:
     dependencies:
       '@types/node': 22.19.3
 
+  '@types/d3-array@3.2.2': {}
+
+  '@types/d3-axis@3.0.6':
+    dependencies:
+      '@types/d3-selection': 3.0.11
+
+  '@types/d3-brush@3.0.6':
+    dependencies:
+      '@types/d3-selection': 3.0.11
+
+  '@types/d3-chord@3.0.6': {}
+
+  '@types/d3-color@3.1.3': {}
+
+  '@types/d3-contour@3.0.6':
+    dependencies:
+      '@types/d3-array': 3.2.2
+      '@types/geojson': 7946.0.16
+
+  '@types/d3-delaunay@6.0.4': {}
+
+  '@types/d3-dispatch@3.0.7': {}
+
+  '@types/d3-drag@3.0.7':
+    dependencies:
+      '@types/d3-selection': 3.0.11
+
+  '@types/d3-dsv@3.0.7': {}
+
+  '@types/d3-ease@3.0.2': {}
+
+  '@types/d3-fetch@3.0.7':
+    dependencies:
+      '@types/d3-dsv': 3.0.7
+
+  '@types/d3-force@3.0.10': {}
+
+  '@types/d3-format@3.0.4': {}
+
+  '@types/d3-geo@3.1.0':
+    dependencies:
+      '@types/geojson': 7946.0.16
+
+  '@types/d3-hierarchy@3.1.7': {}
+
+  '@types/d3-interpolate@3.0.4':
+    dependencies:
+      '@types/d3-color': 3.1.3
+
+  '@types/d3-path@3.1.1': {}
+
+  '@types/d3-polygon@3.0.2': {}
+
+  '@types/d3-quadtree@3.0.6': {}
+
+  '@types/d3-random@3.0.4': {}
+
+  '@types/d3-scale-chromatic@3.1.0': {}
+
+  '@types/d3-scale@4.0.9':
+    dependencies:
+      '@types/d3-time': 3.0.4
+
+  '@types/d3-selection@3.0.11': {}
+
+  '@types/d3-shape@3.1.8':
+    dependencies:
+      '@types/d3-path': 3.1.1
+
+  '@types/d3-time-format@4.0.3': {}
+
+  '@types/d3-time@3.0.4': {}
+
+  '@types/d3-timer@3.0.2': {}
+
+  '@types/d3-transition@3.0.9':
+    dependencies:
+      '@types/d3-selection': 3.0.11
+
+  '@types/d3-zoom@3.0.8':
+    dependencies:
+      '@types/d3-interpolate': 3.0.4
+      '@types/d3-selection': 3.0.11
+
+  '@types/d3@7.4.3':
+    dependencies:
+      '@types/d3-array': 3.2.2
+      '@types/d3-axis': 3.0.6
+      '@types/d3-brush': 3.0.6
+      '@types/d3-chord': 3.0.6
+      '@types/d3-color': 3.1.3
+      '@types/d3-contour': 3.0.6
+      '@types/d3-delaunay': 6.0.4
+      '@types/d3-dispatch': 3.0.7
+      '@types/d3-drag': 3.0.7
+      '@types/d3-dsv': 3.0.7
+      '@types/d3-ease': 3.0.2
+      '@types/d3-fetch': 3.0.7
+      '@types/d3-force': 3.0.10
+      '@types/d3-format': 3.0.4
+      '@types/d3-geo': 3.1.0
+      '@types/d3-hierarchy': 3.1.7
+      '@types/d3-interpolate': 3.0.4
+      '@types/d3-path': 3.1.1
+      '@types/d3-polygon': 3.0.2
+      '@types/d3-quadtree': 3.0.6
+      '@types/d3-random': 3.0.4
+      '@types/d3-scale': 4.0.9
+      '@types/d3-scale-chromatic': 3.1.0
+      '@types/d3-selection': 3.0.11
+      '@types/d3-shape': 3.1.8
+      '@types/d3-time': 3.0.4
+      '@types/d3-time-format': 4.0.3
+      '@types/d3-timer': 3.0.2
+      '@types/d3-transition': 3.0.9
+      '@types/d3-zoom': 3.0.8
+
   '@types/debug@4.1.13':
     dependencies:
       '@types/ms': 2.1.0
@@ -11775,6 +12271,8 @@ snapshots:
       '@types/express-serve-static-core': 4.19.8
       '@types/qs': 6.15.1
       '@types/serve-static': 1.15.10
+
+  '@types/geojson@7946.0.16': {}
 
   '@types/hast@3.0.4':
     dependencies:
@@ -11834,10 +12332,6 @@ snapshots:
   '@types/node@24.13.3':
     dependencies:
       undici-types: 7.18.2
-
-  '@types/node@25.9.1':
-    dependencies:
-      undici-types: 7.24.6
 
   '@types/node@26.1.1':
     dependencies:
@@ -11902,6 +12396,9 @@ snapshots:
   '@types/stack-utils@2.0.3': {}
 
   '@types/tough-cookie@4.0.5': {}
+
+  '@types/trusted-types@2.0.7':
+    optional: true
 
   '@types/unist@3.0.3': {}
 
@@ -12166,6 +12663,11 @@ snapshots:
 
   '@unrs/resolver-binding-win32-x64-msvc@1.12.2':
     optional: true
+
+  '@upsetjs/venn.js@2.0.0':
+    optionalDependencies:
+      d3-selection: 3.0.0
+      d3-transition: 3.0.1(d3-selection@3.0.0)
 
   '@vitejs/plugin-react@4.7.0(vite@6.4.2(@types/node@22.19.3)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.22.3)(yaml@2.9.0))':
     dependencies:
@@ -13210,10 +13712,14 @@ snapshots:
 
   commander@14.0.3: {}
 
-  commitizen@4.3.1(@types/node@25.9.1)(typescript@5.9.2):
+  commander@7.2.0: {}
+
+  commander@8.3.0: {}
+
+  commitizen@4.3.1(@types/node@26.1.1)(typescript@5.9.2):
     dependencies:
       cachedir: 2.3.0
-      cz-conventional-changelog: 3.3.0(@types/node@25.9.1)(typescript@5.9.2)
+      cz-conventional-changelog: 3.3.0(@types/node@26.1.1)(typescript@5.9.2)
       dedent: 0.7.0
       detect-indent: 6.1.0
       find-node-modules: 2.1.3
@@ -13297,9 +13803,17 @@ snapshots:
       object-assign: 4.1.1
       vary: 1.1.2
 
-  cosmiconfig-typescript-loader@6.3.0(@types/node@25.9.1)(cosmiconfig@9.0.1(typescript@5.9.2))(typescript@5.9.2):
+  cose-base@1.0.3:
     dependencies:
-      '@types/node': 25.9.1
+      layout-base: 1.0.2
+
+  cose-base@2.2.0:
+    dependencies:
+      layout-base: 2.0.1
+
+  cosmiconfig-typescript-loader@6.3.0(@types/node@26.1.1)(cosmiconfig@9.0.1(typescript@5.9.2))(typescript@5.9.2):
+    dependencies:
+      '@types/node': 26.1.1
       cosmiconfig: 9.0.1(typescript@5.9.2)
       jiti: 2.6.1
       typescript: 5.9.2
@@ -13353,19 +13867,203 @@ snapshots:
 
   csstype@3.2.3: {}
 
-  cz-conventional-changelog@3.3.0(@types/node@25.9.1)(typescript@5.9.2):
+  cytoscape-cose-bilkent@4.1.0(cytoscape@3.34.0):
+    dependencies:
+      cose-base: 1.0.3
+      cytoscape: 3.34.0
+
+  cytoscape-fcose@2.2.0(cytoscape@3.34.0):
+    dependencies:
+      cose-base: 2.2.0
+      cytoscape: 3.34.0
+
+  cytoscape@3.34.0: {}
+
+  cz-conventional-changelog@3.3.0(@types/node@26.1.1)(typescript@5.9.2):
     dependencies:
       chalk: 2.4.2
-      commitizen: 4.3.1(@types/node@25.9.1)(typescript@5.9.2)
+      commitizen: 4.3.1(@types/node@26.1.1)(typescript@5.9.2)
       conventional-commit-types: 3.0.0
       lodash.map: 4.6.0
       longest: 2.0.1
       word-wrap: 1.2.5
     optionalDependencies:
-      '@commitlint/load': 21.0.1(@types/node@25.9.1)(typescript@5.9.2)
+      '@commitlint/load': 21.0.1(@types/node@26.1.1)(typescript@5.9.2)
     transitivePeerDependencies:
       - '@types/node'
       - typescript
+
+  d3-array@2.12.1:
+    dependencies:
+      internmap: 1.0.1
+
+  d3-array@3.2.4:
+    dependencies:
+      internmap: 2.0.3
+
+  d3-axis@3.0.0: {}
+
+  d3-brush@3.0.0:
+    dependencies:
+      d3-dispatch: 3.0.1
+      d3-drag: 3.0.0
+      d3-interpolate: 3.0.1
+      d3-selection: 3.0.0
+      d3-transition: 3.0.1(d3-selection@3.0.0)
+
+  d3-chord@3.0.1:
+    dependencies:
+      d3-path: 3.1.0
+
+  d3-color@3.1.0: {}
+
+  d3-contour@4.0.2:
+    dependencies:
+      d3-array: 3.2.4
+
+  d3-delaunay@6.0.4:
+    dependencies:
+      delaunator: 5.1.0
+
+  d3-dispatch@3.0.1: {}
+
+  d3-drag@3.0.0:
+    dependencies:
+      d3-dispatch: 3.0.1
+      d3-selection: 3.0.0
+
+  d3-dsv@3.0.1:
+    dependencies:
+      commander: 7.2.0
+      iconv-lite: 0.6.3
+      rw: 1.3.3
+
+  d3-ease@3.0.1: {}
+
+  d3-fetch@3.0.1:
+    dependencies:
+      d3-dsv: 3.0.1
+
+  d3-force@3.0.0:
+    dependencies:
+      d3-dispatch: 3.0.1
+      d3-quadtree: 3.0.1
+      d3-timer: 3.0.1
+
+  d3-format@3.1.2: {}
+
+  d3-geo@3.1.1:
+    dependencies:
+      d3-array: 3.2.4
+
+  d3-hierarchy@3.1.2: {}
+
+  d3-interpolate@3.0.1:
+    dependencies:
+      d3-color: 3.1.0
+
+  d3-path@1.0.9: {}
+
+  d3-path@3.1.0: {}
+
+  d3-polygon@3.0.1: {}
+
+  d3-quadtree@3.0.1: {}
+
+  d3-random@3.0.1: {}
+
+  d3-sankey@0.12.3:
+    dependencies:
+      d3-array: 2.12.1
+      d3-shape: 1.3.7
+
+  d3-scale-chromatic@3.1.0:
+    dependencies:
+      d3-color: 3.1.0
+      d3-interpolate: 3.0.1
+
+  d3-scale@4.0.2:
+    dependencies:
+      d3-array: 3.2.4
+      d3-format: 3.1.2
+      d3-interpolate: 3.0.1
+      d3-time: 3.1.0
+      d3-time-format: 4.1.0
+
+  d3-selection@3.0.0: {}
+
+  d3-shape@1.3.7:
+    dependencies:
+      d3-path: 1.0.9
+
+  d3-shape@3.2.0:
+    dependencies:
+      d3-path: 3.1.0
+
+  d3-time-format@4.1.0:
+    dependencies:
+      d3-time: 3.1.0
+
+  d3-time@3.1.0:
+    dependencies:
+      d3-array: 3.2.4
+
+  d3-timer@3.0.1: {}
+
+  d3-transition@3.0.1(d3-selection@3.0.0):
+    dependencies:
+      d3-color: 3.1.0
+      d3-dispatch: 3.0.1
+      d3-ease: 3.0.1
+      d3-interpolate: 3.0.1
+      d3-selection: 3.0.0
+      d3-timer: 3.0.1
+
+  d3-zoom@3.0.0:
+    dependencies:
+      d3-dispatch: 3.0.1
+      d3-drag: 3.0.0
+      d3-interpolate: 3.0.1
+      d3-selection: 3.0.0
+      d3-transition: 3.0.1(d3-selection@3.0.0)
+
+  d3@7.9.0:
+    dependencies:
+      d3-array: 3.2.4
+      d3-axis: 3.0.0
+      d3-brush: 3.0.0
+      d3-chord: 3.0.1
+      d3-color: 3.1.0
+      d3-contour: 4.0.2
+      d3-delaunay: 6.0.4
+      d3-dispatch: 3.0.1
+      d3-drag: 3.0.0
+      d3-dsv: 3.0.1
+      d3-ease: 3.0.1
+      d3-fetch: 3.0.1
+      d3-force: 3.0.0
+      d3-format: 3.1.2
+      d3-geo: 3.1.1
+      d3-hierarchy: 3.1.2
+      d3-interpolate: 3.0.1
+      d3-path: 3.1.0
+      d3-polygon: 3.0.1
+      d3-quadtree: 3.0.1
+      d3-random: 3.0.1
+      d3-scale: 4.0.2
+      d3-scale-chromatic: 3.1.0
+      d3-selection: 3.0.0
+      d3-shape: 3.2.0
+      d3-time: 3.1.0
+      d3-time-format: 4.1.0
+      d3-timer: 3.0.1
+      d3-transition: 3.0.1(d3-selection@3.0.0)
+      d3-zoom: 3.0.0
+
+  dagre-d3-es@7.0.14:
+    dependencies:
+      d3: 7.9.0
+      lodash-es: 4.18.1
 
   damerau-levenshtein@1.0.8: {}
 
@@ -13395,6 +14093,8 @@ snapshots:
       call-bound: 1.0.4
       es-errors: 1.3.0
       is-data-view: 1.0.2
+
+  dayjs@1.11.21: {}
 
   de-indent@1.0.2: {}
 
@@ -13453,6 +14153,10 @@ snapshots:
 
   defu@6.1.7: {}
 
+  delaunator@5.1.0:
+    dependencies:
+      robust-predicates: 3.0.3
+
   delayed-stream@1.0.0: {}
 
   depd@2.0.0: {}
@@ -13508,6 +14212,10 @@ snapshots:
   domhandler@5.0.3:
     dependencies:
       domelementtype: 2.3.0
+
+  dompurify@3.4.12:
+    optionalDependencies:
+      '@types/trusted-types': 2.0.7
 
   domutils@3.2.2:
     dependencies:
@@ -14290,12 +14998,12 @@ snapshots:
       - encoding
       - supports-color
 
-  firebase-functions-test@3.4.1(firebase-admin@12.7.0)(firebase-functions@7.2.2(firebase-admin@12.7.0))(jest@30.2.0(@types/node@26.1.1)(esbuild-register@3.6.0(esbuild@0.28.0))):
+  firebase-functions-test@3.4.1(firebase-admin@12.7.0)(firebase-functions@7.2.2(firebase-admin@12.7.0))(jest@30.2.0(@types/node@22.19.3)(esbuild-register@3.6.0(esbuild@0.28.0))):
     dependencies:
       '@types/lodash': 4.17.21
       firebase-admin: 12.7.0
       firebase-functions: 7.2.2(firebase-admin@12.7.0)
-      jest: 30.2.0(@types/node@26.1.1)(esbuild-register@3.6.0(esbuild@0.28.0))
+      jest: 30.2.0(@types/node@22.19.3)(esbuild-register@3.6.0(esbuild@0.28.0))
       lodash: 4.17.21
       ts-deepmerge: 2.0.7
 
@@ -14668,6 +15376,8 @@ snapshots:
       ufo: 1.6.4
       uncrypto: 0.1.3
 
+  hachure-fill@0.5.2: {}
+
   happy-dom@17.6.3:
     dependencies:
       webidl-conversions: 7.0.0
@@ -14870,6 +15580,10 @@ snapshots:
     dependencies:
       safer-buffer: 2.1.2
 
+  iconv-lite@0.6.3:
+    dependencies:
+      safer-buffer: 2.1.2
+
   idb@7.1.1: {}
 
   ieee754@1.2.1: {}
@@ -14939,6 +15653,10 @@ snapshots:
       es-errors: 1.3.0
       hasown: 2.0.2
       side-channel: 1.1.0
+
+  internmap@1.0.1: {}
+
+  internmap@2.0.3: {}
 
   ipaddr.js@1.9.1: {}
 
@@ -15156,7 +15874,7 @@ snapshots:
       '@jest/expect': 30.2.0
       '@jest/test-result': 30.2.0
       '@jest/types': 30.2.0
-      '@types/node': 26.1.1
+      '@types/node': 22.19.3
       chalk: 4.1.2
       co: 4.6.0
       dedent: 1.7.2
@@ -15176,7 +15894,7 @@ snapshots:
       - babel-plugin-macros
       - supports-color
 
-  jest-cli@30.2.0(@types/node@26.1.1)(esbuild-register@3.6.0(esbuild@0.28.0)):
+  jest-cli@30.2.0(@types/node@22.19.3)(esbuild-register@3.6.0(esbuild@0.28.0)):
     dependencies:
       '@jest/core': 30.2.0(esbuild-register@3.6.0(esbuild@0.28.0))
       '@jest/test-result': 30.2.0
@@ -15184,7 +15902,7 @@ snapshots:
       chalk: 4.1.2
       exit-x: 0.2.2
       import-local: 3.2.0
-      jest-config: 30.2.0(@types/node@26.1.1)(esbuild-register@3.6.0(esbuild@0.28.0))
+      jest-config: 30.2.0(@types/node@22.19.3)(esbuild-register@3.6.0(esbuild@0.28.0))
       jest-util: 30.2.0
       jest-validate: 30.2.0
       yargs: 17.7.3
@@ -15195,7 +15913,7 @@ snapshots:
       - supports-color
       - ts-node
 
-  jest-config@30.2.0(@types/node@26.1.1)(esbuild-register@3.6.0(esbuild@0.28.0)):
+  jest-config@30.2.0(@types/node@22.19.3)(esbuild-register@3.6.0(esbuild@0.28.0)):
     dependencies:
       '@babel/core': 7.29.7
       '@jest/get-type': 30.1.0
@@ -15222,7 +15940,7 @@ snapshots:
       slash: 3.0.0
       strip-json-comments: 3.1.1
     optionalDependencies:
-      '@types/node': 26.1.1
+      '@types/node': 22.19.3
       esbuild-register: 3.6.0(esbuild@0.28.0)
     transitivePeerDependencies:
       - babel-plugin-macros
@@ -15252,7 +15970,7 @@ snapshots:
       '@jest/environment': 30.2.0
       '@jest/fake-timers': 30.2.0
       '@jest/types': 30.2.0
-      '@types/node': 26.1.1
+      '@types/node': 22.19.3
       jest-mock: 30.2.0
       jest-util: 30.2.0
       jest-validate: 30.2.0
@@ -15260,7 +15978,7 @@ snapshots:
   jest-haste-map@30.2.0:
     dependencies:
       '@jest/types': 30.2.0
-      '@types/node': 26.1.1
+      '@types/node': 22.19.3
       anymatch: 3.1.3
       fb-watchman: 2.0.2
       graceful-fs: 4.2.11
@@ -15299,7 +16017,7 @@ snapshots:
   jest-mock@30.2.0:
     dependencies:
       '@jest/types': 30.2.0
-      '@types/node': 26.1.1
+      '@types/node': 22.19.3
       jest-util: 30.2.0
 
   jest-pnp-resolver@1.2.3(jest-resolve@30.2.0):
@@ -15333,7 +16051,7 @@ snapshots:
       '@jest/test-result': 30.2.0
       '@jest/transform': 30.2.0
       '@jest/types': 30.2.0
-      '@types/node': 26.1.1
+      '@types/node': 22.19.3
       chalk: 4.1.2
       emittery: 0.13.1
       exit-x: 0.2.2
@@ -15362,7 +16080,7 @@ snapshots:
       '@jest/test-result': 30.2.0
       '@jest/transform': 30.2.0
       '@jest/types': 30.2.0
-      '@types/node': 26.1.1
+      '@types/node': 22.19.3
       chalk: 4.1.2
       cjs-module-lexer: 2.2.0
       collect-v8-coverage: 1.0.3
@@ -15409,7 +16127,7 @@ snapshots:
   jest-util@30.2.0:
     dependencies:
       '@jest/types': 30.2.0
-      '@types/node': 26.1.1
+      '@types/node': 22.19.3
       chalk: 4.1.2
       ci-info: 4.4.0
       graceful-fs: 4.2.11
@@ -15428,7 +16146,7 @@ snapshots:
     dependencies:
       '@jest/test-result': 30.2.0
       '@jest/types': 30.2.0
-      '@types/node': 26.1.1
+      '@types/node': 22.19.3
       ansi-escapes: 4.3.2
       chalk: 4.1.2
       emittery: 0.13.1
@@ -15437,18 +16155,18 @@ snapshots:
 
   jest-worker@30.2.0:
     dependencies:
-      '@types/node': 26.1.1
+      '@types/node': 22.19.3
       '@ungap/structured-clone': 1.3.3
       jest-util: 30.2.0
       merge-stream: 2.0.0
       supports-color: 8.1.1
 
-  jest@30.2.0(@types/node@26.1.1)(esbuild-register@3.6.0(esbuild@0.28.0)):
+  jest@30.2.0(@types/node@22.19.3)(esbuild-register@3.6.0(esbuild@0.28.0)):
     dependencies:
       '@jest/core': 30.2.0(esbuild-register@3.6.0(esbuild@0.28.0))
       '@jest/types': 30.2.0
       import-local: 3.2.0
-      jest-cli: 30.2.0(@types/node@26.1.1)(esbuild-register@3.6.0(esbuild@0.28.0))
+      jest-cli: 30.2.0(@types/node@22.19.3)(esbuild-register@3.6.0(esbuild@0.28.0))
     transitivePeerDependencies:
       - '@types/node'
       - babel-plugin-macros
@@ -15592,9 +16310,15 @@ snapshots:
       jwa: 2.0.1
       safe-buffer: 5.2.1
 
+  katex@0.16.47:
+    dependencies:
+      commander: 8.3.0
+
   keyv@4.5.4:
     dependencies:
       json-buffer: 3.0.1
+
+  khroma@2.1.0: {}
 
   kleur@3.0.3: {}
 
@@ -15605,6 +16329,10 @@ snapshots:
   language-tags@1.0.9:
     dependencies:
       language-subtag-registry: 0.3.23
+
+  layout-base@1.0.2: {}
+
+  layout-base@2.0.1: {}
 
   leven@3.1.0: {}
 
@@ -15701,6 +16429,8 @@ snapshots:
   locate-path@6.0.0:
     dependencies:
       p-locate: 5.0.0
+
+  lodash-es@4.18.1: {}
 
   lodash.camelcase@4.3.0: {}
 
@@ -15799,6 +16529,8 @@ snapshots:
   markdown-table@3.0.4: {}
 
   marked@15.0.12: {}
+
+  marked@16.4.2: {}
 
   math-intrinsics@1.1.0: {}
 
@@ -15937,6 +16669,30 @@ snapshots:
   merge2@1.4.1: {}
 
   merge@2.1.1: {}
+
+  mermaid@11.16.0:
+    dependencies:
+      '@braintree/sanitize-url': 7.1.2
+      '@iconify/utils': 3.1.4
+      '@mermaid-js/parser': 1.2.0
+      '@types/d3': 7.4.3
+      '@upsetjs/venn.js': 2.0.0
+      cytoscape: 3.34.0
+      cytoscape-cose-bilkent: 4.1.0(cytoscape@3.34.0)
+      cytoscape-fcose: 2.2.0(cytoscape@3.34.0)
+      d3: 7.9.0
+      d3-sankey: 0.12.3
+      dagre-d3-es: 7.0.14
+      dayjs: 1.11.21
+      dompurify: 3.4.12
+      es-toolkit: 1.46.1
+      katex: 0.16.47
+      khroma: 2.1.0
+      marked: 16.4.2
+      roughjs: 4.6.6
+      stylis: 4.4.0
+      ts-dedent: 2.2.0
+      uuid: 14.0.0
 
   methods@1.1.2: {}
 
@@ -16517,6 +17273,8 @@ snapshots:
 
   path-browserify@1.0.1: {}
 
+  path-data-parser@0.1.0: {}
+
   path-exists@4.0.0: {}
 
   path-expression-matcher@1.5.0:
@@ -16600,6 +17358,13 @@ snapshots:
       playwright-core: 1.61.0
     optionalDependencies:
       fsevents: 2.3.2
+
+  points-on-curve@0.2.0: {}
+
+  points-on-path@0.2.1:
+    dependencies:
+      path-data-parser: 0.1.0
+      points-on-curve: 0.2.0
 
   possible-typed-array-names@1.1.0: {}
 
@@ -17011,6 +17776,8 @@ snapshots:
     dependencies:
       glob: 10.5.0
 
+  robust-predicates@3.0.3: {}
+
   rolldown@1.1.5:
     dependencies:
       '@oxc-project/types': 0.139.0
@@ -17063,6 +17830,13 @@ snapshots:
       '@rollup/rollup-win32-x64-msvc': 4.60.4
       fsevents: 2.3.3
 
+  roughjs@4.6.6:
+    dependencies:
+      hachure-fill: 0.5.2
+      path-data-parser: 0.1.0
+      points-on-curve: 0.2.0
+      points-on-path: 0.2.1
+
   run-applescript@7.1.0: {}
 
   run-async@2.4.1: {}
@@ -17070,6 +17844,8 @@ snapshots:
   run-parallel@1.2.0:
     dependencies:
       queue-microtask: 1.2.3
+
+  rw@1.3.3: {}
 
   rxjs@7.8.2:
     dependencies:
@@ -17544,11 +18320,11 @@ snapshots:
     dependencies:
       js-tokens: 9.0.1
 
-  stripe@20.1.2(@types/node@26.1.1):
+  stripe@20.1.2(@types/node@22.19.3):
     dependencies:
       qs: 6.14.1
     optionalDependencies:
-      '@types/node': 26.1.1
+      '@types/node': 22.19.3
 
   strnum@1.1.2:
     optional: true
@@ -17557,6 +18333,8 @@ snapshots:
     optional: true
 
   stubs@3.0.0: {}
+
+  stylis@4.4.0: {}
 
   suf-log@2.5.3:
     dependencies:
@@ -17828,8 +18606,6 @@ snapshots:
   undici-types@6.21.0: {}
 
   undici-types@7.18.2: {}
-
-  undici-types@7.24.6: {}
 
   undici-types@8.3.0: {}
 


### PR DESCRIPTION
Closes #303.

## Summary
- Sixth page build: the long-form article template (`blog/[slug].astro`), covering headings, prose, callouts, code blocks, Mermaid diagrams, and youtube/tweet/instagram embeds.
- Uses already-published `@fhdamd/threads` 0.5.1 components throughout (`Prose`, `Callout`, `CodeBlock`, `MermaidDiagramCard`, `EmbedCard`, `TableOfContents`, `Breadcrumb`, `ContentCard`, `ReadingProgressBar`) — no new Threads components needed.
- Three small client islands, matching the existing `ContactForm`/`PostGrid` pattern: `MermaidDiagram` (lazy-loads mermaid, renders from source, re-renders on theme toggle, scales the SVG to fill its container), `ArticleReadingProgress` (thin ref-resolving wrapper for `ReadingProgressBar`), `CopyLinkButton`.
- Real syntax highlighting via Shiki (already an Astro dependency, added explicitly), resolved at build time.

## Notable fixes along the way
- Hero/article sections were missing `Container` wrapping entirely — no centering, no side padding. Fixed.
- A CSS Grid `min-width:auto` blowout let the code block push the whole layout into horizontal overflow on mobile. Fixed.
- Hero/byline/footer-meta rows converted to `Stack`/`Cluster` instead of hand-rolled flex CSS.
- Dropped the bottom `AuthorBox` — the top byline already covers author info, so it was redundant.
- Precomputed React nodes (and arrays of them) can't be passed as bare Astro children even into a React component — same "[object Object]" gotcha as earlier pages, hit again here for syntax-highlighted code. Fixed by building the token spans as literal JSX inside the template's own `.map()` instead of precomputing them.

## Filed for follow-up (not blocking this PR)
- #304 — `MermaidDiagramCard` needs an expand-to-fullscreen control for genuine legibility on complex diagrams. Real diagram width is capped by the article column regardless of card padding, so this needs a proper expand affordance rather than further CSS sizing tweaks.
- #305 — `TableOfContents`'s mobile bar collides with a sticky site header (no `className` forwarded on that variant); worked around here via its `data-testid`.

## Test plan
- [x] `pnpm --filter fhdamd-web build` succeeds
- [x] `tsc --noEmit` and `eslint` pass (app + repo-wide via turbo)
- [x] Visual check against `blog-post.html` design (desktop + mobile) via Playwright screenshots
- [x] Mermaid diagrams render and re-render correctly on theme toggle; syntax-highlighted code block copy button copies clean plain text
- [x] TOC scroll-spy and mobile dropdown work; no horizontal overflow on mobile (375–900px sweep)