### PR TITLE
feat(fhdamd-web): Lab listing page against typed mock data

### DIFF
--- a/apps/fhdamd-web/src/components/LabGrid/LabGrid.tsx
+++ b/apps/fhdamd-web/src/components/LabGrid/LabGrid.tsx
@@ -1,0 +1,61 @@
+import { useMemo, useState } from "react";
+import { Stack, Grid, ContentCard, TagFilterBar } from "@fhdamd/threads";
+import { titleToReact } from "../../utils/titleToReact";
+import { LAB_TAG_LABELS, LAB_TAG_BADGE_VARIANT } from "../../utils/labTags";
+import type { LabItem } from "../../content/types";
+
+interface LabGridProps {
+  items: LabItem[];
+}
+
+/**
+ * Tag pills and grid share filter state, so both live in one island rather
+ * than two — TagFilterBar only reports the active tag via onChange, it
+ * doesn't touch the grid itself. Same pattern as Blog's PostGrid.
+ */
+export function LabGrid({ items }: LabGridProps) {
+  const tagOptions = useMemo(() => {
+    const seen = new Set<string>();
+    items.forEach((item) => item.tags.forEach((tag) => seen.add(tag)));
+    return Array.from(seen).map((value) => ({
+      value,
+      label: LAB_TAG_LABELS[value] ?? value,
+    }));
+  }, [items]);
+
+  const [activeTag, setActiveTag] = useState("all");
+  const visible =
+    activeTag === "all"
+      ? items
+      : items.filter((item) => item.tags.includes(activeTag));
+
+  return (
+    <Stack gap={5}>
+      <TagFilterBar
+        tags={tagOptions}
+        allLabel="All experiments"
+        onChange={setActiveTag}
+      />
+      <Grid cols={3} gap={4}>
+        {visible.map((item, i) => (
+          <ContentCard
+            key={item.href ?? `${item.title}-${i}`}
+            href={item.comingSoon ? undefined : item.href}
+            date={item.dateLabel}
+            description={item.description}
+            title={titleToReact(item.title, {
+              color: "var(--th-color-accent)",
+            })}
+            comingSoon={item.comingSoon}
+            badges={[
+              {
+                label: LAB_TAG_LABELS[item.tags[0]] ?? item.tags[0],
+                variant: LAB_TAG_BADGE_VARIANT[item.tags[0]],
+              },
+            ]}
+          />
+        ))}
+      </Grid>
+    </Stack>
+  );
+}

--- a/apps/fhdamd-web/src/content/mock/labPage.ts
+++ b/apps/fhdamd-web/src/content/mock/labPage.ts
@@ -1,0 +1,35 @@
+import type { LabPage } from "../types";
+
+export const labPage: LabPage = {
+  heroKicker: "Lab",
+  heroHeading: "UI experiments, *played with in the open.*",
+  heroSubheading:
+    "Interaction patterns, component ideas, and small prototypes — the demo-first counterpart to the blog. Some of these get written up properly later; most are just here to be poked at.",
+
+  items: [
+    {
+      href: "/blog/sequence-diagram-you-can-trust",
+      title: "Mermaid diagrams as living docs",
+      description:
+        "Sequence and flow diagrams rendered live from text, with a working theme-toggle re-render.",
+      dateLabel: "View on the blog",
+      tags: ["prototype", "interaction"],
+    },
+    {
+      title: "Next experiment",
+      description:
+        "Reserved for the next component idea worth playing with in the open.",
+      dateLabel: "Coming soon",
+      tags: ["component"],
+      comingSoon: true,
+    },
+    {
+      title: "Next experiment",
+      description:
+        "Reserved for the next interaction pattern worth playing with in the open.",
+      dateLabel: "Coming soon",
+      tags: ["interaction"],
+      comingSoon: true,
+    },
+  ],
+};

--- a/apps/fhdamd-web/src/content/types.ts
+++ b/apps/fhdamd-web/src/content/types.ts
@@ -195,6 +195,27 @@ export interface CaseStudiesPage {
   items: CaseStudyItem[];
 }
 
+export interface LabItem {
+  /** Omitted for comingSoon placeholders — Lab items have no detail pages of
+   *  their own, so a real item links out (e.g. to a blog post). */
+  href?: string;
+  /** Plain string; wrap a segment in *asterisks* for an <em> accent. */
+  title: string;
+  description: string;
+  dateLabel: string;
+  /** First tag is the displayed badge; the full set drives tag-filter matching. */
+  tags: string[];
+  comingSoon?: boolean;
+}
+
+export interface LabPage {
+  heroKicker: string;
+  /** Plain string; wrap a segment in *asterisks* for an <em> accent. */
+  heroHeading: string;
+  heroSubheading: string;
+  items: LabItem[];
+}
+
 export type BlogEmbed =
   | { kind: "youtube"; videoUrl: string; title: string }
   | {

--- a/apps/fhdamd-web/src/lib/cms/index.ts
+++ b/apps/fhdamd-web/src/lib/cms/index.ts
@@ -7,6 +7,7 @@ import { blogPage } from "../../content/mock/blogPage";
 import { blogPostDetails } from "../../content/mock/blogPostDetails";
 import { caseStudiesPage } from "../../content/mock/caseStudiesPage";
 import { caseStudyDetails } from "../../content/mock/caseStudyDetails";
+import { labPage } from "../../content/mock/labPage";
 import { employers } from "../../content/mock/employers";
 import { clientWork } from "../../content/mock/clientWork";
 import { experience } from "../../content/mock/experience";
@@ -21,6 +22,7 @@ import type {
   BlogPostDetail,
   CaseStudiesPage,
   CaseStudyDetail,
+  LabPage,
   Employer,
   ClientWorkItem,
   ExperienceItem,
@@ -68,6 +70,10 @@ export async function getCaseStudiesPage(): Promise<CaseStudiesPage> {
 
 export async function getCaseStudyDetails(): Promise<CaseStudyDetail[]> {
   return caseStudyDetails;
+}
+
+export async function getLabPage(): Promise<LabPage> {
+  return labPage;
 }
 
 export async function getEmployers(): Promise<Employer[]> {

--- a/apps/fhdamd-web/src/pages/lab/index.astro
+++ b/apps/fhdamd-web/src/pages/lab/index.astro
@@ -1,0 +1,104 @@
+---
+import { createElement, Fragment as ReactFragment } from "react";
+import Layout from "../../layouts/Layout.astro";
+import {
+  Container,
+  Section,
+  Stack,
+  Hero,
+  Card,
+  Badge,
+  Button,
+  DarkStrip,
+} from "@fhdamd/threads";
+import { getLabPage, getSiteSettings } from "../../lib/cms";
+import { titleToReact, markupToHtml } from "../../utils/titleToReact";
+import { ArrowRightIcon, SettingsIcon } from "../../components/icons/icons";
+import { LabGrid } from "../../components/LabGrid/LabGrid";
+import "../../styles/lab.css";
+
+const page = await getLabPage();
+const settings = await getSiteSettings();
+
+// Astro's template compiler intercepts bare JSX written as a prop-expression
+// value and hands React an internal object instead of a real element, so
+// every such value must be precomputed here and passed as a plain variable.
+const heroHeading = titleToReact(page.heroHeading, {
+  color: "var(--th-color-accent)",
+});
+const arrowRightIcon = createElement(ArrowRightIcon);
+const demoTitleHtml = markupToHtml("Micro-interactions, *collected*");
+
+const ctaHeading = titleToReact(settings.ctaTitle);
+const ctaActions = createElement(
+  ReactFragment,
+  null,
+  createElement(
+    Button,
+    { href: "/services", variant: "solid-ink", icon: arrowRightIcon },
+    "View services",
+  ),
+  createElement(Button, { href: "/contact", variant: "ghost" }, "Get in touch"),
+);
+---
+
+<Layout title={`Lab — Fahad Ahmed · fhdamd.dev`}>
+  <Container>
+    <Hero
+      eyebrow={page.heroKicker}
+      heading={heroHeading}
+      body={page.heroSubheading}
+    />
+  </Container>
+
+  <Container>
+    <Section size="md">
+      <Stack gap={8}>
+        <!-- Live demo tile: hand-authored, no content model — see #267 -->
+        <Card accentBar="top" accentColor="terra">
+          <div class="demo-eyebrow">
+            <Badge variant="neutral">Live demo</Badge>
+            Interaction
+          </div>
+          <h3 class="demo-title" set:html={demoTitleHtml} />
+          <p class="demo-desc">
+            The small hover and press states used across this site, isolated
+            here so they're easy to poke at on their own. Hover or focus each
+            one.
+          </p>
+          <div class="demo-row">
+            <Button variant="solid-ink" icon={arrowRightIcon}>
+              Magnetic lift
+            </Button>
+            <div class="demo-item demo-item--card">
+              <div class="demo-item__icon">
+                <SettingsIcon />
+              </div>
+              <span>Icon rotate on hover</span>
+            </div>
+            <a class="demo-item demo-item--link" href="/lab"
+              >Underline draw on hover</a
+            >
+            <div class="demo-item">
+              <span class="demo-pulse-dot"><span></span></span>
+              Ambient pulse
+            </div>
+          </div>
+        </Card>
+
+        <LabGrid client:load items={page.items} />
+      </Stack>
+    </Section>
+  </Container>
+
+  <Container>
+    <Section size="md">
+      <DarkStrip
+        heading={ctaHeading}
+        body={settings.ctaSubtitle}
+        align="start"
+        actions={ctaActions}
+      />
+    </Section>
+  </Container>
+</Layout>

--- a/apps/fhdamd-web/src/styles/lab.css
+++ b/apps/fhdamd-web/src/styles/lab.css
@@ -1,0 +1,144 @@
+/* ─── LIVE DEMO TILE — hand-authored, no content model, see #267 ───────────── */
+/* Card has no href, so it can't reuse FeaturedCard (href is required) for a
+   non-link tile — this mirrors FeaturedCard's own typography instead. */
+.demo-eyebrow {
+  font-family: var(--th-font-mono);
+  font-size: 0.6875rem;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+  color: var(--th-color-text-4);
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.demo-title {
+  font-family: var(--th-font-serif);
+  font-weight: 300;
+  font-size: clamp(1.5rem, 3vw, 2.5rem);
+  letter-spacing: -0.02em;
+  line-height: 1.08;
+  color: var(--th-color-text-1);
+}
+
+.demo-title em {
+  font-style: italic;
+  color: var(--th-color-accent);
+}
+
+.demo-desc {
+  font-family: var(--th-font-display);
+  font-variation-settings:
+    "wdth" 90,
+    "wght" 370;
+  font-size: 0.9375rem;
+  line-height: 1.7;
+  color: var(--th-color-text-3);
+  max-width: 640px;
+}
+
+.demo-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 14px;
+  margin-top: 8px;
+}
+
+.demo-item {
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  padding: 12px 18px;
+  background: var(--th-color-bg);
+  border: 1px solid var(--th-color-border-default);
+  border-radius: var(--th-radius-md);
+  font-family: var(--th-font-display);
+  font-variation-settings:
+    "wdth" 90,
+    "wght" 420;
+  font-size: 0.8125rem;
+  color: var(--th-color-text-2);
+  text-decoration: none;
+  transition:
+    transform 0.16s var(--th-ease-out),
+    border-color 0.16s;
+}
+
+.demo-item--card:hover {
+  transform: translateY(-3px);
+  border-color: var(--th-color-border-strong);
+}
+
+.demo-item__icon {
+  width: 24px;
+  height: 24px;
+  border-radius: var(--th-radius-sm);
+  background: var(--th-color-surface-2);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  transition: transform 0.18s var(--th-ease-out);
+}
+
+.demo-item__icon svg {
+  width: 12px;
+  height: 12px;
+  stroke: var(--th-color-text-2);
+  fill: none;
+  stroke-width: 1.6;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+}
+
+.demo-item--card:hover .demo-item__icon {
+  transform: scale(1.08) rotate(-4deg);
+}
+
+.demo-item--link {
+  background-image: linear-gradient(currentColor, currentColor);
+  background-size: 0% 1px;
+  background-position: 0 100%;
+  background-repeat: no-repeat;
+  transition: background-size 0.2s var(--th-ease-out);
+}
+
+.demo-item--link:hover {
+  background-size: 100% 1px;
+}
+
+.demo-pulse-dot {
+  width: 20px;
+  height: 20px;
+  border-radius: 99px;
+  background: var(--th-color-sage-subtle);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+}
+
+.demo-pulse-dot span {
+  width: 7px;
+  height: 7px;
+  border-radius: 99px;
+  background: var(--th-color-sage-text);
+  display: block;
+  animation: demoPulse 2.2s ease-in-out infinite;
+}
+
+@keyframes demoPulse {
+  0%,
+  100% {
+    opacity: 1;
+  }
+  50% {
+    opacity: 0.35;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .demo-pulse-dot span {
+    animation: none;
+  }
+}

--- a/apps/fhdamd-web/src/utils/labTags.ts
+++ b/apps/fhdamd-web/src/utils/labTags.ts
@@ -1,0 +1,13 @@
+import type { BadgeVariant } from "@fhdamd/threads";
+
+export const LAB_TAG_LABELS: Record<string, string> = {
+  interaction: "Interaction",
+  component: "Components",
+  prototype: "Prototype",
+};
+
+export const LAB_TAG_BADGE_VARIANT: Record<string, BadgeVariant> = {
+  interaction: "neutral",
+  component: "neutral",
+  prototype: "sage",
+};


### PR DESCRIPTION
Closes #312.

## Summary
- Ninth and final page build — closes out #266's page-conversion scope entirely.
- Reuses `ContentCard`/`TagFilterBar` via a `LabGrid` island (matching Blog's `PostGrid` and Case Studies' `CaseStudyGrid`) for the experiment grid.
- The "live demo" tile (real hover/press states — icon rotate, underline draw, ambient pulse) is hand-authored directly in the page per the explicit scope carve-out in #267 — there's no meaningful content to model in DatoCMS for it. `Card`'s `accentBar="top" accentColor="terra"` reproduces `FeaturedCard`'s chrome for this tile, since `FeaturedCard` requires an `href` that doesn't apply to a non-link demo card.
- The "Magnetic lift" demo item uses `Button`'s own native hover lift rather than a custom transform — confirmed via computed style that it already matches the design's intended effect.

## Test plan
- [x] `pnpm --filter fhdamd-web build` succeeds
- [x] `tsc --noEmit` and `eslint` pass (app + repo-wide via turbo)
- [x] Visual check against `lab.html` design (desktop + mobile) via Playwright screenshots
- [x] Tag filter correctly narrows the grid; magnetic-lift hover transform verified via computed style
- [x] No horizontal overflow on mobile (390px viewport)