### PR TITLE
feat(fhdamd-web): Case Studies listing page against typed mock data

### DIFF
--- a/apps/fhdamd-web/src/components/CaseStudyGrid/CaseStudyGrid.tsx
+++ b/apps/fhdamd-web/src/components/CaseStudyGrid/CaseStudyGrid.tsx
@@ -1,0 +1,64 @@
+import { useMemo, useState } from "react";
+import { Stack, Grid, ContentCard, TagFilterBar } from "@fhdamd/threads";
+import { titleToReact } from "../../utils/titleToReact";
+import {
+  CASE_STUDY_TAG_LABELS,
+  CASE_STUDY_TAG_BADGE_VARIANT,
+} from "../../utils/caseStudyTags";
+import type { CaseStudyItem } from "../../content/types";
+
+interface CaseStudyGridProps {
+  items: CaseStudyItem[];
+}
+
+/**
+ * Tag pills and grid share filter state, so both live in one island rather
+ * than two — TagFilterBar only reports the active tag via onChange, it
+ * doesn't touch the grid itself. Same pattern as Blog's PostGrid.
+ */
+export function CaseStudyGrid({ items }: CaseStudyGridProps) {
+  const tagOptions = useMemo(() => {
+    const seen = new Set<string>();
+    items.forEach((item) => seen.add(item.tag));
+    return Array.from(seen).map((value) => ({
+      value,
+      label: CASE_STUDY_TAG_LABELS[value] ?? value,
+    }));
+  }, [items]);
+
+  const [activeTag, setActiveTag] = useState("all");
+  const visible =
+    activeTag === "all"
+      ? items
+      : items.filter((item) => item.tag === activeTag);
+
+  return (
+    <Stack gap={5}>
+      <TagFilterBar
+        tags={tagOptions}
+        allLabel="All case studies"
+        onChange={setActiveTag}
+      />
+      <Grid cols={3} gap={4}>
+        {visible.map((item) => (
+          <ContentCard
+            key={item.slug}
+            href={item.comingSoon ? undefined : `/case-studies/${item.slug}`}
+            date={item.dateLabel}
+            description={item.description}
+            title={titleToReact(item.title, {
+              color: "var(--th-color-accent)",
+            })}
+            comingSoon={item.comingSoon}
+            badges={[
+              {
+                label: CASE_STUDY_TAG_LABELS[item.tag] ?? item.tag,
+                variant: CASE_STUDY_TAG_BADGE_VARIANT[item.tag],
+              },
+            ]}
+          />
+        ))}
+      </Grid>
+    </Stack>
+  );
+}

--- a/apps/fhdamd-web/src/content/mock/caseStudiesPage.ts
+++ b/apps/fhdamd-web/src/content/mock/caseStudiesPage.ts
@@ -1,0 +1,47 @@
+import type { CaseStudiesPage } from "../types";
+
+export const caseStudiesPage: CaseStudiesPage = {
+  heroKicker: "Case studies",
+  heroHeading: "Real engagements, *real outcomes.*",
+  heroSubheading:
+    "Full write-ups of client work outside EY — what the brief was, the decisions made along the way, and how it turned out. Most enterprise work at EY is confidential by nature, so this is where the independent projects live.",
+
+  featured: {
+    slug: "rzest",
+    eyebrowMeta: "Structural engineering · New Delhi",
+    title: "RZest Engineers — *a Presence build in under three weeks*",
+    description:
+      "A brochure-and-portfolio site for a New Delhi structural engineering firm — a filterable project portfolio, DatoCMS-backed case study pages, and full OG/meta implementation, built on Astro and delivered in under three weeks.",
+    dateLabel: "Delivered",
+    tag: "website",
+    techBadge: "Astro · DatoCMS",
+  },
+
+  items: [
+    {
+      slug: "rzest",
+      title: "RZest Engineers",
+      description:
+        "Filterable project portfolio and case study pages for a structural engineering firm.",
+      dateLabel: "Delivered",
+      tag: "website",
+    },
+    {
+      slug: "next-app",
+      title: "Next case study",
+      description:
+        "Reserved for the next apps & products engagement — same template, new client.",
+      dateLabel: "Coming soon",
+      tag: "app",
+      comingSoon: true,
+    },
+    {
+      slug: "next-advisory",
+      title: "Next case study",
+      description: "Reserved for the next architecture or advisory engagement.",
+      dateLabel: "Coming soon",
+      tag: "advisory",
+      comingSoon: true,
+    },
+  ],
+};

--- a/apps/fhdamd-web/src/content/types.ts
+++ b/apps/fhdamd-web/src/content/types.ts
@@ -168,6 +168,33 @@ export interface BlogPage {
   posts: BlogPost[];
 }
 
+export interface CaseStudyItem {
+  slug: string;
+  /** Plain string; wrap a segment in *asterisks* for an <em> accent. */
+  title: string;
+  description: string;
+  /** Display label, e.g. "Delivered" or "Coming soon" — not a real date. */
+  dateLabel: string;
+  tag: "website" | "app" | "advisory";
+  /** Dashed, non-interactive placeholder tile — no href, no arrow. */
+  comingSoon?: boolean;
+}
+
+export interface FeaturedCaseStudy extends CaseStudyItem {
+  eyebrowMeta: string;
+  /** Secondary meta badge, e.g. "Astro · DatoCMS". */
+  techBadge: string;
+}
+
+export interface CaseStudiesPage {
+  heroKicker: string;
+  /** Plain string; wrap a segment in *asterisks* for an <em> accent. */
+  heroHeading: string;
+  heroSubheading: string;
+  featured: FeaturedCaseStudy;
+  items: CaseStudyItem[];
+}
+
 export type BlogEmbed =
   | { kind: "youtube"; videoUrl: string; title: string }
   | {

--- a/apps/fhdamd-web/src/lib/cms/index.ts
+++ b/apps/fhdamd-web/src/lib/cms/index.ts
@@ -1,14 +1,15 @@
-import { siteSettings } from '../../content/mock/siteSettings';
-import { aboutPage } from '../../content/mock/aboutPage';
-import { contactPage } from '../../content/mock/contactPage';
-import { homePage } from '../../content/mock/homePage';
-import { servicesPage } from '../../content/mock/servicesPage';
-import { blogPage } from '../../content/mock/blogPage';
-import { blogPostDetails } from '../../content/mock/blogPostDetails';
-import { employers } from '../../content/mock/employers';
-import { clientWork } from '../../content/mock/clientWork';
-import { experience } from '../../content/mock/experience';
-import { skills } from '../../content/mock/skills';
+import { siteSettings } from "../../content/mock/siteSettings";
+import { aboutPage } from "../../content/mock/aboutPage";
+import { contactPage } from "../../content/mock/contactPage";
+import { homePage } from "../../content/mock/homePage";
+import { servicesPage } from "../../content/mock/servicesPage";
+import { blogPage } from "../../content/mock/blogPage";
+import { blogPostDetails } from "../../content/mock/blogPostDetails";
+import { caseStudiesPage } from "../../content/mock/caseStudiesPage";
+import { employers } from "../../content/mock/employers";
+import { clientWork } from "../../content/mock/clientWork";
+import { experience } from "../../content/mock/experience";
+import { skills } from "../../content/mock/skills";
 import type {
   SiteSettings,
   AboutPage,
@@ -17,11 +18,12 @@ import type {
   ServicesPage,
   BlogPage,
   BlogPostDetail,
+  CaseStudiesPage,
   Employer,
   ClientWorkItem,
   ExperienceItem,
   SkillCategory,
-} from '../../content/types';
+} from "../../content/types";
 
 /**
  * Thin data-access layer — one function per content type, each currently
@@ -56,6 +58,10 @@ export async function getBlogPage(): Promise<BlogPage> {
 
 export async function getBlogPostDetails(): Promise<BlogPostDetail[]> {
   return blogPostDetails;
+}
+
+export async function getCaseStudiesPage(): Promise<CaseStudiesPage> {
+  return caseStudiesPage;
 }
 
 export async function getEmployers(): Promise<Employer[]> {

--- a/apps/fhdamd-web/src/pages/case-studies/index.astro
+++ b/apps/fhdamd-web/src/pages/case-studies/index.astro
@@ -1,0 +1,92 @@
+---
+import { createElement, Fragment as ReactFragment } from "react";
+import Layout from "../../layouts/Layout.astro";
+import {
+  Container,
+  Section,
+  Stack,
+  Hero,
+  FeaturedCard,
+  Button,
+  DarkStrip,
+} from "@fhdamd/threads";
+import { getCaseStudiesPage, getSiteSettings } from "../../lib/cms";
+import { titleToReact } from "../../utils/titleToReact";
+import {
+  CASE_STUDY_TAG_LABELS,
+  CASE_STUDY_TAG_BADGE_VARIANT,
+} from "../../utils/caseStudyTags";
+import { ArrowRightIcon } from "../../components/icons/icons";
+import { CaseStudyGrid } from "../../components/CaseStudyGrid/CaseStudyGrid";
+
+const page = await getCaseStudiesPage();
+const settings = await getSiteSettings();
+
+// Astro's template compiler intercepts bare JSX written as a prop-expression
+// value and hands React an internal object instead of a real element, so
+// every such value must be precomputed here and passed as a plain variable.
+const heroHeading = titleToReact(page.heroHeading, {
+  color: "var(--th-color-accent)",
+});
+const arrowRightIcon = createElement(ArrowRightIcon);
+const featuredTitle = titleToReact(page.featured.title, {
+  color: "var(--th-color-accent)",
+});
+
+const featuredMetaBadges = [
+  {
+    label: CASE_STUDY_TAG_LABELS[page.featured.tag] ?? page.featured.tag,
+    variant: CASE_STUDY_TAG_BADGE_VARIANT[page.featured.tag],
+  },
+  { label: page.featured.techBadge, variant: "neutral" as const },
+];
+
+const ctaHeading = titleToReact(settings.ctaTitle);
+const ctaActions = createElement(
+  ReactFragment,
+  null,
+  createElement(
+    Button,
+    { href: "/services", variant: "solid-ink", icon: arrowRightIcon },
+    "View services",
+  ),
+  createElement(Button, { href: "/contact", variant: "ghost" }, "Get in touch"),
+);
+---
+
+<Layout title={`Case Studies — Fahad Ahmed · fhdamd.dev`}>
+  <Container>
+    <Hero
+      eyebrow={page.heroKicker}
+      heading={heroHeading}
+      body={page.heroSubheading}
+    />
+  </Container>
+
+  <Container>
+    <Section size="md">
+      <Stack gap={8}>
+        <FeaturedCard
+          href={`/case-studies/${page.featured.slug}`}
+          eyebrowMeta={page.featured.eyebrowMeta}
+          title={featuredTitle}
+          description={page.featured.description}
+          metaBadges={featuredMetaBadges}
+        />
+
+        <CaseStudyGrid client:load items={page.items} />
+      </Stack>
+    </Section>
+  </Container>
+
+  <Container>
+    <Section size="md">
+      <DarkStrip
+        heading={ctaHeading}
+        body={settings.ctaSubtitle}
+        align="start"
+        actions={ctaActions}
+      />
+    </Section>
+  </Container>
+</Layout>

--- a/apps/fhdamd-web/src/utils/caseStudyTags.ts
+++ b/apps/fhdamd-web/src/utils/caseStudyTags.ts
@@ -1,0 +1,13 @@
+import type { BadgeVariant } from "@fhdamd/threads";
+
+export const CASE_STUDY_TAG_LABELS: Record<string, string> = {
+  website: "Custom website",
+  app: "Apps & products",
+  advisory: "Architecture & advisory",
+};
+
+export const CASE_STUDY_TAG_BADGE_VARIANT: Record<string, BadgeVariant> = {
+  website: "terra",
+  app: "neutral",
+  advisory: "neutral",
+};


### PR DESCRIPTION
Closes #307.

## Summary
- Seventh page build, same established pattern as Blog (typed mock data → `src/lib/cms` → Astro page from Threads components).
- Reuses `FeaturedCard`, `ContentCard`, and `TagFilterBar` from `@fhdamd/threads` 0.5.1 — `ContentCard`'s existing `comingSoon` prop covers the two placeholder tiles exactly, no new component work needed.
- Small React island (`CaseStudyGrid`, `client:load`) composing `TagFilterBar` + `Grid` + `ContentCard` with local filter state, matching Blog's `PostGrid` island. Tag pills derived from data, not hardcoded.
- Routed under `src/pages/case-studies/index.astro` (folder, matching Blog's convention) so the upcoming `case-studies/[slug].astro` (rzest) detail page sits alongside it.

## Test plan
- [x] `pnpm --filter fhdamd-web build` succeeds
- [x] `tsc --noEmit` and `eslint` pass (app + repo-wide via turbo)
- [x] Visual check against `case-studies.html` design (desktop + mobile) via Playwright screenshots
- [x] Tag filter pills correctly narrow the grid (verified "Architecture & advisory" isolates the right tile); featured card stays visible regardless of filter
- [x] No horizontal overflow on mobile (390px viewport)