### PR TITLE
fix(ci): add --ignore-scripts to dependency installs in workflows

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -41,14 +41,14 @@ jobs:
         uses: pnpm/action-setup@v4
 
       - name: Install dependencies
-        run: pnpm install --frozen-lockfile
+        run: pnpm install --frozen-lockfile --ignore-scripts
 
       - name: Build functions
         working-directory: apps/pdf-craft/functions
         run: pnpm run build
 
       - name: Install Firebase CLI
-        run: pnpm add -g firebase-tools
+        run: pnpm add -g firebase-tools --ignore-scripts
 
       - name: Deploy Firestore rules and indexes
         working-directory: apps/pdf-craft

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -87,14 +87,14 @@ jobs:
           cache: pnpm
 
       - name: Install dependencies
-        run: pnpm install --frozen-lockfile
+        run: pnpm install --frozen-lockfile --ignore-scripts
 
       - name: Build functions
         working-directory: apps/pdf-craft/functions
         run: pnpm run build
 
       - name: Install Firebase CLI
-        run: pnpm add -g firebase-tools
+        run: pnpm add -g firebase-tools --ignore-scripts
 
       - name: Deploy Firestore rules and indexes
         working-directory: apps/pdf-craft

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -90,14 +90,14 @@ jobs:
           cache: pnpm
 
       - name: Install dependencies
-        run: pnpm install --frozen-lockfile
+        run: pnpm install --frozen-lockfile --ignore-scripts
 
       - name: Build functions
         working-directory: apps/pdf-craft/functions
         run: pnpm run build
 
       - name: Install Firebase CLI
-        run: pnpm add -g firebase-tools
+        run: pnpm add -g firebase-tools --ignore-scripts
 
       - name: Deploy Firestore rules and indexes
         working-directory: apps/pdf-craft

--- a/.github/workflows/e2e-staging.yml
+++ b/.github/workflows/e2e-staging.yml
@@ -29,7 +29,7 @@ jobs:
           cache: pnpm
 
       - name: Install dependencies
-        run: pnpm install --frozen-lockfile
+        run: pnpm install --frozen-lockfile --ignore-scripts
 
       - name: Fetch runtime secrets from Secret Manager
         run: |

--- a/.github/workflows/test-pdf-craft.yml
+++ b/.github/workflows/test-pdf-craft.yml
@@ -29,7 +29,7 @@ jobs:
         uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
 
       - name: Install dependencies
-        run: pnpm install --frozen-lockfile
+        run: pnpm install --frozen-lockfile --ignore-scripts
 
       - name: Run tests with coverage
         run: pnpm --filter pdf-craft test:coverage


### PR DESCRIPTION
## Summary
`main`'s SonarCloud quality gate is failing on `new_security_rating` (rule `githubactions:S6505`, 8 hits) — several `pnpm install`/`pnpm add -g` steps across CI workflows don't pass `--ignore-scripts`, meaning a compromised dependency could run arbitrary lifecycle scripts during CI installs.

- `.github/workflows/deploy-dev.yml` (2 installs)
- `.github/workflows/deploy-prod.yml` (2 installs)
- `.github/workflows/deploy-staging.yml` (2 installs)
- `.github/workflows/e2e-staging.yml` (1 install — the dependency install; the Playwright browser-download line is intentionally left alone, see below)
- `.github/workflows/test-pdf-craft.yml` (1 install)

## Validation
None of these 5 workflows trigger automatically on a normal PR (push-to-main-with-path-filter, release-tag-push, or manual dispatch only), so I validated locally in an isolated clone rather than risking an untested change to deploy/CI infrastructure:
- Clean `pnpm install --frozen-lockfile --ignore-scripts` — succeeds, no missing binaries.
- `pnpm --filter pdf-craft build` — succeeds.
- `pnpm --filter pdf-craft test:coverage` — all 34 test files / 352 tests pass.
- `pnpm add -g firebase-tools --ignore-scripts` — installs a working `firebase` CLI (`firebase --version` resolves correctly).

## Note
`e2e-staging.yml`'s `pnpm exec playwright install chromium --with-deps` line matches the same Sonar rule but isn't actually a dependency install — it's Playwright's own browser-download subcommand, which has no `--ignore-scripts` flag (confirmed via `playwright install --help`). Left unchanged; this is very likely a tool false-positive and may need a manual "won't fix" resolution directly in the SonarCloud dashboard rather than a code change.

## Test plan
- [x] Isolated local validation as described above (install, build, full test suite, global CLI install)
- [x] Diff reviewed — only the flagged lines changed, no other behavior touched