### PR TITLE
fix(ci): scope fhdamd-web workflow write permissions to the preview job

### DIFF
--- a/.github/workflows/ci-fhdamd-web.yml
+++ b/.github/workflows/ci-fhdamd-web.yml
@@ -13,9 +13,7 @@ on:
       - apps/fhdamd-web/**
 
 permissions:
-  checks: write
   contents: read
-  pull-requests: write
 
 jobs:
   test:
@@ -52,6 +50,10 @@ jobs:
     needs: test
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
+    permissions:
+      checks: write
+      contents: read
+      pull-requests: write
     steps:
       - name: Checkout code
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4


### PR DESCRIPTION
## Summary
- Fixes the SonarCloud whole-repo automatic-analysis failure on `main` after #315 merged: `ci-fhdamd-web.yml` declared `checks: write` and `pull-requests: write` at workflow level (rule `githubactions:S8233` — least-privilege wants write grants scoped to the job that uses them).
- Moves those two permissions down to the `preview` job only (it posts the Firebase preview-deploy check/comment); the `test` job keeps just `contents: read` at workflow level.

## Test plan
- [x] YAML validated
- [x] This is purely a `permissions:` scoping change — no step behavior changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)