### PR TITLE
feat(ci): add fhdamd-web PR preview channel workflow

### DIFF
--- a/.github/workflows/preview-fhdamd-web.yml
+++ b/.github/workflows/preview-fhdamd-web.yml
@@ -1,0 +1,50 @@
+name: Preview fhdamd-web
+
+on:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - apps/fhdamd-web/**
+
+permissions:
+  checks: write
+  contents: read
+  pull-requests: write
+
+jobs:
+  preview:
+    name: Build and deploy fhdamd-web (preview)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v2
+        with:
+          version: 10
+
+      # Pinned below 22.23.0: that Node security release broke node-fetch's
+      # handling of keep-alive socket closures, which breaks firebase-tools'
+      # Firebase Hosting deploy calls (ERR_STREAM_PREMATURE_CLOSE) — see #201.
+      - name: Set up Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: "22.22.0"
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile --ignore-scripts
+
+      - name: Build fhdamd-web
+        run: pnpm --filter fhdamd-web build
+
+      - name: Deploy to Firebase Hosting (preview channel)
+        uses: FirebaseExtended/action-hosting-deploy@v0
+        with:
+          repoToken: ${{ secrets.GITHUB_TOKEN }}
+          firebaseServiceAccount: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_FAHAD_WEB }}
+          projectId: fahad-web
+          expires: 7d
+          entryPoint: apps/fhdamd-web

--- a/.github/workflows/preview-fhdamd-web.yml
+++ b/.github/workflows/preview-fhdamd-web.yml
@@ -21,7 +21,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v2
+        uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
         with:
           version: 10
 
@@ -41,7 +41,7 @@ jobs:
         run: pnpm --filter fhdamd-web build
 
       - name: Deploy to Firebase Hosting (preview channel)
-        uses: FirebaseExtended/action-hosting-deploy@v0
+        uses: FirebaseExtended/action-hosting-deploy@500ac625ca2dd40cbd15f7659af953801858032a # v0
         with:
           repoToken: ${{ secrets.GITHUB_TOKEN }}
           firebaseServiceAccount: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_FAHAD_WEB }}


### PR DESCRIPTION
Closes #268.

## Summary
New `.github/workflows/preview-fhdamd-web.yml`, modeled directly on `preview-storybook.yml`:
- Builds the Astro static site (`pnpm --filter fhdamd-web build`).
- Deploys via `FirebaseExtended/action-hosting-deploy` to a 7-day Firebase Hosting preview channel on the `fahad-web` project — the service account (`FIREBASE_SERVICE_ACCOUNT_FAHAD_WEB`) was already provisioned in #263.
- Triggers on `pull_request` against `main`, path-filtered to `apps/fhdamd-web/**`.
- Node pinned to `22.22.0` (not latest) — matches `preview-storybook.yml`'s existing workaround for a Node security release that broke `firebase-tools`' Hosting deploy calls (#201).
- Install step includes `--ignore-scripts`, matching the security hardening just applied to the other CI workflows (#311).

## Note
This workflow's path filter means it won't trigger on this PR itself (which only touches `.github/workflows/**`). First real end-to-end validation — confirming the action actually posts a working preview URL — happens on the next PR that touches `apps/fhdamd-web`.

## Test plan
- [x] YAML syntax validated
- [x] Structure diffed against the working `preview-storybook.yml` precedent
- [ ] End-to-end validation pending the next `apps/fhdamd-web` PR (can't self-validate due to the path filter)