### PR TITLE
feat(fhdamd-web): Case Study detail page (rzest) against typed mock data

### DIFF
--- a/apps/fhdamd-web/src/content/mock/caseStudyDetails.ts
+++ b/apps/fhdamd-web/src/content/mock/caseStudyDetails.ts
@@ -1,0 +1,156 @@
+import type { CaseStudyDetail } from "../types";
+
+export const caseStudyDetails: CaseStudyDetail[] = [
+  {
+    slug: "rzest",
+    breadcrumbCategory: "Custom website",
+    badges: [
+      { label: "Custom website", variant: "terra" },
+      { label: "Astro · DatoCMS", variant: "neutral" },
+    ],
+    title: "RZest Engineers — a Presence build *in under three weeks*",
+    dek: "A New Delhi structural engineering firm needed a site that looked as credible as their client list — with a portfolio their own team could keep current without filing a ticket with a developer every time a project wrapped.",
+    authorInitials: "FA",
+    authorName: "Fahad Ahmed",
+    authorRole: "Solution Architect",
+    clientName: "RZest Engineers",
+    location: "New Delhi",
+    facts: [
+      { label: "Client", value: "RZest Engineers" },
+      { label: "Industry", value: "Structural engineering" },
+      { label: "Timeline", value: "Under 3 weeks" },
+      { label: "Offering", value: "Custom website" },
+      { label: "Stack", value: "Astro · DatoCMS" },
+    ],
+    postTags: ["Custom website", "Astro", "DatoCMS", "Presence"],
+    buildCreditName: "Built by Fahad Ahmed",
+    buildCreditRole: "Solution Architect · fhdamd.dev",
+    buildCreditBio:
+      "Designed and built end to end — brand, content model, and code.",
+    relatedItems: [
+      {
+        badgeLabel: "Architecture",
+        badgeVariant: "neutral",
+        title: "Building a sequence diagram you can trust",
+        dateLabel: "From the blog",
+        href: "/blog/sequence-diagram-you-can-trust",
+      },
+      {
+        badgeLabel: "Apps & products",
+        badgeVariant: "neutral",
+        title: "Next case study — reserved",
+        dateLabel: "Coming soon",
+        href: "/case-studies",
+      },
+      {
+        badgeLabel: "Architecture & advisory",
+        badgeVariant: "neutral",
+        title: "Next case study — reserved",
+        dateLabel: "Coming soon",
+        href: "/case-studies",
+      },
+    ],
+    body: [
+      { type: "heading", id: "overview", text: "*Overview*" },
+      {
+        type: "html",
+        html: "<p>RZest Engineers is a structural engineering practice in New Delhi — the kind of firm whose clients decide whether to call based on whether the last ten projects look credible. Their old site was a static one-pager with a project list that hadn't been touched in over a year, because updating it meant emailing a developer and waiting.</p><p>They came to me through a referral wanting a <b>Presence-tier</b> build: a brochure site with a real, browsable portfolio — and, critically, one they could keep current themselves.</p>",
+      },
+      {
+        type: "screenshot",
+        caption: "Homepage screenshot — swap in the live capture",
+      },
+
+      { type: "heading", id: "challenge", text: "The *challenge*" },
+      {
+        type: "html",
+        html: "<p>Three constraints shaped the build: a tight three-week timeline set by an upcoming tender the firm wanted to point prospective clients to, a portfolio that needed to be filterable by project type and sector rather than just listed, and a non-technical team who needed to add new projects without touching code.</p>",
+      },
+      {
+        type: "callout",
+        variant: "warn",
+        title: "The real constraint wasn't the timeline",
+        body: "It was building something that would still look intentional a year later, once the firm — not me — was the one adding content to it.",
+      },
+
+      { type: "heading", id: "approach", text: "The *approach*" },
+      {
+        type: "html",
+        html: "<p>The build started the same way every Presence engagement does: a component library drawn from the firm's existing brand marks before a single page was laid out, so the site would read as considered rather than assembled. The content model went into DatoCMS — projects, sectors, and case study pages as structured content, not hard-coded markup.</p>",
+      },
+      {
+        type: "code",
+        filename: "src/content/config.ts",
+        code: `import { defineCollection, z } from 'astro:content';
+import { datocmsLoader } from './loaders/datocms';
+
+// Projects are structured content in DatoCMS, not hard-coded pages —
+// the client adds a project, the portfolio and filters update themselves.
+const projects = defineCollection({
+  loader: datocmsLoader('project'),
+  schema: z.object({
+    title: z.string(),
+    sector: z.enum(['residential', 'commercial', 'infrastructure']),
+    completedYear: z.number(),
+    heroImage: z.string(),
+  }),
+});
+
+export const collections = { projects };`,
+      },
+      {
+        type: "html",
+        html: "<p>With the content model settled, the portfolio's filter-by-sector interaction and the case-study page template were the two pieces of actual custom engineering — everything else was composition of the component library against DatoCMS data.</p>",
+      },
+      {
+        type: "diagram",
+        label: "Architecture · Mermaid",
+        caption:
+          "Content lives in DatoCMS; the site rebuilds and redeploys on publish — no server to manage",
+        source: `flowchart LR
+    accTitle: RZest Engineers site architecture
+    accDescr: The client edits projects in DatoCMS, which Astro builds at deploy time into a static site served from Firebase Hosting, with a client-side filter over the pre-built portfolio data.
+    A[RZest team] -->|Adds a project| B[DatoCMS]
+    B -->|Build-time fetch| C[Astro SSG]
+    C -->|Static output| D[Firebase Hosting]
+    C -->|Portfolio JSON| E[Client-side sector filter]
+    D --> F[Visitor]
+    E --> F`,
+      },
+
+      { type: "heading", id: "built", text: "What was *built*" },
+      {
+        type: "html",
+        html: "<ul><li>A component library drawn from RZest's existing brand marks — colour, type, cards, and layout, consistent before the first real page was built.</li><li>A filterable project portfolio, sortable by sector, backed by structured content in DatoCMS rather than hard-coded HTML.</li><li>A reusable case-study page template so each completed project gets its own page without a one-off build.</li><li>Full Open Graph and meta implementation, so project pages preview properly when shared.</li><li>A CMS the RZest team could use directly — no developer in the loop to publish a new project.</li></ul>",
+      },
+      {
+        type: "screenshot",
+        caption:
+          "Portfolio & case study page screenshots — swap in the live captures",
+      },
+
+      { type: "heading", id: "results", text: "*Results*" },
+      {
+        type: "statRow",
+        stats: [
+          { number: "<3", unit: "wks", label: "Discovery to launch" },
+          {
+            number: "0",
+            label: "Dev tickets needed to publish a new project since launch",
+          },
+          { number: "100", unit: "%", label: "Pages with OG/meta coverage" },
+        ],
+      },
+      {
+        type: "html",
+        html: "<blockquote>The brief was simple to state and easy to get wrong: a site the RZest team could grow themselves, that still looked like it had a firm hand behind it on day one and a year later.</blockquote>",
+      },
+      {
+        type: "testimonialReserved",
+        title: "Client testimonial — reserved",
+        description:
+          "A quote from Rabi Akhtar at RZest Engineers goes here once confirmed — not written on their behalf.",
+      },
+    ],
+  },
+];

--- a/apps/fhdamd-web/src/content/types.ts
+++ b/apps/fhdamd-web/src/content/types.ts
@@ -206,7 +206,7 @@ export type BlogEmbed =
     }
   | { kind: "instagram"; accountName: string; caption?: string };
 
-export type BlogContentBlock =
+export type ArticleContentBlock =
   /** id must be unique on the page — TableOfContents links to it and scroll-spies it. */
   | { type: "heading"; id: string; text: string }
   | { type: "subheading"; id: string; text: string }
@@ -218,7 +218,14 @@ export type BlogContentBlock =
   | { type: "code"; filename?: string; lang?: string; code: string }
   /** source is raw Mermaid syntax, rendered client-side — see MermaidDiagram island. */
   | { type: "diagram"; label: string; caption?: string; source: string }
-  | ({ type: "embed" } & BlogEmbed);
+  | ({ type: "embed" } & BlogEmbed)
+  /** No src yet — always the placeholder state until real screenshots exist. */
+  | { type: "screenshot"; caption?: string }
+  | {
+      type: "statRow";
+      stats: { number: string; unit?: string; label: string }[];
+    }
+  | { type: "testimonialReserved"; title?: string; description: string };
 
 export interface BlogPostDetail {
   slug: string;
@@ -233,10 +240,41 @@ export interface BlogPostDetail {
   authorRole: string;
   publishedDate: string;
   readTime: string;
-  body: BlogContentBlock[];
+  body: ArticleContentBlock[];
   postTags: string[];
   /** Slugs into BlogPage's posts/featuredPost, for the related-posts grid. */
   relatedSlugs: string[];
+}
+
+export interface CaseStudyRelatedItem {
+  badgeLabel: string;
+  badgeVariant: "terra" | "sage" | "neutral";
+  title: string;
+  dateLabel: string;
+  href: string;
+}
+
+export interface CaseStudyDetail {
+  slug: string;
+  breadcrumbCategory: string;
+  badges: { label: string; variant: "terra" | "sage" | "neutral" }[];
+  /** Plain string; wrap a segment in *asterisks* for an <em> accent. */
+  title: string;
+  dek: string;
+  authorInitials: string;
+  authorName: string;
+  authorRole: string;
+  clientName: string;
+  location: string;
+  facts: { label: string; value: string }[];
+  body: ArticleContentBlock[];
+  postTags: string[];
+  buildCreditName: string;
+  buildCreditRole: string;
+  /** Plain string; wrap a segment in *asterisks* for an <em> accent, and a trailing
+   *  "[Get a proposal](/contact)"-style link is appended in the page itself. */
+  buildCreditBio: string;
+  relatedItems: CaseStudyRelatedItem[];
 }
 
 export interface Employer {

--- a/apps/fhdamd-web/src/lib/cms/index.ts
+++ b/apps/fhdamd-web/src/lib/cms/index.ts
@@ -6,6 +6,7 @@ import { servicesPage } from "../../content/mock/servicesPage";
 import { blogPage } from "../../content/mock/blogPage";
 import { blogPostDetails } from "../../content/mock/blogPostDetails";
 import { caseStudiesPage } from "../../content/mock/caseStudiesPage";
+import { caseStudyDetails } from "../../content/mock/caseStudyDetails";
 import { employers } from "../../content/mock/employers";
 import { clientWork } from "../../content/mock/clientWork";
 import { experience } from "../../content/mock/experience";
@@ -19,6 +20,7 @@ import type {
   BlogPage,
   BlogPostDetail,
   CaseStudiesPage,
+  CaseStudyDetail,
   Employer,
   ClientWorkItem,
   ExperienceItem,
@@ -62,6 +64,10 @@ export async function getBlogPostDetails(): Promise<BlogPostDetail[]> {
 
 export async function getCaseStudiesPage(): Promise<CaseStudiesPage> {
   return caseStudiesPage;
+}
+
+export async function getCaseStudyDetails(): Promise<CaseStudyDetail[]> {
+  return caseStudyDetails;
 }
 
 export async function getEmployers(): Promise<Employer[]> {

--- a/apps/fhdamd-web/src/pages/case-studies/[slug].astro
+++ b/apps/fhdamd-web/src/pages/case-studies/[slug].astro
@@ -15,19 +15,18 @@ import {
   Prose,
   CodeBlock,
   MermaidDiagramCard,
-  EmbedCard,
   TableOfContents,
   Callout,
   ContentCard,
   SectionHeader,
+  FactStrip,
+  ScreenshotFigure,
+  StatRow,
+  Testimonial,
+  AuthorBox,
 } from "@fhdamd/threads";
-import {
-  getBlogPostDetails,
-  getBlogPage,
-  getSiteSettings,
-} from "../../lib/cms";
+import { getCaseStudyDetails, getSiteSettings } from "../../lib/cms";
 import { titleToReact, markupToHtml } from "../../utils/titleToReact";
-import { BLOG_TAG_LABELS, BLOG_TAG_BADGE_VARIANT } from "../../utils/blogTags";
 import {
   ArrowRightIcon,
   TwitterIcon,
@@ -42,56 +41,59 @@ import type { ArticleContentBlock } from "../../content/types";
 import "../../styles/blogPost.css";
 
 export async function getStaticPaths() {
-  const posts = await getBlogPostDetails();
-  return posts.map((post) => ({ params: { slug: post.slug } }));
+  const items = await getCaseStudyDetails();
+  return items.map((item) => ({ params: { slug: item.slug } }));
 }
 
 const { slug } = Astro.params;
-const posts = await getBlogPostDetails();
-// getStaticPaths only generates a route per mock post above, so this is always found.
-const post = posts.find((p) => p.slug === slug)!;
+const items = await getCaseStudyDetails();
+// getStaticPaths only generates a route per mock item above, so this is always found.
+const study = items.find((i) => i.slug === slug)!;
 
-const blog = await getBlogPage();
 const settings = await getSiteSettings();
 
-const heroTitleHtml = markupToHtml(post.title);
+const heroTitleHtml = markupToHtml(study.title);
 const arrowRightIcon = createElement(ArrowRightIcon);
 const starIcon = createElement(StarIcon);
 
 const breadcrumbItems = [
-  { label: "Blog", href: "/blog" },
-  { label: post.breadcrumbCategory },
+  { label: "Case Studies", href: "/case-studies" },
+  { label: study.breadcrumbCategory },
 ];
 
 const isHeading = (
   block: ArticleContentBlock,
 ): block is Extract<ArticleContentBlock, { type: "heading" }> =>
   block.type === "heading";
-const tocItems = post.body
+const tocItems = study.body
   .filter(isHeading)
   .map((block) => ({ id: block.id, label: block.text.replace(/\*/g, "") }));
 
 // Astro templates can't await inline, so every code block's syntax
-// highlighting is resolved up front here, keyed by its index in post.body.
+// highlighting is resolved up front here, keyed by its index in study.body.
 const highlightedCode = new Map<
   number,
   Awaited<ReturnType<typeof highlightCode>>
 >();
-for (let i = 0; i < post.body.length; i++) {
-  const block = post.body[i];
+for (let i = 0; i < study.body.length; i++) {
+  const block = study.body[i];
   if (block.type === "code") {
     highlightedCode.set(i, await highlightCode(block.code, block.lang ?? "ts"));
   }
 }
 
-const allPosts = [blog.featuredPost, ...blog.posts];
-const relatedPosts = post.relatedSlugs
-  .map((relSlug) => allPosts.find((p) => p.slug === relSlug))
-  .filter((p): p is (typeof allPosts)[number] => Boolean(p));
-const relatedTitle = titleToReact("Related *posts*");
+const buildCreditBio = createElement(
+  ReactFragment,
+  null,
+  `${study.buildCreditBio} Considering something similar? `,
+  createElement("a", { href: "/contact" }, "Get a proposal"),
+  ".",
+);
+
+const relatedTitle = titleToReact("More *case studies*");
 
 const canonicalUrl = new URL(Astro.url.pathname, "https://fhdamd.dev").href;
-const shareText = encodeURIComponent(post.title.replace(/\*/g, ""));
+const shareText = encodeURIComponent(study.title.replace(/\*/g, ""));
 const twitterShareHref = `https://twitter.com/intent/tweet?text=${shareText}&url=${encodeURIComponent(canonicalUrl)}`;
 const linkedinShareHref = `https://www.linkedin.com/sharing/share-offsite/?url=${encodeURIComponent(canonicalUrl)}`;
 
@@ -109,8 +111,8 @@ const ctaActions = createElement(
 ---
 
 <Layout
-  title={`${post.title.replace(/\*/g, "")} — Fahad Ahmed · fhdamd.dev`}
-  description={post.dek}
+  title={`${study.title.replace(/\*/g, "")} — Fahad Ahmed · fhdamd.dev`}
+  description={study.dek}
 >
   <ArticleReadingProgress client:load targetSelector=".post-article" />
 
@@ -118,28 +120,28 @@ const ctaActions = createElement(
     <Stack gap={5} className="post-hero">
       <Breadcrumb items={breadcrumbItems} />
       <Cluster gap={2}>
-        {
-          post.badges.map((tag) => (
-            <Badge variant="neutral">{BLOG_TAG_LABELS[tag] ?? tag}</Badge>
-          ))
-        }
+        {study.badges.map((b) => <Badge variant={b.variant}>{b.label}</Badge>)}
       </Cluster>
       <h1 class="post-hero__title" set:html={heroTitleHtml} />
-      <p class="post-hero__dek">{post.dek}</p>
+      <p class="post-hero__dek">{study.dek}</p>
       <Cluster gap={3} className="post-byline">
         <Cluster gap={2}>
-          <div class="post-byline__avatar">{post.authorInitials}</div>
+          <div class="post-byline__avatar">{study.authorInitials}</div>
           <div>
-            <div class="post-byline__name">{post.authorName}</div>
-            <div class="post-byline__role">{post.authorRole}</div>
+            <div class="post-byline__name">{study.authorName}</div>
+            <div class="post-byline__role">{study.authorRole}</div>
           </div>
         </Cluster>
         <span class="post-byline__sep">·</span>
-        <span class="post-byline__item">{post.publishedDate}</span>
+        <span class="post-byline__item">{study.clientName}</span>
         <span class="post-byline__sep">·</span>
-        <span class="post-byline__item">{post.readTime}</span>
+        <span class="post-byline__item">{study.location}</span>
       </Cluster>
     </Stack>
+  </Container>
+
+  <Container>
+    <FactStrip facts={study.facts} />
   </Container>
 
   <Container>
@@ -148,7 +150,7 @@ const ctaActions = createElement(
 
       <Prose className="post-article">
         {
-          post.body.map((block, i) => {
+          study.body.map((block, i) => {
             if (block.type === "heading") {
               return <h2 id={block.id} set:html={markupToHtml(block.text)} />;
             }
@@ -201,39 +203,30 @@ const ctaActions = createElement(
                 </MermaidDiagramCard>
               );
             }
-            if (block.kind === "youtube") {
+            if (block.type === "screenshot") {
+              return <ScreenshotFigure caption={block.caption} />;
+            }
+            if (block.type === "statRow") {
+              return <StatRow stats={block.stats} />;
+            }
+            if (block.type === "testimonialReserved") {
               return (
-                <EmbedCard
-                  type="youtube"
-                  videoUrl={block.videoUrl}
+                <Testimonial
+                  reserved
                   title={block.title}
+                  description={block.description}
                 />
               );
             }
-            if (block.kind === "tweet") {
-              return (
-                <EmbedCard
-                  type="tweet"
-                  authorName={block.authorName}
-                  handle={block.handle}
-                  text={block.text}
-                  foot={block.foot}
-                />
-              );
-            }
-            return (
-              <EmbedCard
-                type="instagram"
-                accountName={block.accountName}
-                caption={block.caption}
-              />
-            );
+            // No embeds in this mock content, but the shared block union allows
+            // them — nothing to render for that case on this page.
+            return null;
           })
         }
 
         <Cluster gap={4} justify="between" className="post-footer-meta">
           <Cluster gap={2}>
-            {post.postTags.map((tag) => <Tag>{tag}</Tag>)}
+            {study.postTags.map((tag) => <Tag>{tag}</Tag>)}
           </Cluster>
           <Cluster gap={2}>
             <a
@@ -259,32 +252,33 @@ const ctaActions = createElement(
             <CopyLinkButton client:load />
           </Cluster>
         </Cluster>
+
+        <AuthorBox
+          initials={study.authorInitials}
+          name={study.buildCreditName}
+          role={study.buildCreditRole}
+          bio={buildCreditBio}
+        />
       </Prose>
     </div>
   </Container>
 
   {
-    relatedPosts.length > 0 && (
+    study.relatedItems.length > 0 && (
       <section style="border-top:1px solid var(--th-color-border-default)">
         <Container>
           <Section size="md">
             <Stack gap={8}>
-              <SectionHeader title={relatedTitle} meta="More from the blog" />
+              <SectionHeader title={relatedTitle} meta="See the full list" />
               <Grid cols={3} gap={4}>
-                {relatedPosts.map((rp) => (
+                {study.relatedItems.map((item) => (
                   <ContentCard
-                    key={rp.slug}
-                    href={`/blog/${rp.slug}`}
-                    date={rp.date}
-                    description={rp.description}
-                    title={titleToReact(rp.title, {
-                      color: "var(--th-color-accent)",
-                    })}
+                    key={item.href + item.title}
+                    href={item.href}
+                    date={item.dateLabel}
+                    title={item.title}
                     badges={[
-                      {
-                        label: BLOG_TAG_LABELS[rp.tags[0]] ?? rp.tags[0],
-                        variant: BLOG_TAG_BADGE_VARIANT[rp.tags[0]],
-                      },
+                      { label: item.badgeLabel, variant: item.badgeVariant },
                     ]}
                   />
                 ))}

--- a/apps/fhdamd-web/src/styles/blogPost.css
+++ b/apps/fhdamd-web/src/styles/blogPost.css
@@ -5,6 +5,7 @@
   max-width: 820px;
   margin-inline: auto;
   padding-top: 56px;
+  padding-bottom: 40px;
 }
 
 .post-hero__title {


### PR DESCRIPTION
Closes #309.

## Summary
- Eighth page build: the rzest case-study detail page, pairing with the Case Studies listing (#307/#308).
- Renamed the shared long-form block-content type `BlogContentBlock` → `ArticleContentBlock` (it wasn't actually blog-specific, and this page reuses it directly), and extended it with three new case-study block variants: `screenshot`, `statRow`, `testimonialReserved`.
- Reuses everything already built for the Blog detail page (#303/#306): `Prose`, `Callout`, `CodeBlock`, `MermaidDiagramCard`, the `MermaidDiagram`/`ArticleReadingProgress`/`CopyLinkButton` islands, and Shiki-based syntax highlighting.
- New components consumed for the first time — `FactStrip`, `ScreenshotFigure`, `StatRow`, `Testimonial` (reserved variant), `AuthorBox` — all already published in `@fhdamd/threads` 0.5.1, no new component work needed.

## Test plan
- [x] `pnpm --filter fhdamd-web build` succeeds
- [x] `tsc --noEmit` and `eslint` pass (app + repo-wide via turbo)
- [x] Visual check against `case-study-detail.html` design (desktop + mobile) via Playwright screenshots
- [x] No horizontal overflow on mobile (390px viewport); `FactStrip` wraps to its own responsive grid correctly
- [x] TOC scroll-spy, reading progress bar, Mermaid diagram rendering, and syntax-highlighted code block all work; "Get a proposal" link in the author bio resolves to `/contact`